### PR TITLE
Clarify site access and deployment in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,22 @@
 
 Practical Go concurrency patterns documented with VitePress.
 
-- English docs: `docs/`
-- Korean docs: `docs/ko/`
+## Where to view it
+
+- GitHub repository: `https://github.com/jaeyoung0509/golang-conccurency-patterns`
+- Expected GitHub Pages site: `https://jaeyoung0509.github.io/golang-conccurency-patterns/`
+- English docs source: `docs/`
+- Korean docs source: `docs/ko/`
 - Runnable examples and tests: `examples/`
-- Fundamentals: scheduler, channels, memory model
-- Advanced topics: actor pattern, CSP theory
+
+If the GitHub Pages URL still returns `404`, go to:
+
+1. GitHub repository `Settings`
+2. `Pages`
+3. `Build and deployment`
+4. Set the source to `GitHub Actions`
+
+After that, pushes to `develop` will deploy the site automatically through the `Deploy docs` workflow.
 
 ## Run locally
 
@@ -15,6 +26,14 @@ npm install
 npm run docs:dev
 go test ./...
 ```
+
+VitePress will print a local preview URL in the terminal, usually `http://localhost:5173/`.
+
+## Deployment
+
+- Deployment branch flow: push to `develop`
+- Deployment workflow: `.github/workflows/deploy-docs.yml`
+- GitHub Actions page: `https://github.com/jaeyoung0509/golang-conccurency-patterns/actions`
 
 ## Included patterns
 
@@ -26,3 +45,19 @@ go test ./...
 - Weighted semaphore
 - Singleflight request coalescing
 - Actor pattern
+
+## Included foundations
+
+- Go runtime and scheduler
+- Channels, `select`, and the memory model
+- Channel internals
+- Mutex and runtime semaphore internals
+
+## Included advanced topics
+
+- Structured concurrency with `errgroup`
+- Weighted semaphore admission control
+- Singleflight request coalescing
+- Actor pattern
+- CSP theory in Go
+- Backpressure and load shedding


### PR DESCRIPTION
## Summary
- add the expected GitHub Pages URL to the README
- explain how to preview the site locally
- explain that pushes to `develop` trigger deployment
- add a short note for enabling GitHub Pages with GitHub Actions when the site is still 404

## Validation
- reviewed README diff

Closes #5