### PR TITLE
Deploy docs from develop

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -3,7 +3,7 @@ name: Deploy docs
 on:
   push:
     branches:
-      - main
+      - develop
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- update the GitHub Pages workflow trigger from `main` to `develop`
- keep manual workflow dispatch enabled

## Validation
- reviewed workflow diff for the trigger branch update

Closes #3