### PR TITLE
Add production-focused docs and failure-pattern walkthroughs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ VitePress will print a local preview URL in the terminal, usually `http://localh
 - CSP theory in Go
 - Backpressure and load shedding
 
+## Included production topics
+
+- Large-scale Go systems: admission control, goroutine ownership, memory budgets, and shutdown policy
+- Open-source case studies from Kubernetes, etcd/raft, Prometheus, and NATS
+
 ## Included testing topics
 
 - Race detector strategy

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -48,6 +48,14 @@ const enSidebar = [
     ],
   },
   {
+    text: "Production",
+    items: [
+      { text: "Overview", link: "/production/" },
+      { text: "Large-Scale Go Systems", link: "/production/large-scale-go-systems" },
+      { text: "Open-Source Case Studies", link: "/production/open-source-case-studies" },
+    ],
+  },
+  {
     text: "Testing",
     items: [
       { text: "Overview", link: "/testing/" },
@@ -111,6 +119,14 @@ const koSidebar = [
       { text: "역압력과 로드 셰딩", link: "/ko/advanced/backpressure-load-shedding" },
       { text: "액터 패턴", link: "/ko/advanced/actor-pattern" },
       { text: "Go에서의 CSP 이론", link: "/ko/advanced/csp-theory" },
+    ],
+  },
+  {
+    text: "프로덕션",
+    items: [
+      { text: "개요", link: "/ko/production/" },
+      { text: "대규모 Go 시스템", link: "/ko/production/large-scale-go-systems" },
+      { text: "오픈소스 사례", link: "/ko/production/open-source-case-studies" },
     ],
   },
   {
@@ -183,6 +199,7 @@ export default defineConfig({
           { text: "Fundamentals", link: "/fundamentals/" },
           { text: "Patterns", link: "/patterns/" },
           { text: "Advanced", link: "/advanced/" },
+          { text: "Production", link: "/production/" },
           { text: "Testing", link: "/testing/" },
           { text: "Extras", link: "/extras/" },
           {
@@ -217,6 +234,7 @@ export default defineConfig({
           { text: "기초 원리", link: "/ko/fundamentals/" },
           { text: "패턴", link: "/ko/patterns/" },
           { text: "고급 주제", link: "/ko/advanced/" },
+          { text: "프로덕션", link: "/ko/production/" },
           { text: "테스트", link: "/ko/testing/" },
           { text: "비교 / 확장", link: "/ko/extras/" },
           {

--- a/docs/advanced/actor-pattern.md
+++ b/docs/advanced/actor-pattern.md
@@ -58,6 +58,23 @@ func (actor *InventoryActor) loop(state *inventoryState) {
 }
 ```
 
+## Simplified mailbox sketch
+
+```go
+type envelope struct {
+    cmd   Command
+    reply chan Result
+}
+
+func loop(state *State, mailbox <-chan envelope) {
+    for env := range mailbox {
+        env.reply <- env.cmd.Apply(state)
+    }
+}
+```
+
+This is the minimum useful actor shape: one mailbox, one owner loop, one state machine.
+
 The safety comes from one rule: only the actor loop mutates `inventoryState`.
 
 That means:
@@ -96,6 +113,16 @@ You can even combine them: a worker pool might talk to many actors, or one actor
 
 ## Caveats
 
+### Failure pattern: exposing owned state back to callers
+
+```go
+func (actor *InventoryActor) UnsafeState() *inventoryState {
+    return actor.state // breaks the ownership boundary
+}
+```
+
+The whole actor guarantee collapses if outside code can mutate or even rely on internal pointers without going through the mailbox.
+
 ### Mailboxes need backpressure
 
 If callers can enqueue faster than the actor can process, you need a bounded mailbox, rejection policy, or upstream throttling.
@@ -107,6 +134,10 @@ That is often acceptable because serialization is the point. But if the state ca
 ### Supervision is manual
 
 Go does not give you Erlang-style supervisors out of the box. Restart policy, mailbox durability, and lifecycle orchestration are your responsibility.
+
+### Reply channels need lifecycle discipline
+
+If the caller can abandon a request, the reply path must not wedge the actor loop. This is why bounded or one-shot reply channels are often safer than ad hoc shared response paths.
 
 ## Practical takeaway
 

--- a/docs/advanced/singleflight.md
+++ b/docs/advanced/singleflight.md
@@ -50,6 +50,21 @@ That is an important practical detail:
 - the leader's function decides the shared work,
 - followers may still need independent timeout behavior while they wait.
 
+## Simplified integration sketch
+
+```go
+value, ok := cache.Get(key)
+if ok {
+    return value, nil
+}
+
+resCh := group.DoChan(key, func() (any, error) {
+    return loadFromBackend(key)
+})
+```
+
+The key idea is that singleflight usually lives between a cache check and a real backend load.
+
 ## What the tests prove
 
 The tests verify that:
@@ -74,6 +89,15 @@ Each choice is defensible in different systems. The important part is to make it
 
 ## Common mistakes
 
+### Failure pattern: caching an error path as success
+
+```go
+v, err, _ := group.Do(key, load)
+cache.Set(key, v) // wrong if err != nil
+```
+
+Duplicate suppression is not the same as success. Cache writes still need real error checks.
+
 ### Assuming singleflight replaces caching
 
 It only suppresses duplicate *in-flight* work. Once the call finishes, future callers will invoke the function again unless you also store the result somewhere.
@@ -85,6 +109,10 @@ If your keys explode in cardinality and every request uses a unique key, singlef
 ### Hiding stampedes but not overload
 
 Singleflight helps a thundering herd on the same key. It does not protect you from a thundering herd across many distinct keys.
+
+### Forgetting that the leader decides the load lifetime
+
+If the leader uses a very short deadline, all followers may end up sharing a load that dies too early. That is a policy decision, not an implementation accident you should ignore.
 
 ## Practical takeaway
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -25,6 +25,7 @@ That split matters because the site explains the patterns, but the Go packages p
 │   ├── .vitepress/
 │   ├── fundamentals/
 │   ├── advanced/
+│   ├── production/
 │   ├── guide/
 │   ├── patterns/
 │   ├── testing/
@@ -67,7 +68,8 @@ Use the commands above before pushing changes. The first validates the static si
 1. Read [Fundamentals Overview](/fundamentals/).
 2. Move through [Patterns Overview](/patterns/) with the matching package under `examples/`.
 3. Read [Testing Overview](/testing/) before trusting any timeout or shutdown path.
-4. Only then move into [Advanced Overview](/advanced/) and [Extras Overview](/extras/).
+4. Read [Production Overview](/production/) once you care about operating rules and large-scale system tradeoffs.
+5. Only then move into [Advanced Overview](/advanced/) and [Extras Overview](/extras/).
 
 ## What is inside each example
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,9 @@ hero:
       text: Browse Patterns
       link: /patterns/
     - theme: alt
+      text: Production Guide
+      link: /production/
+    - theme: alt
       text: Testing Playbook
       link: /testing/
     - theme: alt
@@ -30,6 +33,8 @@ features:
     details: "Every example is backed by `go test` so ordering, cancellation, limits, and failure policy are verified."
   - title: Advanced production topics
     details: "Structured concurrency, weighted semaphores, singleflight, actors, and load shedding are documented alongside the basics."
+  - title: Production operating rules
+    details: "Admission control, queue budgets, lifecycle ownership, and large-system concurrency tradeoffs are documented as first-class topics."
   - title: Testing and observability
     details: "Race detection, synctest, leak testing, traces, and contention profiles are treated as first-class concurrency skills."
   - title: English and Korean
@@ -67,7 +72,12 @@ features:
     <p><a href="/testing/">Open testing</a></p>
   </div>
   <div class="path-card">
-    <h3>5. Extras</h3>
+    <h3>5. Production</h3>
+    <p>Study queue budgets, overload policy, goroutine ownership, and open-source concurrency designs from real Go systems.</p>
+    <p><a href="/production/">Open production</a></p>
+  </div>
+  <div class="path-card">
+    <h3>6. Extras</h3>
     <p>Compare Go's CSP-flavored model with Rust Tokio so your mental model holds across ecosystems.</p>
     <p><a href="/extras/">Open extras</a></p>
   </div>
@@ -84,6 +94,7 @@ features:
 | How to stop duplicate cache-miss fetches | [Singleflight](/advanced/singleflight) |
 | How to survive overload instead of just failing later | [Backpressure and Load Shedding](/advanced/backpressure-load-shedding) |
 | How to test timeout-heavy code without real sleeps | [Deterministic Tests with synctest](/testing/synctest) |
+| What large Go production systems care about beyond toy patterns | [Large-Scale Go Systems](/production/large-scale-go-systems) |
 | How Go differs from Rust Tokio's async runtime model | [Go CSP vs Rust Tokio](/extras/go-csp-vs-rust-tokio) |
 
 ## What Makes This Site Different
@@ -110,4 +121,5 @@ features:
 3. Work through [Fundamentals Overview](/fundamentals/) before jumping into implementation patterns.
 4. Pick the practical pattern that matches your workload in [Patterns Overview](/patterns/).
 5. Read [Testing Overview](/testing/) before treating any concurrent component as production-ready.
-6. Finish with [Advanced Overview](/advanced/) and [Extras Overview](/extras/) when you want stronger production and comparative context.
+6. Read [Production Overview](/production/) for operating rules and open-source case studies.
+7. Finish with [Advanced Overview](/advanced/) and [Extras Overview](/extras/) for deeper design and ecosystem comparison.

--- a/docs/ko/advanced/actor-pattern.md
+++ b/docs/ko/advanced/actor-pattern.md
@@ -58,6 +58,23 @@ func (actor *InventoryActor) loop(state *inventoryState) {
 }
 ```
 
+## 단순화한 mailbox 스케치
+
+```go
+type envelope struct {
+    cmd   Command
+    reply chan Result
+}
+
+func loop(state *State, mailbox <-chan envelope) {
+    for env := range mailbox {
+        env.reply <- env.cmd.Apply(state)
+    }
+}
+```
+
+가장 작은 유효 actor 형태는 이것입니다. mailbox 하나, owner loop 하나, state machine 하나.
+
 안전성은 한 가지 규칙에서 나옵니다. `inventoryState`를 실제로 변경하는 곳이 액터 루프 하나뿐이라는 점입니다.
 
 즉,
@@ -96,6 +113,16 @@ func (actor *InventoryActor) loop(state *inventoryState) {
 
 ## 주의할 점
 
+### 실패 패턴: 내부 상태를 바깥에 노출하기
+
+```go
+func (actor *InventoryActor) UnsafeState() *inventoryState {
+    return actor.state // ownership boundary 붕괴
+}
+```
+
+바깥 코드가 내부 포인터를 직접 만질 수 있으면 actor 보장은 거의 사라집니다.
+
 ### mailbox에도 역압력이 필요하다
 
 호출자가 액터 처리 속도보다 빠르게 enqueue할 수 있으면 bounded mailbox, 거절 정책, 상위 레벨 throttling이 필요합니다.
@@ -107,6 +134,10 @@ func (actor *InventoryActor) loop(state *inventoryState) {
 ### supervision은 직접 설계해야 한다
 
 Go는 Erlang OTP 같은 supervisor를 기본 제공하지 않습니다. 재시작 정책, mailbox 내구성, 수명 주기 관리가 모두 애플리케이션 책임입니다.
+
+### reply channel의 수명도 설계해야 한다
+
+caller가 요청을 포기할 수 있다면, reply path가 actor loop를 wedge시키지 않아야 합니다. 그래서 one-shot buffered reply channel이 shared response path보다 안전한 경우가 많습니다.
 
 ## 실전 요약
 

--- a/docs/ko/advanced/singleflight.md
+++ b/docs/ko/advanced/singleflight.md
@@ -51,6 +51,21 @@ flowchart LR
 - follower는 기다리기만 하되,
 - waiting policy는 자기 timeout에 맞출 수 있습니다.
 
+## 단순화한 통합 스케치
+
+```go
+value, ok := cache.Get(key)
+if ok {
+    return value, nil
+}
+
+resCh := group.DoChan(key, func() (any, error) {
+    return loadFromBackend(key)
+})
+```
+
+singleflight는 보통 cache lookup과 실제 backend load 사이에 들어갑니다.
+
 ## 테스트가 증명하는 것
 
 테스트는 다음을 검증합니다.
@@ -75,6 +90,15 @@ singleflight는 여러 caller의 context를 자동으로 "완벽하게 합친" s
 
 ## 흔한 실수
 
+### 실패 패턴: 에러 경로를 성공처럼 cache하는 경우
+
+```go
+v, err, _ := group.Do(key, load)
+cache.Set(key, v) // err 체크 없이 쓰면 잘못됨
+```
+
+중복 억제와 성공은 같은 것이 아닙니다. cache write는 여전히 제대로 된 error check가 필요합니다.
+
 ### singleflight가 cache를 대체한다고 착각하기
 
 아닙니다. singleflight는 진행 중인 중복 작업만 줄입니다. 호출이 끝나면 결과를 따로 저장하지 않는 이상 다음 요청은 다시 backend를 칩니다.
@@ -86,6 +110,10 @@ singleflight는 여러 caller의 context를 자동으로 "완벽하게 합친" s
 ### stampede 일부만 해결하고 overload는 그대로 두기
 
 singleflight는 같은 key에 대한 herd를 줄여줍니다. 서로 다른 수많은 key에 대한 폭주까지 막아주진 않습니다.
+
+### leader의 deadline이 전체 load lifetime을 좌우한다는 점을 무시하기
+
+leader가 너무 짧은 deadline을 쓰면 follower도 그 load를 공유하다가 너무 일찍 실패할 수 있습니다. 이건 구현 세부사항이 아니라 정책 결정입니다.
 
 ## 실전 요약
 

--- a/docs/ko/guide/getting-started.md
+++ b/docs/ko/guide/getting-started.md
@@ -25,6 +25,7 @@ description: VitePress 기반 Go 동시성 문서 저장소의 구조와 실행 
 │   ├── .vitepress/
 │   ├── fundamentals/
 │   ├── advanced/
+│   ├── production/
 │   ├── guide/
 │   ├── patterns/
 │   ├── testing/
@@ -68,7 +69,8 @@ go test ./...
 1. [기초 원리 개요](/ko/fundamentals/)부터 읽습니다.
 2. [패턴 개요](/ko/patterns/)와 `examples/` 대응 패키지를 같이 읽습니다.
 3. timeout과 shutdown 경로를 믿기 전에 [테스트 개요](/ko/testing/)를 읽습니다.
-4. 그 다음에 [고급 주제 개요](/ko/advanced/), [비교 / 확장 개요](/ko/extras/)로 넘어갑니다.
+4. 운영 규칙과 대규모 시스템 tradeoff가 중요해지면 [프로덕션 개요](/ko/production/)를 읽습니다.
+5. 그 다음에 [고급 주제 개요](/ko/advanced/), [비교 / 확장 개요](/ko/extras/)로 넘어갑니다.
 
 ## 예제 패키지 구성 원칙
 

--- a/docs/ko/index.md
+++ b/docs/ko/index.md
@@ -13,6 +13,9 @@ hero:
       text: 패턴 둘러보기
       link: /ko/patterns/
     - theme: alt
+      text: 프로덕션 가이드
+      link: /ko/production/
+    - theme: alt
       text: 테스트 플레이북
       link: /ko/testing/
     - theme: alt
@@ -30,6 +33,8 @@ features:
     details: "`go test`로 순서 보장, 취소 전파, 동시성 제한, 실패 정책을 실제로 확인합니다."
   - title: 고급 운영 주제 포함
     details: "구조화된 동시성, 가중 세마포어, singleflight, 액터, 로드 셰딩까지 운영 관점의 주제를 다룹니다."
+  - title: 프로덕션 운영 규칙 포함
+    details: "admission control, queue budget, lifetime ownership, 대규모 시스템 동시성 tradeoff를 별도 섹션으로 다룹니다."
   - title: 테스트와 관측도 포함
     details: "Race detector, synctest, leak test, trace, contention profile을 동시성 역량의 일부로 다룹니다."
   - title: 영어/한국어 지원
@@ -67,7 +72,12 @@ features:
     <p><a href="/ko/testing/">테스트 보기</a></p>
   </div>
   <div class="path-card">
-    <h3>5. 비교 / 확장</h3>
+    <h3>5. 프로덕션</h3>
+    <p>queue budget, overload policy, goroutine ownership, 실제 오픈소스의 concurrency 구조를 같이 봅니다.</p>
+    <p><a href="/ko/production/">프로덕션 보기</a></p>
+  </div>
+  <div class="path-card">
+    <h3>6. 비교 / 확장</h3>
     <p>Go의 CSP 계열 모델을 Rust Tokio와 비교해 mental model을 더 넓힙니다.</p>
     <p><a href="/ko/extras/">비교 / 확장 보기</a></p>
   </div>
@@ -84,6 +94,7 @@ features:
 | 같은 cache miss 요청을 어떻게 하나로 합치는지 | [Singleflight](/ko/advanced/singleflight) |
 | 과부하를 늦게 터뜨리지 않고 초기에 제어하는 법 | [역압력과 로드 셰딩](/ko/advanced/backpressure-load-shedding) |
 | timeout-heavy 코드를 실제 sleep 없이 어떻게 테스트하는지 | [synctest로 결정적 테스트](/ko/testing/synctest) |
+| 토이 패턴을 넘어 대규모 Go 운영에서 무엇이 중요한지 | [대규모 Go 시스템](/ko/production/large-scale-go-systems) |
 | Go와 Rust Tokio의 async runtime 모델이 어떻게 다른지 | [Go CSP vs Rust Tokio](/ko/extras/go-csp-vs-rust-tokio) |
 
 ## 이 사이트가 다른 이유
@@ -110,4 +121,5 @@ features:
 3. [기초 원리 개요](/ko/fundamentals/)부터 읽습니다.
 4. 자기 workload에 맞는 패턴을 [패턴 개요](/ko/patterns/)에서 고릅니다.
 5. concurrent component를 production-ready로 보기 전에 [테스트 개요](/ko/testing/)를 읽습니다.
-6. 운영 설계와 비교 관점까지 확장할 때 [고급 주제 개요](/ko/advanced/), [비교 / 확장 개요](/ko/extras/)로 넘어갑니다.
+6. 운영 규칙과 오픈소스 사례를 보려면 [프로덕션 개요](/ko/production/)를 읽습니다.
+7. 운영 설계와 비교 관점까지 확장할 때 [고급 주제 개요](/ko/advanced/), [비교 / 확장 개요](/ko/extras/)로 넘어갑니다.

--- a/docs/ko/patterns/context-cancellation.md
+++ b/docs/ko/patterns/context-cancellation.md
@@ -66,6 +66,19 @@ func (service DashboardService) Build(ctx context.Context, userID string) (Dashb
 1. 결과 채널이 버퍼드라서 collector가 먼저 종료되어도 로더가 send에서 영원히 막히지 않습니다.
 2. 취소 결정은 collector가 가져가야 합니다. 비즈니스 계약을 가장 잘 아는 위치이기 때문입니다.
 
+## 단순화한 cancellation 스케치
+
+```go
+ctx, cancel := context.WithCancel(parent)
+defer cancel()
+
+go func() { results <- loadA(ctx) }()
+go func() { results <- loadB(ctx) }()
+go func() { results <- loadC(ctx) }()
+```
+
+작은 형태지만 핵심은 다 들어 있습니다. 하나의 parent lifetime, 여러 child, 하나의 shared stop signal.
+
 ## 테스트가 증명하는 것
 
 테스트는 다음을 검증합니다.
@@ -75,6 +88,14 @@ func (service DashboardService) Build(ctx context.Context, userID string) (Dashb
 - 호출자 데드라인이 `context.DeadlineExceeded`로 제대로 드러나는가
 
 ## 흔한 실수
+
+### 실패 패턴: 분리된 child goroutine
+
+```go
+go loadProfile(context.Background(), userID, results) // request lifetime과 분리됨
+```
+
+이렇게 되면 caller는 떠났는데 child work는 계속 살아남습니다.
 
 ### 파생 컨텍스트를 실제 하위 호출에 넘기지 않기
 
@@ -87,6 +108,10 @@ func (service DashboardService) Build(ctx context.Context, userID string) (Dashb
 ### 취소 정책을 헬퍼 함수 안으로 숨기기
 
 무엇이 전체 실패인지 결정하는 로직은 집계 지점 가까이에 있어야 유지보수가 쉽습니다.
+
+### collector가 먼저 끝나도 sender가 탈출하지 못하는 구조
+
+child goroutine에 buffered send 경로도 없고 `ctx.Done()` 경로도 없고 외부 shutdown 경로도 없으면, 조기 반환은 곧 leak가 됩니다.
 
 ## 이 패턴을 쓸 때
 

--- a/docs/ko/patterns/fan-out-fan-in.md
+++ b/docs/ko/patterns/fan-out-fan-in.md
@@ -61,6 +61,25 @@ func CollectInventory(ctx context.Context, sku string, lookups map[string]Wareho
 }
 ```
 
+## 단순화한 집계 스케치
+
+```go
+results := make(chan result, len(backends))
+
+for _, backend := range backends {
+    go func(backend Backend) {
+        value, err := backend.Lookup(ctx, key)
+        results <- result{value: value, err: err}
+    }(backend)
+}
+
+for range backends {
+    merge(<-results)
+}
+```
+
+핵심 질문은 "fan-out이 일어났는가?"가 아니라 "일부 branch가 실패했을 때 어떤 aggregate가 허용 가능한가?"입니다.
+
 창고 한 곳이 장애라고 해서 전체 가용성 정보를 버리는 것은 실무적으로 과한 경우가 많습니다.
 이 예제는 그 점을 반영합니다.
 
@@ -80,6 +99,16 @@ func CollectInventory(ctx context.Context, sku string, lookups map[string]Wareho
 
 ## 흔한 실수
 
+### 실패 패턴: 무의식적인 all-or-nothing 정책
+
+```go
+if item.err != nil {
+    return InventoryReport{}, item.err // 유용한 partial success까지 버림
+}
+```
+
+그 정책이 맞을 수도 있지만, 기본 반사 동작이면 안 됩니다. 계약으로 정해야 합니다.
+
 ### 모든 오류를 같은 방식으로 취급하기
 
 어떤 시스템은 "전부 성공해야 한다"가 맞고, 어떤 시스템은 "최대한 많이 가져오자"가 맞습니다. 먼저 계약을 정해야 합니다.
@@ -91,3 +120,7 @@ func CollectInventory(ctx context.Context, sku string, lookups map[string]Wareho
 ### 팬아웃 대상을 무제한으로 늘리기
 
 이 예제는 창고 수가 작고 고정적이라는 전제입니다. 대상 수가 커질 수 있다면 워커 풀이나 세마포어와 결합해야 합니다.
+
+### worker가 shared results 채널을 닫아버리는 경우
+
+shared channel의 close 조건은 보통 aggregator가 소유해야 합니다. 여러 worker가 같은 채널을 닫을 수 있는 구조면 이미 위험합니다.

--- a/docs/ko/patterns/pipeline.md
+++ b/docs/ko/patterns/pipeline.md
@@ -61,6 +61,28 @@ func RunAlertPipeline(ctx context.Context, events []CheckoutEvent, workers int, 
 }
 ```
 
+## 단순화한 단계 스케치
+
+파이프라인의 핵심 형태는 이렇습니다.
+
+```go
+in := source(ctx)
+mid := stageA(ctx, in)
+out := stageB(ctx, mid)
+
+for item := range out {
+    consume(item)
+}
+```
+
+각 단계는 책임이 하나여야 합니다.
+
+- 읽기,
+- 변환,
+- 필터링,
+- 집계,
+- 취소 판단.
+
 이 구조의 장점은 책임이 섞이지 않는다는 데 있습니다.
 
 - `source()`는 슬라이스를 스트림으로 바꾸는 책임만 갖고,
@@ -88,6 +110,29 @@ scoring이 병렬 실행되므로 완료 순서는 안정적이지 않습니다.
 ### 에러 정책을 의식적으로 정해야 한다
 
 모든 파이프라인이 첫 오류에서 중단할 필요는 없습니다. 이 예제는 점수 계산이 실패하면 전체 결과 신뢰도가 무너진다고 보고 즉시 취소합니다.
+
+## 실패 패턴
+
+### output close를 빼먹은 단계
+
+```go
+func stage(in <-chan Event) <-chan Score {
+    out := make(chan Score)
+    go func() {
+        for event := range in {
+            out <- score(event)
+        }
+        // forgot: close(out)
+    }()
+    return out
+}
+```
+
+`close(out)` 하나를 빼먹으면 downstream collector가 영원히 block될 수 있습니다.
+
+### 긴 stage가 cancellation을 무시하는 경우
+
+비싼 remote work나 CPU work를 하는 stage가 `ctx.Done()`을 전혀 보지 않으면, 문서상 cancellable pipeline과 실제 동작이 달라집니다.
 
 ## 이 패턴을 쓸 때
 

--- a/docs/ko/patterns/worker-pool.md
+++ b/docs/ko/patterns/worker-pool.md
@@ -73,6 +73,30 @@ func GenerateQuotes(ctx context.Context, orders []Order, workers int, quoteFn Qu
 }
 ```
 
+## 단순화한 구현 스케치
+
+워커 풀의 가장 작은 유효 mental model은 이런 형태입니다.
+
+```go
+jobs := make(chan Job)
+results := make(chan Result, workers)
+
+for range workers {
+    go func() {
+        for job := range jobs {
+            results <- process(job)
+        }
+    }()
+}
+```
+
+실전 버전은 여기에 다음이 더해집니다.
+
+- context cancellation,
+- 입력 순서 복원을 위한 index,
+- worker shutdown coordination,
+- 명시적인 error policy.
+
 여기서 중요한 선택은 세 가지입니다.
 
 1. 결과에 원래 입력 인덱스를 실어 보내서 순서를 복원합니다.
@@ -89,6 +113,18 @@ func GenerateQuotes(ctx context.Context, orders []Order, workers int, quoteFn Qu
 
 ## 흔한 실수
 
+### 실패 패턴: collector가 먼저 끝나는데 unbuffered results 채널을 쓰는 경우
+
+```go
+results := make(chan result) // 조기 반환 흐름에서는 위험
+
+if err != nil {
+    return nil, err // worker가 send에서 영원히 막힐 수 있음
+}
+```
+
+collector가 모든 worker send를 받기 전에 종료될 수 있다면, unbuffered results 채널은 goroutine leak를 만들기 가장 쉬운 구조 중 하나입니다.
+
 ### 완료 순서를 그대로 반환하기
 
 호출자가 입력 순서를 기대한다면 쉽게 버그가 납니다. 이런 계약이 필요하면 인덱스를 붙여야 합니다.
@@ -100,6 +136,10 @@ func GenerateQuotes(ctx context.Context, orders []Order, workers int, quoteFn Qu
 ### 너무 작은 작업량에 과하게 적용하기
 
 평균 요청 크기가 1~2개라면 워커 풀의 복잡도만 늘고 이득이 거의 없을 수 있습니다.
+
+### worker가 배치 수명보다 오래 살아남게 두기
+
+worker가 shared context나 shutdown signal을 보지 않으면, caller가 이미 결과를 포기한 뒤에도 downstream capacity를 계속 태울 수 있습니다.
 
 ## 이 패턴을 쓸 때
 

--- a/docs/ko/production/index.md
+++ b/docs/ko/production/index.md
@@ -1,0 +1,34 @@
+---
+title: 프로덕션 개요
+description: Go 코드가 실제 대규모 트래픽을 받을 때 중요해지는 동시성 관점을 다룹니다.
+---
+
+# 프로덕션 개요
+
+앞선 섹션은 Go 동시성이 왜 동작하는지, 각 패턴을 언제 써야 하는지를 설명합니다.
+
+이 섹션은 코드가 예제를 넘어 실제 트래픽을 받기 시작했을 때 무엇이 달라지는지를 다룹니다.
+
+## 무엇을 다루나
+
+| 주제 | 왜 중요한가 |
+| --- | --- |
+| [대규모 Go 시스템](/ko/production/large-scale-go-systems) | 런타임 지식을 실제 latency, memory, overload, shutdown 규칙으로 바꿉니다 |
+| [오픈소스 사례](/ko/production/open-source-case-studies) | 대표적인 Go 오픈소스가 concurrency를 어떻게 구조화하는지 소스와 함께 봅니다 |
+
+## 프로덕션에서 질문이 달라진다
+
+예제에서는 보통 "이 패턴이 맞는가?"가 핵심입니다.
+
+프로덕션에서는 질문이 이렇게 바뀝니다.
+
+- 이 goroutine의 lifetime owner는 누구인가
+- 어디서 load를 reject할 것인가
+- deploy와 shutdown 때 어떤 일이 일어나는가
+- heap pressure 아래에서 runtime이 어떻게 반응하는가
+- tail latency를 만드는 hot lock / hot queue는 무엇인가
+- 이걸 추측이 아니라 관측으로 어떻게 볼 것인가
+
+## Practical takeaway
+
+fundamentals가 Go 동시성이 왜 가능한지 설명한다면, production 섹션은 그 장점을 운영에서 잃지 않는 법을 설명합니다.

--- a/docs/ko/production/large-scale-go-systems.md
+++ b/docs/ko/production/large-scale-go-systems.md
@@ -1,0 +1,154 @@
+---
+title: 대규모 Go 시스템
+description: latency, memory, admission control, lifecycle, observability 관점에서 대규모 Go 서비스가 알아야 할 동시성 규칙을 정리합니다.
+---
+
+# 대규모 Go 시스템
+
+튜토리얼 코드와 프로덕션 코드 사이의 가장 큰 차이는 문법이 아니라 운영 압력입니다.
+
+실제 부하를 받기 시작하면 핵심 질문은 한계, 소유권, 가시성, 실패 격리로 바뀝니다.
+
+:::tip Quick takeaway
+대규모 시스템에서 가장 비싼 동시성 버그는 보통 "goroutine 문법 실수"가 아닙니다. 무한 queue, 새는 lifetime, 빠진 deadline, hot shared state, 약한 observability가 더 위험합니다.
+:::
+
+## 규칙 1: 모든 goroutine에는 owner가 있어야 한다
+
+다음 질문에 답할 수 있어야 합니다.
+
+- 누가 이 goroutine을 시작했는가
+- 무엇이 이 goroutine을 멈추게 하는가
+- 누가 종료를 기다리는가
+- parent request나 process가 먼저 끝나면 어떻게 되는가
+
+이 질문에 답할 수 없으면 아직 production-grade concurrency design이 아닙니다.
+
+## 규칙 2: cleanup보다 admission control이 먼저다
+
+많은 시스템이 overload를 나중 cleanup으로 버티려 합니다.
+
+그건 늦습니다.
+
+더 좋은 구조는:
+
+- queue를 제한하고,
+- worker 수를 제한하고,
+- 초기에 reject 또는 degrade하고,
+- latency를 예측 가능하게 유지하는 것입니다.
+
+```go
+func Submit(ctx context.Context, job Job) error {
+    select {
+    case jobs <- job:
+        return nil
+    default:
+        return ErrOverloaded
+    }
+}
+```
+
+이 스케치의 핵심은 overload policy가 인터페이스에 드러난다는 점입니다.
+
+## 규칙 3: deadline은 전체 호출 트리로 흘러야 한다
+
+경계에서 timeout을 걸었다고 끝이 아닙니다.
+
+leaf goroutine이 파생 context를 받지 않으면, timeout은 control mechanism이 아니라 로그 이벤트에 불과합니다.
+
+### 실패 패턴
+
+```go
+ctx, cancel := context.WithTimeout(parent, 100*time.Millisecond)
+defer cancel()
+
+go fetchFromBackend(context.Background(), id) // 잘못됨: request lifetime과 분리됨
+```
+
+이게 request timeout이 background leak로 바뀌는 전형적인 방식입니다.
+
+## 규칙 4: queue는 단순 buffer가 아니라 latency object다
+
+queue는 세 가지를 합니다.
+
+- burst를 흡수하고,
+- overload를 잠시 숨기고,
+- 서비스 압력을 대기 시간으로 바꿉니다.
+
+그래서 queue length, queue age, drop policy는 구현 디테일이 아니라 운영 신호입니다.
+
+## 규칙 5: hot shared state는 ownership 결정을 요구한다
+
+map, cache, state machine이 hot해지면 의도적으로 선택해야 합니다.
+
+- `map + mutex`
+- actor ownership
+- sharding
+- read-mostly atomic snapshot
+- per-key worker / mailbox partitioning
+
+이건 취향 문제가 아니라 tail latency와 failure behavior를 바꾸는 선택입니다.
+
+## 규칙 6: cgo와 syscall은 scheduler 현실을 바꾼다
+
+순수 Go 네트워크 서비스는 runtime netpoller의 이점을 강하게 받습니다.
+
+하지만 cgo나 opaque blocking syscall이 많아지면:
+
+- thread가 더 오래 block될 수 있고,
+- `P` handoff가 더 중요해지며,
+- pure Go 기반 직감이 덜 맞게 됩니다.
+
+그래서 "그냥 I/O bound예요"는 충분한 진단이 아닙니다.
+
+## 규칙 7: 메모리는 concurrency budget의 일부다
+
+대규모 시스템에서는 heap shape 자체가 concurrency behavior를 바꿉니다.
+
+allocation rate가 높으면:
+
+- GC assist가 늘고,
+- background marking pressure가 커지고,
+- object churn에 대한 latency 민감도가 올라갑니다.
+
+즉, 요청 하나가 많은 goroutine fan-out과 allocation을 만든다면 GC도 concurrency story의 일부입니다.
+
+## 규칙 8: shutdown도 correctness의 일부다
+
+deploy, rollout, node drain은 늘 일어납니다.
+
+프로덕션 서비스는 shutdown contract가 있어야 합니다.
+
+1. 새 작업 수락 중단
+2. 이미 받은 작업은 정책대로 drain 또는 cancel
+3. hard deadline 강제
+4. shutdown이 깔끔히 끝나지 않을 때 metric / log 노출
+
+## 규칙 9: trace와 profile은 선택이 아니다
+
+시스템이 충분히 커지면 직감만으로는 부족합니다.
+
+필요합니다.
+
+- `go test -trace`와 `go tool trace`
+- block / mutex profile
+- heap / alloc profile
+- queue metric
+- timeout / cancellation metric
+- 필요시 goroutine lifecycle counter
+
+## 실전 체크리스트
+
+- 비싼 외부 경계마다 bounded concurrency 존재
+- queue capacity와 overload behavior가 명시적
+- request-scoped context가 모든 하위 goroutine에 전달됨
+- graceful shutdown에 실제 deadline 존재
+- 정당화 없는 unbounded mailbox 없음
+- hot shared map에 ownership model이 명시됨
+- incident 전부터 runtime observability가 준비됨
+
+## Practical takeaway
+
+프로덕션 Go 동시성은 "더 많은 goroutine"의 문제가 아닙니다.
+
+어디서 concurrency를 멈추고, 어디서 기다리게 하고, 어디서 fail fast할지를 정하는 문제입니다.

--- a/docs/ko/production/open-source-case-studies.md
+++ b/docs/ko/production/open-source-case-studies.md
@@ -1,0 +1,130 @@
+---
+title: 오픈소스 사례
+description: 대표적인 Go 오픈소스가 실제로 concurrency를 어떻게 구조화하는지 소스 포인터와 함께 설명합니다.
+---
+
+# 오픈소스 사례
+
+동시성 감각을 빠르게 끌어올리는 가장 좋은 방법 중 하나는 실제 production pressure를 버틴 Go 프로젝트를 읽는 것입니다.
+
+이 문서는 프로젝트 전체를 요약하려는 것이 아니라, 특히 볼 가치가 있는 concurrency 구조를 짚습니다.
+
+## Kubernetes client-go workqueue
+
+소스:
+
+- [kubernetes/client-go util/workqueue/queue.go](https://github.com/kubernetes/client-go/blob/master/util/workqueue/queue.go)
+
+볼 포인트:
+
+- `dirty`와 `processing` 집합
+- `Get`, `Done`, `ShutDown`
+- 중복 work를 dedupe하면서도 requeue semantics를 잃지 않는 방식
+
+왜 중요한가:
+
+이 queue 설계는 "같은 item이 처리 중일 때 다시 업데이트되면 어떻게 할 것인가"에 대한 production-grade 답입니다. 같은 item이 queue를 무한히 오염시키지 않으면서도 재처리 신호는 보존합니다.
+
+단순화한 형태:
+
+```go
+if item already processing {
+    mark dirty
+    return
+}
+enqueue(item)
+```
+
+핵심 takeaway:
+
+프로덕션 queue는 단순 slice + channel이 아닙니다. 재처리 semantics와 shutdown semantics를 함께 품습니다.
+
+## etcd raft node loop
+
+소스:
+
+- [etcd-io/raft node.go](https://github.com/etcd-io/raft/blob/main/node.go)
+
+볼 포인트:
+
+- `Ready() <-chan Ready`
+- `Advance()`
+- `Tick()`
+- `Step(ctx, msg)`
+
+왜 중요한가:
+
+Raft core와 storage / transport를 channel 기반 경계로 분리합니다. core는 "다음에 persist/send 해야 할 것"을 내보내고, 바깥 계층이 durability를 보장한 뒤 `Advance`로 진행시킵니다.
+
+단순화한 형태:
+
+```go
+for {
+    select {
+    case rd := <-node.Ready():
+        persist(rd)
+        send(rd.Messages)
+        node.Advance()
+    }
+}
+```
+
+핵심 takeaway:
+
+communication boundary가 곧 correctness boundary가 되는 아주 좋은 예입니다.
+
+## Prometheus scrape loop
+
+소스:
+
+- [prometheus/prometheus scrape/scrape.go](https://github.com/prometheus/prometheus/blob/main/scrape/scrape.go)
+
+볼 포인트:
+
+- `newScrapeLoop`
+- `(*scrapeLoop).run`
+- ticker-driven scheduling, cancellation, staleness handling이 한 lifecycle loop 안에 모여 있는 구조
+
+왜 중요한가:
+
+Prometheus는 단순히 "N초마다 goroutine 하나 돌린다"가 아닙니다. scrape loop가 시간, 에러 처리, append flow, shutdown semantics를 하나의 owner loop에서 책임집니다.
+
+핵심 takeaway:
+
+주기 작업은 helper 곳곳에 timer를 뿌리는 것보다, explicit owner loop 하나에 lifecycle을 모으는 편이 대규모 운영에서 훨씬 낫습니다.
+
+## NATS server client read/write loops
+
+소스:
+
+- [nats-io/nats-server server/client.go](https://github.com/nats-io/nats-server/blob/main/server/client.go)
+
+볼 포인트:
+
+- `readLoop`
+- `writeLoop`
+- outbound flush를 위한 `sync.Cond` signaling
+
+왜 중요한가:
+
+NATS는 socket read와 write를 분리하고, busy waiting 대신 명시적 signaling을 사용합니다. 모든 것을 channel로만 밀어붙이지 않고, condition variable과 소유권이 더 잘 맞는 경우를 보여줍니다.
+
+핵심 takeaway:
+
+프로덕션 Go에서는 channel만이 정답이 아닙니다. `sync.Cond`와 명확한 owner loop가 더 적합한 경우가 분명히 있습니다.
+
+## 어떻게 읽어야 하나
+
+오픈소스 Go 코드를 읽을 때는 이렇게 물어보면 좋습니다.
+
+1. lifetime owner는 어디인가
+2. overload boundary는 어디인가
+3. state owner는 누구인가
+4. shutdown contract는 어디에 드러나는가
+5. 어떤 metric / trace가 실패를 드러내는가
+
+## Practical takeaway
+
+오픈소스 Go 코드는 API보다 경계를 읽을 때 가장 많이 배울 수 있습니다.
+
+좋은 프로젝트일수록 queue design, lifecycle loop, signaling edge, shutdown path 안에 concurrency policy가 잘 드러납니다.

--- a/docs/patterns/context-cancellation.md
+++ b/docs/patterns/context-cancellation.md
@@ -63,6 +63,19 @@ Two details matter here:
 1. The result channel is buffered, so goroutines are not left hanging on a send if the collector exits early.
 2. The collector owns cancellation, because it has enough context to decide whether an error should abort the whole workflow.
 
+## Simplified cancellation sketch
+
+```go
+ctx, cancel := context.WithCancel(parent)
+defer cancel()
+
+go func() { results <- loadA(ctx) }()
+go func() { results <- loadB(ctx) }()
+go func() { results <- loadC(ctx) }()
+```
+
+That small shape already carries the whole idea: one parent lifetime, many children, one shared stop signal.
+
 ## What the tests prove
 
 The tests verify:
@@ -72,6 +85,14 @@ The tests verify:
 - caller deadlines surface as `context.DeadlineExceeded`.
 
 ## Common mistakes
+
+### Failure pattern: detached child goroutine
+
+```go
+go loadProfile(context.Background(), userID, results) // detached from request lifetime
+```
+
+This turns request cancellation into a lie. The caller may leave, but the child work keeps running.
 
 ### Forgetting to pass the derived context downstream
 
@@ -84,6 +105,10 @@ If the collector exits after the first error, an unbuffered channel can leave si
 ### Hiding cancellation in helper functions
 
 Keep the cancellation decision near the aggregation point. That is where the business contract is visible.
+
+### Returning before senders can escape
+
+If child goroutines have no buffered send path, no select on `ctx.Done()`, and no external shutdown path, an early return from the collector can leave them wedged forever.
 
 ## Use this pattern when
 

--- a/docs/patterns/fan-out-fan-in.md
+++ b/docs/patterns/fan-out-fan-in.md
@@ -60,6 +60,25 @@ func CollectInventory(ctx context.Context, sku string, lookups map[string]Wareho
 }
 ```
 
+## Simplified aggregation sketch
+
+```go
+results := make(chan result, len(backends))
+
+for _, backend := range backends {
+    go func(backend Backend) {
+        value, err := backend.Lookup(ctx, key)
+        results <- result{value: value, err: err}
+    }(backend)
+}
+
+for range backends {
+    merge(<-results)
+}
+```
+
+The important production question is not "did fan-out happen?" The important question is "what counts as an acceptable aggregate when some branches fail?"
+
 That contract is practical because warehouse outages are common, but that does not mean the caller should lose all availability information.
 
 ## What the tests prove
@@ -79,6 +98,16 @@ If your product can work with partial inventory visibility, keep partial results
 
 ## Common mistakes
 
+### Failure pattern: accidental all-or-nothing policy
+
+```go
+if item.err != nil {
+    return InventoryReport{}, item.err // throws away useful partial success
+}
+```
+
+That policy may be correct in some systems, but it should be a conscious choice rather than the default reflex.
+
 ### Treating all downstream errors equally
 
 Some systems need "all or nothing". Others need "best effort". Decide which one you are building before you write the code.
@@ -90,3 +119,7 @@ Concurrent completion order is rarely the same as business priority. Sort after 
 ### Unbounded fan-out
 
 This example fans out once per warehouse. That is usually small and known. If the target set can grow large, combine this pattern with a worker pool or semaphore.
+
+### Closing the shared results channel from a worker
+
+The aggregator should usually own the receive loop and the final close condition. If multiple workers might close the same shared channel, the design is already in danger.

--- a/docs/patterns/pipeline.md
+++ b/docs/patterns/pipeline.md
@@ -61,6 +61,28 @@ func RunAlertPipeline(ctx context.Context, events []CheckoutEvent, workers int, 
 }
 ```
 
+## Simplified stage sketch
+
+The core pipeline shape is:
+
+```go
+in := source(ctx)
+mid := stageA(ctx, in)
+out := stageB(ctx, mid)
+
+for item := range out {
+    consume(item)
+}
+```
+
+Each stage should have one clear responsibility:
+
+- read,
+- transform,
+- filter,
+- aggregate,
+- or decide cancellation.
+
 That structure keeps each decision in one place:
 
 - `source()` is responsible for turning a slice into a stream,
@@ -88,6 +110,29 @@ The scoring stage runs concurrently, so completion order is not stable. The exam
 ### Error handling must be intentional
 
 Not every pipeline should stop on the first error. In this example, a failed risk score means the whole alert set is unreliable, so the collector cancels the run.
+
+## Failure patterns
+
+### A stage that never closes its output
+
+```go
+func stage(in <-chan Event) <-chan Score {
+    out := make(chan Score)
+    go func() {
+        for event := range in {
+            out <- score(event)
+        }
+        // forgot: close(out)
+    }()
+    return out
+}
+```
+
+One forgotten `close(out)` can leave the downstream collector blocked forever.
+
+### Ignoring cancellation inside a long stage
+
+If a stage performs expensive remote work or CPU work and never checks `ctx.Done()`, the pipeline looks cancellable on paper but not in reality.
 
 ## Use this pattern when
 

--- a/docs/patterns/worker-pool.md
+++ b/docs/patterns/worker-pool.md
@@ -74,6 +74,30 @@ func GenerateQuotes(ctx context.Context, orders []Order, workers int, quoteFn Qu
 }
 ```
 
+## Simplified implementation sketch
+
+The smallest useful worker-pool mental model looks like this:
+
+```go
+jobs := make(chan Job)
+results := make(chan Result, workers)
+
+for range workers {
+    go func() {
+        for job := range jobs {
+            results <- process(job)
+        }
+    }()
+}
+```
+
+The real production version adds:
+
+- context cancellation,
+- index tracking for stable output order,
+- worker shutdown coordination,
+- explicit error policy.
+
 Three design choices matter here:
 
 1. Results carry the original input index, so the collector can restore input order.
@@ -92,6 +116,18 @@ They prove:
 
 ## Common mistakes
 
+### Failure pattern: early return with an unbuffered results channel
+
+```go
+results := make(chan result) // risky in early-return flows
+
+if err != nil {
+    return nil, err // workers may now block forever on send
+}
+```
+
+If the collector can exit before all workers finish sending, an unbuffered results channel is one of the fastest ways to leak goroutines.
+
 ### Returning completion order when callers expect input order
 
 This is one of the easiest regressions to ship. If your API contract needs stable ordering, attach the original index to each job.
@@ -103,6 +139,10 @@ If workers do not receive a shared derived context, a failed batch keeps burning
 ### Using a worker pool for tiny request sizes
 
 If the batch is usually one or two items, the extra complexity may not buy you anything. Measure first.
+
+### Letting workers outlive the batch contract
+
+If workers do not watch a shared context or another shutdown signal, the pool can keep consuming downstream capacity after the caller no longer cares about the result.
 
 ## Use this pattern when
 

--- a/docs/production/index.md
+++ b/docs/production/index.md
@@ -1,0 +1,34 @@
+---
+title: Production Overview
+description: Learn the concurrency concerns that matter once Go code is serving real traffic at scale.
+---
+
+# Production Overview
+
+The earlier sections explain how Go concurrency works and how to apply specific patterns.
+
+This section is about what changes when the code is no longer a neat example and starts carrying real production load.
+
+## What this section covers
+
+| Topic | Why it matters |
+| --- | --- |
+| [Large-Scale Go Systems](/production/large-scale-go-systems) | Turns runtime knowledge into operating rules for latency, memory, shutdown, and overload |
+| [Open-Source Case Studies](/production/open-source-case-studies) | Shows how major Go projects structure concurrency in real source code |
+
+## The production shift
+
+In examples, the main question is often "is this pattern correct?"
+
+In production, the questions become:
+
+- who owns goroutine lifetime,
+- where do we reject load,
+- what happens during deploy and shutdown,
+- what does the runtime do under heap pressure,
+- which hot loops or hot locks dominate tail latency,
+- how do we observe all of that without guessing.
+
+## Practical takeaway
+
+If fundamentals teach you why Go concurrency works, the production section teaches you how not to lose that advantage at scale.

--- a/docs/production/large-scale-go-systems.md
+++ b/docs/production/large-scale-go-systems.md
@@ -1,0 +1,152 @@
+---
+title: Large-Scale Go Systems
+description: Practical concurrency rules for latency, memory, admission control, lifecycle, and observability in real Go production systems.
+---
+
+# Large-Scale Go Systems
+
+The biggest gap between tutorial code and production code is not syntax. It is operational pressure.
+
+Once a Go service is under real load, the questions become about limits, ownership, visibility, and failure containment.
+
+:::tip Quick takeaway
+At scale, the most expensive concurrency bugs are usually not "goroutine syntax mistakes." They are unbounded queues, leaky lifetimes, missing deadlines, hot shared state, and weak observability.
+:::
+
+## Rule 1: every goroutine needs an owner
+
+You should be able to answer:
+
+- who started this goroutine,
+- what condition makes it stop,
+- who waits for it to finish,
+- what happens if the parent request or process ends first.
+
+If you cannot answer those questions, you do not yet have a production-grade concurrency design.
+
+## Rule 2: admission control beats cleanup
+
+Many systems try to survive overload by doing more cleanup after the fact.
+
+That is too late.
+
+The stronger pattern is:
+
+- bound the queue,
+- bound the worker set,
+- reject or degrade early,
+- keep latency predictable.
+
+```go
+func Submit(ctx context.Context, job Job) error {
+    select {
+    case jobs <- job:
+        return nil
+    default:
+        return ErrOverloaded
+    }
+}
+```
+
+This sketch is intentionally simple. The point is that overload policy should be explicit in the interface.
+
+## Rule 3: deadlines must flow through the whole call tree
+
+At scale, "we had a timeout at the edge" is not enough.
+
+If the leaf goroutines do not receive the derived context, then the timeout is only a logging event, not a control mechanism.
+
+### Failure pattern
+
+```go
+ctx, cancel := context.WithTimeout(parent, 100*time.Millisecond)
+defer cancel()
+
+go fetchFromBackend(context.Background(), id) // wrong: detached from request lifetime
+```
+
+This is how request timeouts turn into background leaks.
+
+## Rule 4: queues are latency objects, not just buffers
+
+A queue does three things:
+
+- absorbs burst,
+- hides overload for a while,
+- converts service pressure into waiting time.
+
+That means queue length, queue age, and drop policy are production signals, not implementation details.
+
+## Rule 5: hot shared state needs an ownership choice
+
+When one map, cache, or state machine becomes hot, you must choose on purpose:
+
+- `map + mutex`,
+- actor ownership,
+- sharding,
+- read-mostly atomic snapshots,
+- per-key worker / mailbox partitioning.
+
+This is not an aesthetic choice. It changes tail latency and failure behavior.
+
+## Rule 6: cgo and syscalls change scheduler reality
+
+Pure Go network services benefit from the runtime's netpoll integration.
+
+Heavy cgo or opaque blocking syscalls shift the scheduler model:
+
+- threads can stay blocked longer,
+- `P` handoff matters more,
+- latency intuition based on pure Go code becomes less reliable.
+
+This is why "just I/O bound" is not a sufficient production diagnosis.
+
+## Rule 7: memory is part of the concurrency budget
+
+At large scale, heap shape affects concurrency behavior.
+
+High allocation rate means:
+
+- more GC assist work,
+- more background marking pressure,
+- more latency sensitivity to object churn.
+
+If each request fans out aggressively and allocates aggressively, the GC becomes part of your concurrency story whether you wanted that or not.
+
+## Rule 8: shutdown is part of correctness
+
+Deploys, rollouts, and node drains happen all the time.
+
+A production service needs a shutdown contract:
+
+1. stop admitting new work,
+2. drain or cancel accepted work by policy,
+3. enforce a hard deadline,
+4. expose metrics or logs when shutdown does not complete cleanly.
+
+## Rule 9: traces and profiles are not optional
+
+Once the system is large enough, intuition is not enough.
+
+You need:
+
+- `go test -trace` and `go tool trace`,
+- block and mutex profiles,
+- heap and alloc profiles,
+- queue metrics,
+- request timeout and cancellation metrics,
+- goroutine lifecycle counters where useful.
+
+## A practical production checklist
+
+- bounded concurrency at every expensive external boundary
+- explicit queue capacity and overload behavior
+- request-scoped context passed to every dependent goroutine
+- graceful shutdown with a real deadline
+- no unbounded mailbox without justification
+- no hot shared map without a stated ownership model
+- runtime observability available before the incident
+
+## Practical takeaway
+
+Production Go concurrency is not about using more goroutines. It is about deciding where concurrency should stop, where it should wait, and where it should fail fast.

--- a/docs/production/open-source-case-studies.md
+++ b/docs/production/open-source-case-studies.md
@@ -1,0 +1,130 @@
+---
+title: Open-Source Case Studies
+description: Learn how major Go open-source projects structure concurrency in practice, with source pointers and design takeaways.
+---
+
+# Open-Source Case Studies
+
+The fastest way to deepen your concurrency taste is to read real Go systems that survived production pressure.
+
+This page does not try to summarize whole projects. It focuses on concurrency structures worth studying.
+
+## Kubernetes client-go workqueue
+
+Source:
+
+- [kubernetes/client-go util/workqueue/queue.go](https://github.com/kubernetes/client-go/blob/master/util/workqueue/queue.go)
+
+What to study:
+
+- `dirty` and `processing` sets,
+- `Get`, `Done`, and `ShutDown`,
+- how duplicate work is deduplicated without losing requeue semantics.
+
+Why it matters:
+
+This queue design is a production answer to a subtle problem: work items can be updated again while they are still being processed. The queue preserves that signal without letting the same item flood the queue endlessly.
+
+Simplified shape:
+
+```go
+if item already processing {
+    mark dirty
+    return
+}
+enqueue(item)
+```
+
+Takeaway:
+
+Production queues are not just slices plus channels. They encode reprocessing semantics and shutdown semantics.
+
+## etcd raft node loop
+
+Source:
+
+- [etcd-io/raft node.go](https://github.com/etcd-io/raft/blob/main/node.go)
+
+What to study:
+
+- `Ready() <-chan Ready`
+- `Advance()`
+- `Tick()`
+- `Step(ctx, msg)`
+
+Why it matters:
+
+The Raft core is separated from storage and transport through channel-driven boundaries. The core says "here is what must be persisted and sent next," while the application side decides when that work is durable and can be advanced.
+
+Simplified shape:
+
+```go
+for {
+    select {
+    case rd := <-node.Ready():
+        persist(rd)
+        send(rd.Messages)
+        node.Advance()
+    }
+}
+```
+
+Takeaway:
+
+This is a strong example of communication-first design where the concurrency boundary also becomes a correctness boundary.
+
+## Prometheus scrape loop
+
+Source:
+
+- [prometheus/prometheus scrape/scrape.go](https://github.com/prometheus/prometheus/blob/main/scrape/scrape.go)
+
+What to study:
+
+- `newScrapeLoop`
+- `(*scrapeLoop).run`
+- how ticker-driven scheduling, cancellation, and staleness handling live together.
+
+Why it matters:
+
+Prometheus is not just "run a goroutine every N seconds." The scrape loop owns time, error handling, sample append flow, and shutdown behavior in one lifecycle-aware loop.
+
+Takeaway:
+
+Periodic work at scale should usually have one explicit owner loop rather than ad hoc timers scattered across helpers.
+
+## NATS server client read/write loops
+
+Source:
+
+- [nats-io/nats-server server/client.go](https://github.com/nats-io/nats-server/blob/main/server/client.go)
+
+What to study:
+
+- `readLoop`
+- `writeLoop`
+- `sync.Cond` signaling around outbound flush behavior
+
+Why it matters:
+
+NATS separates socket reading from socket writing and uses explicit signaling instead of busy waiting. This is a good example of where channels are not the only correct Go tool; condition variables and carefully owned loops can be exactly right.
+
+Takeaway:
+
+Do not force every production concurrency design into channels if a condition variable plus clear ownership gives a tighter fit.
+
+## How to read these systems well
+
+When you study production Go code, ask:
+
+1. where is the lifetime owner,
+2. where is the overload boundary,
+3. where is the state owner,
+4. where is the shutdown contract,
+5. what metrics or traces would expose failure here.
+
+## Practical takeaway
+
+Reading open-source Go code is most useful when you read it for boundaries, not just APIs.
+
+The best projects make concurrency policy visible in queue design, lifecycle loops, signaling edges, and shutdown paths.


### PR DESCRIPTION
## Summary
- add a new production section for large-scale Go system operating rules and real open-source concurrency case studies
- strengthen existing pattern pages with simplified implementation sketches and explicit failure-pattern snippets
- surface the new production material across nav, home pages, and README in both English and Korean

## Testing
- npm run docs:build
- go test ./...

Closes #11
