### PR TITLE
Docs: deepen snippets and failure walkthroughs

### DIFF
--- a/docs/advanced/backpressure-load-shedding.md
+++ b/docs/advanced/backpressure-load-shedding.md
@@ -50,6 +50,21 @@ Common building blocks are:
 - request deadlines and context cancellation,
 - degraded responses instead of full failure when possible.
 
+## Simplified admission sketch
+
+```go
+func TryEnqueue(job Job) error {
+    select {
+    case queue <- job:
+        return nil
+    default:
+        return ErrOverloaded
+    }
+}
+```
+
+That tiny pattern is often more honest than silently accepting work your system has no realistic chance of serving on time.
+
 ```mermaid
 flowchart LR
     A["incoming work"] --> B{"capacity available?"}
@@ -71,6 +86,14 @@ flowchart LR
 - [Weighted Semaphore](/advanced/weighted-semaphore): bounds resource weight.
 - [Structured Concurrency](/advanced/structured-concurrency): keeps canceled work from lingering.
 - [Singleflight](/advanced/singleflight): reduces duplicate backend pressure for the same key.
+
+## Failure pattern
+
+```go
+go handle(job) // one goroutine per incoming unit, no bound, no queue policy
+```
+
+This is the classic overload trap. The code looks responsive at first because admission is instant. Under pressure it converts load into goroutine count, memory growth, and tail-latency collapse.
 
 ## Practical takeaway
 

--- a/docs/advanced/csp-theory.md
+++ b/docs/advanced/csp-theory.md
@@ -59,6 +59,25 @@ flowchart LR
     Q --> D["Receiver"]
 ```
 
+## Tiny code sketch
+
+```go
+func producer(out chan<- Item) {
+    for _, item := range items {
+        out <- item
+    }
+    close(out)
+}
+
+func consumer(in <-chan Item) {
+    for item := range in {
+        handle(item)
+    }
+}
+```
+
+That is the CSP-shaped intuition in everyday Go: independent processes connected by explicit communication edges.
+
 ## Why this matters in practice
 
 The patterns in this repository become easier to classify once you see the CSP influence:
@@ -104,6 +123,15 @@ CSP gives you a way to think about composition. It does not remove the need for 
 - observability.
 
 Those are the places where production systems either stay clean or become fragile.
+
+## Failure pattern
+
+```go
+go func() { state.count++ }()
+go func() { state.count++ }()
+```
+
+This is precisely the kind of shared-memory mutation CSP-influenced Go style tries to make you question. Once shared state escapes the communication protocol, the conceptual simplicity disappears quickly.
 
 ## Practical takeaway
 

--- a/docs/advanced/structured-concurrency.md
+++ b/docs/advanced/structured-concurrency.md
@@ -34,6 +34,26 @@ That leads to:
 
 Recent versions also support `SetLimit`, which makes structured concurrency practical even for larger finite task sets.
 
+## Simplified implementation sketch
+
+```go
+group, ctx := errgroup.WithContext(parent)
+group.SetLimit(limit)
+
+for _, tenant := range tenants {
+    tenant := tenant
+    group.Go(func() error {
+        return backfillTenant(ctx, tenant)
+    })
+}
+
+if err := group.Wait(); err != nil {
+    return err
+}
+```
+
+That is the core shape: one parent context, one bounded task set, one wait point.
+
 ## Example scenario
 
 `examples/errgroupbatch` runs tenant backfills for a fixed batch:
@@ -88,15 +108,31 @@ The package source is explicit about this. Treat the limit as part of group cons
 
 Even with nice helpers like `errgroup`, you still need the standard Go pattern of rebinding loop variables inside the loop before launching goroutines.
 
-## Common failure mode
+## Failure patterns
 
-The most common mistake is mixing structured and unstructured lifetimes:
+### Mixing structured and unstructured lifetimes
 
-- one task is in the group,
-- another goroutine is spawned outside the group,
-- cancellation stops only part of the real workflow.
+```go
+group.Go(func() error {
+    return runPrimary(ctx)
+})
 
-That defeats the main benefit.
+go fireAndForgetAudit(ctx) // outside the group
+```
+
+Now cancellation stops only part of the real workflow. That defeats the main benefit of the pattern.
+
+### Forgetting loop-variable rebinding
+
+```go
+for _, tenant := range tenants {
+    group.Go(func() error {
+        return backfillTenant(ctx, tenant) // risky if tenant is not rebound
+    })
+}
+```
+
+`errgroup` improves lifetime control. It does not remove the standard Go closure rules.
 
 ## Practical takeaway
 

--- a/docs/advanced/weighted-semaphore.md
+++ b/docs/advanced/weighted-semaphore.md
@@ -42,6 +42,26 @@ The example combines:
 - `errgroup.WithContext` for structured cancellation,
 - `x/sync/semaphore` for weighted admission control.
 
+## Simplified implementation sketch
+
+```go
+sem := semaphore.NewWeighted(int64(capacityMB))
+
+for _, job := range jobs {
+    job := job
+    group.Go(func() error {
+        if err := sem.Acquire(ctx, int64(job.WeightMB)); err != nil {
+            return err
+        }
+        defer sem.Release(int64(job.WeightMB))
+
+        return render(job)
+    })
+}
+```
+
+The semaphore answers one narrow question: may this job consume that much budget right now?
+
 ## What the tests prove
 
 The tests verify that:
@@ -78,6 +98,20 @@ If a request needs more capacity than the system can ever provide, fail early. D
 ### Treating a semaphore like a whole workflow
 
 A semaphore answers "may this job proceed?" It does not answer "how should I aggregate errors?" Pair it with structured concurrency or explicit cancellation.
+
+### Failure pattern: acquiring without guaranteed release
+
+```go
+if err := sem.Acquire(ctx, weight); err != nil {
+    return err
+}
+
+if err := render(job); err != nil {
+    return err // leaked budget if Release is forgotten
+}
+```
+
+If every successful acquire does not have a matching release on every path, your limit slowly turns into a dead system.
 
 ## Practical takeaway
 

--- a/docs/extras/go-csp-vs-rust-tokio.md
+++ b/docs/extras/go-csp-vs-rust-tokio.md
@@ -104,6 +104,32 @@ In Tokio:
 - cancellation tokens or select-based cancellation are common,
 - structured task composition is more explicit in the library layer.
 
+## Tiny comparison sketch
+
+Go version:
+
+```go
+for req := range requests {
+	go func(req Request) {
+		replies <- handle(req)
+	}(req)
+}
+```
+
+Tokio version:
+
+```rust
+while let Some(req) = requests.recv().await {
+    let replies = replies.clone();
+    tokio::spawn(async move {
+        let res = handle(req).await;
+        let _ = replies.send(res).await;
+    });
+}
+```
+
+The surface problem is similar. The control points differ: Go leans on goroutines and `select`, while Tokio makes async boundaries, task spawning, and channel ownership more explicit in the library layer.
+
 ## When Go feels better
 
 Go often feels better when:
@@ -119,6 +145,20 @@ Tokio often feels better when:
 - ownership and lifetime constraints should be pushed into the type system,
 - you want explicit async boundaries,
 - you want the broader Rust ecosystem around zero-cost abstractions and tight control over allocation and layout.
+
+## Failure pattern
+
+Porting goroutine habits directly into Tokio usually means detaching work without a clear backpressure or cancellation handle:
+
+```rust
+for req in requests {
+    tokio::spawn(async move {
+        let _ = handle(req).await;
+    });
+}
+```
+
+The mistake is conceptually familiar to Go engineers too, but Go's CSP defaults often push you toward explicit coordination earlier. Tokio makes that coordination possible, but not implicit.
 
 ## Official reading
 

--- a/docs/fundamentals/channel-internals.md
+++ b/docs/fundamentals/channel-internals.md
@@ -227,6 +227,22 @@ These internals explain several surface-level best practices:
 - use context cancellation so blocked goroutines have a clear escape path,
 - prefer bounded queues when overload matters.
 
+## Failure pattern
+
+One of the most common protocol bugs is letting one producer decide it also owns `close` for a shared output channel:
+
+```go
+func producer(out chan<- Job, jobs []Job, wg *sync.WaitGroup) {
+	defer wg.Done()
+	for _, job := range jobs {
+		out <- job
+	}
+	close(out) // bad: one of many producers closes a shared channel
+}
+```
+
+This works only until another producer sends later or also decides to close. The visible panic is just the runtime enforcing a protocol that the application failed to define clearly.
+
 ## Practical takeaway
 
 Channels are efficient, but they are not simplistic. They combine queueing, synchronization, parking, wakeup, and lifecycle signaling in one abstraction.

--- a/docs/fundamentals/channels-memory-model.md
+++ b/docs/fundamentals/channels-memory-model.md
@@ -158,6 +158,25 @@ False.
 
 If the same state is also read or written outside the synchronized channel protocol, you can still have a data race. Channels help only when the state transition protocol is actually built around them.
 
+## Failure pattern
+
+This still races even though a channel exists:
+
+```go
+var cfg Config
+ready := make(chan struct{})
+
+go func() {
+	cfg = loadConfig()
+	close(ready)
+}()
+
+fmt.Println(cfg.Timeout) // bad: read happens before the synchronization edge
+<-ready
+```
+
+Receiving from `ready` would synchronize visibility, but the read above happens too early. The rule is not "a channel exists somewhere"; the rule is "the relevant read happens after the synchronizing operation."
+
 ## Practical takeaway
 
 Correct Go concurrency depends on explicit synchronization, not just goroutine count.

--- a/docs/fundamentals/garbage-collector.md
+++ b/docs/fundamentals/garbage-collector.md
@@ -138,6 +138,21 @@ Pointer-rich long-lived structures cost more to scan than flat numeric buffers.
 
 GC is easier to operate when the service has explicit memory expectations rather than accidental heap growth.
 
+## Failure pattern
+
+Allocation-heavy fan-out turns GC work into part of request latency:
+
+```go
+for _, req := range batch {
+	go func(req Request) {
+		payload := make([]byte, 1<<20) // hot allocation in the fan-out path
+		_ = process(req, payload)
+	}(req)
+}
+```
+
+Go's GC is concurrent, but heavy allocators still pay assist costs and increase heap pressure. "Goroutines are cheap" does not mean "allocation bursts are free."
+
 ## Practical takeaway
 
 Go's concurrency model is strong partly because the GC is engineered for always-on server workloads.

--- a/docs/fundamentals/go-runtime-scheduler.md
+++ b/docs/fundamentals/go-runtime-scheduler.md
@@ -225,6 +225,18 @@ Every goroutine still carries:
 The scheduler decides *when* runnable goroutines execute.
 It does not know your external service limits, memory budget, latency SLOs, or backpressure policy.
 
+## Failure pattern
+
+The scheduler does not turn unbounded fan-out into a safe design:
+
+```go
+for _, req := range requests {
+	go handle(req) // bad: no limit, no queue, no admission control
+}
+```
+
+This can create runnable or blocked goroutines far faster than CPUs, memory, or downstream services can absorb. The runtime multiplexes work; it does not invent a concurrency budget for you.
+
 ## Practical takeaway
 
 The runtime makes Go concurrency patterns viable, but the runtime does not choose your ownership model or failure policy for you.

--- a/docs/fundamentals/map-internals.md
+++ b/docs/fundamentals/map-internals.md
@@ -134,6 +134,19 @@ When updates are protocol-heavy, a single owner goroutine can be easier to reaso
 
 Even with a better table design, a large pointer-rich map changes heap size, scan work, and cache behavior.
 
+## Failure pattern
+
+Swiss Tables improved layout and probing. They did not make concurrent mutation safe:
+
+```go
+counts := map[string]int{}
+
+go func() { counts["ok"]++ }()
+go func() { counts["fail"]++ }()
+```
+
+This is still a race and may panic with concurrent map write errors. Faster internals do not remove the need for a clear ownership model.
+
 ## Runtime source walk
 
 Start here:

--- a/docs/fundamentals/mutex-semaphore-internals.md
+++ b/docs/fundamentals/mutex-semaphore-internals.md
@@ -200,6 +200,23 @@ Understanding these internals should change how you design:
 - choose actors or channels when explicit ownership is clearer than shared-memory locking,
 - choose mutexes when the state is local and the protocol is trivial.
 
+## Failure pattern
+
+This compiles cleanly and still destroys latency:
+
+```go
+mu.Lock()
+defer mu.Unlock()
+
+resp, err := http.Get(url) // bad: slow I/O while the lock is held
+if err != nil {
+	return err
+}
+defer resp.Body.Close()
+```
+
+Once waiters queue behind a lock like this, contention becomes a scheduler and tail-latency problem, not just a local code smell.
+
 ## Practical takeaway
 
 Go's public synchronization primitives look small because the runtime absorbs a lot of complexity on your behalf.

--- a/docs/fundamentals/netpoller-timers-syscalls.md
+++ b/docs/fundamentals/netpoller-timers-syscalls.md
@@ -152,6 +152,24 @@ Use traces when you want to answer questions such as:
 - Are timeouts waking goroutines or are requests just stalling?
 - Is the process limited by downstream I/O or by CPU?
 
+## Failure pattern
+
+The netpoller makes blocked I/O scalable, but it does not rescue a server with no deadline or overload policy:
+
+```go
+for {
+	conn, _ := ln.Accept()
+	go func(c net.Conn) {
+		defer c.Close()
+		buf := make([]byte, 4096)
+		_, _ = c.Read(buf) // bad: a dead peer can park this forever
+		handleSlowRequest(buf)
+	}(conn)
+}
+```
+
+Without deadlines and admission limits, slow or stalled clients still consume file descriptors, heap, and scheduler attention.
+
 ## Practical takeaway
 
 The netpoller is a core part of Go's concurrency model, not an implementation footnote.

--- a/docs/fundamentals/runtime-evolution.md
+++ b/docs/fundamentals/runtime-evolution.md
@@ -122,6 +122,19 @@ That means:
 - better cache behavior during marking,
 - more efficient throughput in allocation-heavy services.
 
+## Failure pattern
+
+Old scheduler folklore often survives as cargo-cult yielding:
+
+```go
+for {
+	doCPUHeavyChunk()
+	runtime.Gosched() // bad: outdated substitute for real cancellation and work budgeting
+}
+```
+
+Modern Go has async preemption, but that does not make endless work loops a good design. Runtime evolution should update your mental model, not replace explicit boundaries.
+
 ## Runtime source walk
 
 If you want to verify the story in code, start here:

--- a/docs/ko/advanced/backpressure-load-shedding.md
+++ b/docs/ko/advanced/backpressure-load-shedding.md
@@ -50,6 +50,21 @@ description: bounded queue, admission control, 거절 정책으로 과부하 상
 - request deadline과 context cancellation
 - full failure 대신 degraded response
 
+## 단순화한 admission 스케치
+
+```go
+func TryEnqueue(job Job) error {
+    select {
+    case queue <- job:
+        return nil
+    default:
+        return ErrOverloaded
+    }
+}
+```
+
+이 작은 패턴 하나가, 처리 불가능한 일을 조용히 받아들이는 것보다 훨씬 정직합니다.
+
 ```mermaid
 flowchart LR
     A["incoming work"] --> B{"capacity available?"}
@@ -71,6 +86,14 @@ flowchart LR
 - [가중 세마포어](/ko/advanced/weighted-semaphore): resource weight를 제한
 - [구조화된 동시성](/ko/advanced/structured-concurrency): cancel된 작업이 계속 남지 않게 함
 - [Singleflight](/ko/advanced/singleflight): 같은 key에 대한 중복 backend pressure를 줄임
+
+## 실패 패턴
+
+```go
+go handle(job) // bound도 없고 queue policy도 없음
+```
+
+이게 전형적인 overload trap입니다. 초반에는 admission이 즉시 되니 빨라 보이지만, 부하가 커지면 goroutine 수, 메모리, tail latency가 같이 무너집니다.
 
 ## 실전 요약
 

--- a/docs/ko/advanced/csp-theory.md
+++ b/docs/ko/advanced/csp-theory.md
@@ -59,6 +59,25 @@ flowchart LR
     Q --> D["Receiver"]
 ```
 
+## 작은 코드 스케치
+
+```go
+func producer(out chan<- Item) {
+    for _, item := range items {
+        out <- item
+    }
+    close(out)
+}
+
+func consumer(in <-chan Item) {
+    for item := range in {
+        handle(item)
+    }
+}
+```
+
+이게 everyday Go에서 보이는 CSP 감각입니다. 독립된 process들이 명시적인 communication edge로 연결됩니다.
+
 ## 실전 패턴과의 연결
 
 이 저장소 패턴도 CSP 관점으로 보면 더 명확해집니다.
@@ -106,6 +125,15 @@ CSP는 조합 방식을 설명해주지만, 다음 같은 실전 문제를 대�
 - 관측 가능성
 
 실제 시스템이 깔끔할지 취약할지는 대부분 여기서 갈립니다.
+
+## 실패 패턴
+
+```go
+go func() { state.count++ }()
+go func() { state.count++ }()
+```
+
+이건 CSP 영향을 받은 Go 스타일이 경계하라고 말하는 shared-memory mutation입니다. communication protocol 밖으로 상태가 새는 순간 개념적 단순성이 빠르게 사라집니다.
 
 ## 실전 요약
 

--- a/docs/ko/advanced/structured-concurrency.md
+++ b/docs/ko/advanced/structured-concurrency.md
@@ -36,6 +36,26 @@ Go에서 이를 가장 실용적으로 표현하는 도구는 `golang.org/x/sync
 
 최근 버전은 `SetLimit`도 지원해서, 유한한 task set에 대한 구조화된 동시성을 실무적으로 쓰기 좋습니다.
 
+## 단순화한 구현 스케치
+
+```go
+group, ctx := errgroup.WithContext(parent)
+group.SetLimit(limit)
+
+for _, tenant := range tenants {
+    tenant := tenant
+    group.Go(func() error {
+        return backfillTenant(ctx, tenant)
+    })
+}
+
+if err := group.Wait(); err != nil {
+    return err
+}
+```
+
+핵심 형태는 이것입니다. 하나의 parent context, 하나의 bounded task set, 하나의 wait point.
+
 ## 예제 시나리오
 
 `examples/errgroupbatch`는 tenant backfill batch를 실행합니다.
@@ -92,13 +112,29 @@ worker pool은 channel 기반의 reusable dispatch 구조가 필요할 때 좋�
 
 ## 흔한 실패 패턴
 
-가장 흔한 실수는 structured lifetime과 unstructured lifetime을 섞는 것입니다.
+### structured lifetime과 unstructured lifetime을 섞는 경우
 
-- 일부 작업은 group 안에 있고,
-- 다른 goroutine은 group 밖에서 따로 생성되고,
-- cancellation이 실제 workflow의 일부에만 적용됩니다.
+```go
+group.Go(func() error {
+    return runPrimary(ctx)
+})
 
-그러면 이 패턴의 핵심 장점이 사라집니다.
+go fireAndForgetAudit(ctx) // group 바깥
+```
+
+이제 cancellation은 실제 workflow의 일부에만 적용됩니다. 그러면 이 패턴의 핵심 장점이 사라집니다.
+
+### loop variable rebinding을 빼먹는 경우
+
+```go
+for _, tenant := range tenants {
+    group.Go(func() error {
+        return backfillTenant(ctx, tenant) // tenant rebinding이 없으면 위험
+    })
+}
+```
+
+`errgroup`은 lifetime control을 좋게 해주지만, Go의 closure rule까지 없애주지는 않습니다.
 
 ## 실전 요약
 

--- a/docs/ko/advanced/weighted-semaphore.md
+++ b/docs/ko/advanced/weighted-semaphore.md
@@ -42,6 +42,26 @@ flowchart LR
 - `errgroup.WithContext`로 structured cancellation을 하고,
 - `x/sync/semaphore`로 weighted admission control을 합니다.
 
+## 단순화한 구현 스케치
+
+```go
+sem := semaphore.NewWeighted(int64(capacityMB))
+
+for _, job := range jobs {
+    job := job
+    group.Go(func() error {
+        if err := sem.Acquire(ctx, int64(job.WeightMB)); err != nil {
+            return err
+        }
+        defer sem.Release(int64(job.WeightMB))
+
+        return render(job)
+    })
+}
+```
+
+세마포어는 한 가지 질문에만 답합니다. 이 작업이 이만큼의 예산을 지금 써도 되는가.
+
 ## 테스트가 증명하는 것
 
 테스트는 다음을 검증합니다.
@@ -78,6 +98,20 @@ flowchart LR
 ### semaphore를 workflow 전체로 착각하기
 
 semaphore는 "이 작업을 지금 시작해도 되는가"를 말해줍니다. error aggregation이나 cancel policy까지 대신해주지는 않습니다.
+
+### 실패 패턴: Acquire 후 Release를 보장하지 않는 경우
+
+```go
+if err := sem.Acquire(ctx, weight); err != nil {
+    return err
+}
+
+if err := render(job); err != nil {
+    return err // Release를 빼먹으면 예산이 새어 나감
+}
+```
+
+성공한 acquire마다 모든 경로에서 matching release가 있어야 합니다. 그렇지 않으면 시스템은 점점 죽어갑니다.
 
 ## 실전 요약
 

--- a/docs/ko/extras/go-csp-vs-rust-tokio.md
+++ b/docs/ko/extras/go-csp-vs-rust-tokio.md
@@ -104,6 +104,32 @@ Tokio에서는:
 - cancellation token이나 `select!` 패턴이 흔하며,
 - structured composition이 더 library layer에서 드러납니다.
 
+## 작은 비교 스케치
+
+Go 버전:
+
+```go
+for req := range requests {
+	go func(req Request) {
+		replies <- handle(req)
+	}(req)
+}
+```
+
+Tokio 버전:
+
+```rust
+while let Some(req) = requests.recv().await {
+    let replies = replies.clone();
+    tokio::spawn(async move {
+        let res = handle(req).await;
+        let _ = replies.send(res).await;
+    });
+}
+```
+
+표면적으로는 같은 문제를 푸는 코드처럼 보이지만, control point는 다릅니다. Go는 goroutine과 `select` 쪽으로 기울고, Tokio는 async boundary, task spawn, channel ownership을 더 명시적으로 드러냅니다.
+
 ## Go가 더 편하게 느껴질 때
 
 - direct-style network service code를 쓰고 싶을 때
@@ -115,6 +141,20 @@ Tokio에서는:
 - ownership / lifetime 제약을 타입 시스템에 더 밀어 넣고 싶을 때
 - async boundary를 더 명시적으로 보고 싶을 때
 - Rust 생태계의 zero-cost abstraction 감각을 함께 가져가고 싶을 때
+
+## 실패 패턴
+
+goroutine 습관을 Tokio에 그대로 옮기면 backpressure나 cancellation handle 없이 task를 마구 분리해 버리기 쉽습니다.
+
+```rust
+for req in requests {
+    tokio::spawn(async move {
+        let _ = handle(req).await;
+    });
+}
+```
+
+개념적으로는 Go에서도 익숙한 실수지만, Go는 CSP 기본 도구가 더 앞쪽에 있어서 coordination을 조금 더 빨리 의식하게 만듭니다. Tokio는 그것을 충분히 표현할 수 있지만, 암묵적으로 제공하지는 않습니다.
 
 ## 공식 자료
 

--- a/docs/ko/fundamentals/channel-internals.md
+++ b/docs/ko/fundamentals/channel-internals.md
@@ -225,6 +225,22 @@ Buffered channel은 다음에 매우 좋습니다.
 - blocked goroutine이 탈출할 수 있도록 context cancellation을 둘 것
 - overload가 중요하면 bounded queue를 사용할 것
 
+## 실패 패턴
+
+공유 output channel을 여러 producer가 쓰는데, 그중 한 producer가 `close`까지 자기 책임이라고 생각하면 프로토콜이 바로 깨지기 시작합니다.
+
+```go
+func producer(out chan<- Job, jobs []Job, wg *sync.WaitGroup) {
+	defer wg.Done()
+	for _, job := range jobs {
+		out <- job
+	}
+	close(out) // bad: 여러 producer 중 하나가 shared channel을 닫음
+}
+```
+
+다른 producer가 나중에 send하거나 또 `close`하려는 순간 panic이 납니다. 겉으로는 runtime panic이지만, 본질은 lifecycle ownership을 명확히 정하지 않은 설계입니다.
+
 ## 실전 요약
 
 채널은 효율적이지만 단순한 추상화는 아닙니다. queueing, synchronization, parking, wakeup, lifecycle signaling을 한 추상화 안에 같이 담고 있습니다.

--- a/docs/ko/fundamentals/channels-memory-model.md
+++ b/docs/ko/fundamentals/channels-memory-model.md
@@ -158,6 +158,25 @@ Go는 CSP 영향을 받았지만 "채널만 써라"는 언어는 아닙니다.
 
 동일한 상태를 채널 프로토콜 바깥에서도 읽거나 쓴다면 여전히 data race가 생길 수 있습니다. 채널은 상태 전이를 실제로 그 프로토콜 안에 넣었을 때만 도움이 됩니다.
 
+## 실패 패턴
+
+채널이 있다고 해서 자동으로 안전해지는 것은 아닙니다.
+
+```go
+var cfg Config
+ready := make(chan struct{})
+
+go func() {
+	cfg = loadConfig()
+	close(ready)
+}()
+
+fmt.Println(cfg.Timeout) // bad: synchronization edge 전에 읽음
+<-ready
+```
+
+`<-ready`는 visibility를 동기화하지만, 위 코드는 읽기가 너무 이르게 일어납니다. 규칙은 "어딘가에 채널이 있다"가 아니라 "관련된 읽기가 동기화 연산 뒤에 있다"입니다.
+
 ## 실전 요약
 
 정확한 Go 동시성은 고루틴 개수보다 명시적 동기화에 달려 있습니다.

--- a/docs/ko/fundamentals/garbage-collector.md
+++ b/docs/ko/fundamentals/garbage-collector.md
@@ -128,6 +128,21 @@ Go 1.25에서는 Green Tea가 실험 기능이었고, Go 1.26에서 기본 활�
 
 accidental heap growth보다 명시적 메모리 예산이 있는 서비스가 운영하기 쉽습니다.
 
+## 실패 패턴
+
+allocation이 무거운 fan-out은 GC 비용을 request latency 안으로 끌어들입니다.
+
+```go
+for _, req := range batch {
+	go func(req Request) {
+		payload := make([]byte, 1<<20) // fan-out 경로에서 큰 allocation
+		_ = process(req, payload)
+	}(req)
+}
+```
+
+Go의 GC는 concurrent지만, allocation이 많은 goroutine은 assist 비용을 치르고 heap pressure도 올립니다. "goroutine이 싸다"는 말은 "allocation burst가 공짜다"라는 뜻이 아닙니다.
+
 ## Practical takeaway
 
 Go의 동시성 모델이 실용적인 이유 중 하나는 GC가 늘 켜져 있는 서버 workload를 염두에 두고 설계되었기 때문입니다.

--- a/docs/ko/fundamentals/go-runtime-scheduler.md
+++ b/docs/ko/fundamentals/go-runtime-scheduler.md
@@ -225,6 +225,18 @@ Go 1.14의 asynchronous preemption은 tight loop, GC responsiveness, scheduler f
 스케줄러는 runnable goroutine을 언제 실행할지 정할 뿐입니다.
 외부 API 한도, 메모리 예산, latency SLO, backpressure 정책은 모릅니다.
 
+## 실패 패턴
+
+스케줄러는 unbounded fan-out을 안전한 설계로 바꿔주지 않습니다.
+
+```go
+for _, req := range requests {
+	go handle(req) // bad: limit도 queue도 admission control도 없음
+}
+```
+
+이 코드는 CPU, 메모리, downstream 서비스가 감당할 수 있는 속도보다 훨씬 빠르게 goroutine을 만들어낼 수 있습니다. runtime은 그 일을 multiplex할 뿐이고, 시스템 예산을 대신 정해주지는 않습니다.
+
 ## 실전 요약
 
 런타임은 Go 동시성 패턴을 가능하게 해주지만, 소유권 모델과 실패 정책은 대신 정해주지 않습니다.

--- a/docs/ko/fundamentals/map-internals.md
+++ b/docs/ko/fundamentals/map-internals.md
@@ -132,6 +132,19 @@ hot map 하나를 lock으로 감싸고 많은 goroutine이 때리면, 병목은 
 
 좋아진 설계와 별개로, pointer-rich large map은 heap scan과 retention 비용을 바꿉니다.
 
+## 실패 패턴
+
+Swiss Table이 들어왔다고 concurrent mutation이 안전해진 것은 아닙니다.
+
+```go
+counts := map[string]int{}
+
+go func() { counts["ok"]++ }()
+go func() { counts["fail"]++ }()
+```
+
+이 코드는 여전히 race이며 concurrent map write panic으로 이어질 수 있습니다. 내부 구현이 빨라졌다는 사실은 ownership 규칙을 없애주지 않습니다.
+
 ## 런타임 소스 포인터
 
 - [runtime/map.go](https://github.com/golang/go/blob/go1.26.0/src/runtime/map.go)

--- a/docs/ko/fundamentals/mutex-semaphore-internals.md
+++ b/docs/ko/fundamentals/mutex-semaphore-internals.md
@@ -200,6 +200,23 @@ mutex는 throughput과 fairness를 동시에 조절하므로 contention은 다�
 - 공유 메모리보다 explicit ownership이 낫다면 actor나 channel을 고려하고,
 - 상태가 로컬하고 프로토콜이 단순하면 mutex를 쓰는 편이 낫습니다.
 
+## 실패 패턴
+
+이 코드는 컴파일은 잘 되지만 latency를 망가뜨리기 딱 좋습니다.
+
+```go
+mu.Lock()
+defer mu.Unlock()
+
+resp, err := http.Get(url) // bad: lock을 잡은 채 느린 I/O 수행
+if err != nil {
+	return err
+}
+defer resp.Body.Close()
+```
+
+이런 코드 뒤에 waiter가 쌓이기 시작하면, 문제는 단순한 코드 냄새가 아니라 scheduler와 tail latency 전체에 영향을 주는 contention 이슈가 됩니다.
+
 ## 실전 요약
 
 Go의 public synchronization primitive가 간단해 보이는 이유는, 런타임이 상당한 복잡도를 대신 흡수하고 있기 때문입니다.

--- a/docs/ko/fundamentals/netpoller-timers-syscalls.md
+++ b/docs/ko/fundamentals/netpoller-timers-syscalls.md
@@ -140,6 +140,24 @@ deadline이 없으면 goroutine은 I/O에서 영원히 park될 수 있습니다.
 - `GODEBUG=schedtrace=1000,scheddetail=1`
 - connection / timeout 관련 서비스 메트릭
 
+## 실패 패턴
+
+netpoller는 blocked I/O를 확장 가능하게 만들지만, deadline이나 overload 정책이 없는 서버를 구해주지는 않습니다.
+
+```go
+for {
+	conn, _ := ln.Accept()
+	go func(c net.Conn) {
+		defer c.Close()
+		buf := make([]byte, 4096)
+		_, _ = c.Read(buf) // bad: 죽은 peer면 영원히 park될 수 있음
+		handleSlowRequest(buf)
+	}(conn)
+}
+```
+
+deadline과 admission limit이 없으면, 느리거나 멈춘 클라이언트는 여전히 file descriptor, heap, scheduler attention을 계속 잡아먹습니다.
+
 ## Practical takeaway
 
 Netpoller는 Go I/O 구현의 부가 기능이 아니라 동시성 모델의 핵심입니다.

--- a/docs/ko/fundamentals/runtime-evolution.md
+++ b/docs/ko/fundamentals/runtime-evolution.md
@@ -117,6 +117,19 @@ Green Tea는 작은 객체 marking에서 span 단위 batching을 통해 locality
 - cache behavior를 개선하며,
 - allocation-heavy 서버에서 marking 효율을 높입니다.
 
+## 실패 패턴
+
+오래된 스케줄러 folklore가 cargo-cult 형태로 남아 있는 경우가 많습니다.
+
+```go
+for {
+	doCPUHeavyChunk()
+	runtime.Gosched() // bad: 진짜 cancellation과 work budgeting을 대신할 수 없음
+}
+```
+
+현대 Go에는 async preemption이 있지만, 그렇다고 끝없는 work loop가 좋은 설계가 되지는 않습니다. 런타임 발전을 배운다는 것은 예전 조언을 반복하는 게 아니라 mental model을 업데이트하는 일입니다.
+
 ## 런타임 소스 포인터
 
 - [runtime/proc.go](https://github.com/golang/go/blob/go1.26.0/src/runtime/proc.go)

--- a/docs/ko/patterns/channel-of-channels.md
+++ b/docs/ko/patterns/channel-of-channels.md
@@ -97,6 +97,18 @@ one-shot reply라면 굳이 channel을 닫을 필요가 없는 경우가 많습�
 
 broker boundary가 없고 concurrency boundary도 없다면 channel protocol은 과할 수 있습니다.
 
+## 실패 패턴
+
+caller가 이미 떠난 뒤 unbuffered per-request reply channel로 응답하면 broker가 그대로 wedge될 수 있습니다.
+
+```go
+func respond(req Request, result Result) {
+	req.Reply <- result // bad: caller가 timeout으로 떠났다면 여기서 멈춤
+}
+```
+
+one-shot request/reply라면 size-1 buffered reply channel이나 caller cancellation을 함께 보는 `select`가 훨씬 안전합니다.
+
 ## Use this pattern when
 
 per-call ownership이 분명한 brokered request/reply가 필요할 때 쓰면 좋습니다.

--- a/docs/ko/patterns/graceful-shutdown.md
+++ b/docs/ko/patterns/graceful-shutdown.md
@@ -50,6 +50,32 @@ flowchart TD
 
 이 순서가 중요한 이유는, "그냥 전부 cancel"보다 운영 계약을 더 잘 반영하기 때문입니다.
 
+## 단순화한 구현 스케치
+
+```go
+func (p *Processor) Shutdown(ctx context.Context) error {
+    p.mu.Lock()
+    p.closed = true
+    close(p.jobs)
+    p.mu.Unlock()
+
+    done := make(chan struct{})
+    go func() {
+        defer close(done)
+        p.wg.Wait()
+    }()
+
+    select {
+    case <-done:
+        return nil
+    case <-ctx.Done():
+        return ctx.Err()
+    }
+}
+```
+
+핵심 계약은 단순합니다. admission 중단, queue close, worker drain 대기, deadline 강제.
+
 ## 예제가 증명하는 것
 
 `examples/gracefulshutdown/gracefulshutdown_test.go`는 다음을 검증합니다.
@@ -81,6 +107,16 @@ Graceful shutdown은 결국 정책 문제이기도 합니다.
 ### outer shutdown deadline이 없는 것
 
 deadline 없는 graceful shutdown은 결국 graceful hang이 될 수 있습니다.
+
+### 실패 패턴: closed 상태만 보고 send를 따로 하는 경우
+
+```go
+if !p.closed {
+    p.jobs <- event // 이 사이 다른 goroutine이 jobs를 닫을 수 있음
+}
+```
+
+이게 "테스트에서는 되던데?"가 production에서 `send on closed channel`로 바뀌는 전형적인 방식입니다.
 
 ## Use this pattern when
 

--- a/docs/ko/patterns/or-done-tee-bridge.md
+++ b/docs/ko/patterns/or-done-tee-bridge.md
@@ -83,6 +83,20 @@ flowchart LR
 
 반대로 ownership이나 backpressure가 핵심인데 이것만 넣는다고 설계가 좋아지지는 않습니다.
 
+## 실패 패턴
+
+아주 작은 forwarding helper도 cancellation을 무시하면 leak factory가 됩니다.
+
+```go
+func forward(in <-chan Item, out chan<- Item) {
+	for v := range in {
+		out <- v // bad: downstream이 멈추면 여기서 영원히 block
+	}
+}
+```
+
+`or-done`이 필요한 이유는 실제 파이프라인이 항상 모든 stage를 끝까지 drain하지 않기 때문입니다.
+
 ## Practical takeaway
 
 이건 "작지만 고급인 패턴"입니다. 전체 아키텍처를 지배하진 않지만, channel-heavy 코드의 가장 까다로운 모서리를 정리하는 데 자주 쓰입니다.

--- a/docs/ko/production/open-source-case-studies.md
+++ b/docs/ko/production/open-source-case-studies.md
@@ -113,6 +113,18 @@ NATS는 socket read와 write를 분리하고, busy waiting 대신 명시적 sign
 
 프로덕션 Go에서는 channel만이 정답이 아닙니다. `sync.Cond`와 명확한 owner loop가 더 적합한 경우가 분명히 있습니다.
 
+## 실패 패턴
+
+프로덕션 Go 코드를 잘못 읽으면 goroutine만 복사하고 그 주변 경계는 빠뜨리기 쉽습니다.
+
+```go
+for _, msg := range batch {
+	go process(msg) // bad: queue도 limit도 shutdown contract도 없음
+}
+```
+
+위에서 본 시스템들이 실제로 강한 이유는 queue, owner loop, signaling edge, lifecycle rule을 같이 갖고 있기 때문입니다. goroutine의 존재 자체보다 그 경계가 더 중요합니다.
+
 ## 어떻게 읽어야 하나
 
 오픈소스 Go 코드를 읽을 때는 이렇게 물어보면 좋습니다.

--- a/docs/ko/testing/leaks-and-shutdowns.md
+++ b/docs/ko/testing/leaks-and-shutdowns.md
@@ -60,6 +60,19 @@ goroutine 수를 전역적으로 세기보다:
 
 같은 completion protocol을 더 선호하는 편이 안정적입니다.
 
+## 실패 패턴
+
+이런 테스트는 마음만 편하게 해주고 실제 종료를 증명하지는 못합니다.
+
+```go
+func TestWorkerStops(t *testing.T) {
+	startWorker()
+	time.Sleep(50 * time.Millisecond) // bad: sleep은 shutdown 증거가 아님
+}
+```
+
+잠깐 기다렸더니 조용하다는 사실은 goroutine이 채널, 타이머, lock에 여전히 parked 되어 있지 않다는 뜻이 아닙니다. 종료 테스트에는 explicit completion signal이나 bounded `Shutdown` contract가 필요합니다.
+
 ## 흔한 실수
 
 ### happy path만 테스트하는 것

--- a/docs/ko/testing/race-detector.md
+++ b/docs/ko/testing/race-detector.md
@@ -17,6 +17,19 @@ nontrivial한 동시성 코드라면 가장 먼저 돌려야 하는 도구가 ra
 - channel protocol이 보호해야 할 상태를 바깥에서 따로 읽거나 쓰는 경우,
 - cache update에 lock을 빠뜨린 경우.
 
+## 작은 race 예시
+
+```go
+func TestRacyMap(t *testing.T) {
+    cache := map[string]int{}
+
+    go func() { cache["a"] = 1 }()
+    go func() { _ = cache["a"] }()
+}
+```
+
+이 코드는 casual run에서는 조용히 지나갈 수도 있습니다. `-race`를 돌리면 바로 잡아야 하는 버그라는 점이 드러납니다.
+
 ## 무엇을 보장하지 않나
 
 `-race`가 깨끗하다고 해서 다음이 보장되지는 않습니다.
@@ -46,6 +59,17 @@ go test -race ./...
 - 리팩터링이 ownership contract를 깨뜨렸는가
 
 하지만 이것만으로 validation을 끝내면 안 됩니다.
+
+## 실패 패턴
+
+```go
+func TestSomething(t *testing.T) {
+    go mutateSharedState()
+    time.Sleep(10 * time.Millisecond)
+}
+```
+
+이런 테스트는 한동안은 통과하면서 잘못된 자신감만 줍니다. `-race`로 돌리고, 그다음 timing luck을 실제 synchronization으로 바꿔야 합니다.
 
 ## 공식 자료
 

--- a/docs/ko/testing/synctest.md
+++ b/docs/ko/testing/synctest.md
@@ -93,6 +93,21 @@ func TestContextTimeout(t *testing.T) {
 - trace / profile 분석
 - 외부 시스템과 얽힌 leak test
 
+## 실패 패턴
+
+wall-clock sleep에 기대는 순간 동시성 테스트는 다시 flaky해집니다.
+
+```go
+go func() {
+	time.Sleep(100 * time.Millisecond)
+	done <- struct{}{}
+}()
+
+time.Sleep(10 * time.Millisecond) // bad: 그냥 timing guess
+```
+
+`testing/synctest`는 이런 내부 timer / scheduling 동작을 운에 맡기지 않고 deterministic하게 다루기 위해 존재합니다.
+
 ## 공식 자료
 
 - [Testing Time (Go Blog)](https://go.dev/blog/testing-time)

--- a/docs/ko/testing/tracing-and-profiling.md
+++ b/docs/ko/testing/tracing-and-profiling.md
@@ -31,6 +31,19 @@ description: runtime trace, block profile, mutex profile, scheduler debug output
 
 즉, "runtime이 실제로 뭘 하고 있는가"를 보기에 가장 좋은 출발점입니다.
 
+## 작은 instrumentation 스케치
+
+```go
+ctx, task := trace.NewTask(ctx, "rebuild-cache")
+defer task.End()
+
+trace.WithRegion(ctx, "load-metadata", func() {
+    loadMetadata()
+})
+```
+
+이 정도 annotation만 있어도 여러 goroutine과 단계가 섞인 trace를 읽기가 훨씬 쉬워집니다.
+
 ## block / mutex profile
 
 서비스가 "동시성은 많은데 느리다"면 실제 문제는 다음일 수 있습니다.
@@ -61,6 +74,14 @@ go tool trace trace.out
 ```
 
 그다음 contention 냄새가 나면 block / mutex profile로 넘어가면 됩니다.
+
+## 실패 패턴
+
+```go
+// request latency metric만 보고 있고, trace도 block profile도 없는 상태
+```
+
+이 정도 관측으로는 scheduler state, lock contention, queue delay, GC interaction을 제대로 볼 수 없습니다. runtime 문제는 runtime-facing tool이 필요합니다.
 
 ## 공식 자료
 

--- a/docs/patterns/channel-of-channels.md
+++ b/docs/patterns/channel-of-channels.md
@@ -97,6 +97,18 @@ The request owner creates the reply channel, but the broker usually owns the sen
 
 If there is no concurrency boundary and no broker loop, do not force a channel protocol just because it looks elegant.
 
+## Failure pattern
+
+The broker can wedge if it replies on an unbuffered per-request channel after the caller has already left:
+
+```go
+func respond(req Request, result Result) {
+	req.Reply <- result // bad: caller may have timed out and stopped receiving
+}
+```
+
+In one-shot request/reply flows, a size-1 buffered reply channel or a `select` on caller cancellation usually makes the protocol much safer.
+
 ## Use this pattern when
 
 Use channel-of-channels when you need a brokered request/reply protocol with clear per-call ownership.

--- a/docs/patterns/graceful-shutdown.md
+++ b/docs/patterns/graceful-shutdown.md
@@ -52,6 +52,32 @@ The crucial sequencing is:
 
 That sequencing is safer than "just cancel everything immediately" when your service contract says accepted work should finish.
 
+## Simplified implementation sketch
+
+```go
+func (p *Processor) Shutdown(ctx context.Context) error {
+    p.mu.Lock()
+    p.closed = true
+    close(p.jobs)
+    p.mu.Unlock()
+
+    done := make(chan struct{})
+    go func() {
+        defer close(done)
+        p.wg.Wait()
+    }()
+
+    select {
+    case <-done:
+        return nil
+    case <-ctx.Done():
+        return ctx.Err()
+    }
+}
+```
+
+That small shape captures the whole contract: stop admission, close the queue, wait, enforce a deadline.
+
 ## What the example proves
 
 The tests in `examples/gracefulshutdown/gracefulshutdown_test.go` verify:
@@ -83,6 +109,16 @@ The bug to watch for is "submit sees queue open, shutdown closes it, submit pani
 ### No outer shutdown deadline
 
 A graceful shutdown without a final timeout can become an infinite shutdown.
+
+### Failure pattern: checking closed state without coordinating the send
+
+```go
+if !p.closed {
+    p.jobs <- event // another goroutine may close jobs right here
+}
+```
+
+This is how "works in tests" becomes "send on closed channel" in production.
 
 ## Use this pattern when
 

--- a/docs/patterns/or-done-tee-bridge.md
+++ b/docs/patterns/or-done-tee-bridge.md
@@ -81,6 +81,20 @@ Use them when the *composition problem* is the hard part.
 
 If the real difficulty is ownership or backpressure, these helpers will not save a weak design by themselves.
 
+## Failure pattern
+
+Small forwarding helpers become leak factories when they ignore cancellation:
+
+```go
+func forward(in <-chan Item, out chan<- Item) {
+	for v := range in {
+		out <- v // bad: blocks forever if downstream stops reading
+	}
+}
+```
+
+`or-done` exists precisely because real pipelines do not always drain every stage to completion.
+
 ## Practical takeaway
 
 These are "advanced small patterns." They do not dominate architecture decisions, but they often clean up the hardest edges in channel-heavy code.

--- a/docs/production/open-source-case-studies.md
+++ b/docs/production/open-source-case-studies.md
@@ -113,6 +113,18 @@ Takeaway:
 
 Do not force every production concurrency design into channels if a condition variable plus clear ownership gives a tighter fit.
 
+## Failure pattern
+
+A common misread of production Go code is to copy the goroutines and forget the boundaries around them:
+
+```go
+for _, msg := range batch {
+	go process(msg) // bad: no queue, no limit, no shutdown contract
+}
+```
+
+The systems above work because they add queues, ownership loops, signaling edges, and lifecycle rules around concurrency. Those boundaries matter more than the raw presence of goroutines.
+
 ## How to read these systems well
 
 When you study production Go code, ask:

--- a/docs/testing/leaks-and-shutdowns.md
+++ b/docs/testing/leaks-and-shutdowns.md
@@ -62,6 +62,19 @@ Instead of counting goroutines globally, prefer explicit completion signals:
 
 These are usually more robust than asserting raw goroutine counts.
 
+## Failure pattern
+
+This kind of test is comforting and nearly useless:
+
+```go
+func TestWorkerStops(t *testing.T) {
+	startWorker()
+	time.Sleep(50 * time.Millisecond) // bad: sleep is not evidence of shutdown
+}
+```
+
+A sleeping test can pass while goroutines remain parked on channels, timers, or locks. Good shutdown tests need an explicit completion signal or a bounded `Shutdown` contract they can assert on.
+
 ## Common mistakes
 
 ### Tests that only check the happy path

--- a/docs/testing/race-detector.md
+++ b/docs/testing/race-detector.md
@@ -17,6 +17,19 @@ Typical examples:
 - mutating shared state outside the channel protocol that is supposed to protect it,
 - forgetting to lock around a cache update.
 
+## Tiny race example
+
+```go
+func TestRacyMap(t *testing.T) {
+    cache := map[string]int{}
+
+    go func() { cache["a"] = 1 }()
+    go func() { _ = cache["a"] }()
+}
+```
+
+That code may appear to "work" in a casual run. Under `-race`, it is exactly the kind of bug you want flagged immediately.
+
 ## What it does not prove
 
 A clean `-race` run does **not** prove:
@@ -46,6 +59,17 @@ Use the race detector to answer:
 - did a refactor break a previously safe ownership boundary?
 
 Do **not** use it as your only concurrency validation step.
+
+## Failure pattern
+
+```go
+func TestSomething(t *testing.T) {
+    go mutateSharedState()
+    time.Sleep(10 * time.Millisecond)
+}
+```
+
+Tests like this often pass just long enough to create false confidence. Run them with `-race`, then replace timing luck with real synchronization.
 
 ## Good design patterns under `-race`
 

--- a/docs/testing/synctest.md
+++ b/docs/testing/synctest.md
@@ -87,6 +87,21 @@ It does not replace:
 - trace and profile analysis,
 - leak tests for code that interacts with external systems.
 
+## Failure pattern
+
+Wall-clock sleeps are still the most common reason concurrency tests stay flaky:
+
+```go
+go func() {
+	time.Sleep(100 * time.Millisecond)
+	done <- struct{}{}
+}()
+
+time.Sleep(10 * time.Millisecond) // bad: timing guess
+```
+
+`testing/synctest` exists so internal timers and scheduling behavior can be driven deterministically instead of by luck.
+
 ## Official reading
 
 - [Testing Time (Go Blog)](https://go.dev/blog/testing-time)

--- a/docs/testing/tracing-and-profiling.md
+++ b/docs/testing/tracing-and-profiling.md
@@ -31,6 +31,19 @@ The `runtime/trace` package and `go test -trace=trace.out` let you inspect:
 
 This is the best first tool when the question is "what is the runtime actually doing?"
 
+## Tiny instrumentation sketch
+
+```go
+ctx, task := trace.NewTask(ctx, "rebuild-cache")
+defer task.End()
+
+trace.WithRegion(ctx, "load-metadata", func() {
+    loadMetadata()
+})
+```
+
+That kind of annotation makes traces dramatically easier to read once a workflow spans several goroutines or phases.
+
 ## Block and mutex profiles
 
 If a service feels "concurrent but slow," the real issue may be:
@@ -61,6 +74,14 @@ go tool trace trace.out
 ```
 
 Then escalate to block or mutex profiles when the problem smells like contention.
+
+## Failure pattern
+
+```go
+// Only looking at request latency metrics, no trace, no block profile.
+```
+
+That is not enough once the issue is scheduler state, lock contention, queue delay, or GC interaction. Runtime behavior needs runtime-facing tools.
 
 ## Official reading
 


### PR DESCRIPTION
## Summary
- add concrete `go` snippets to fundamentals, testing, pattern, production, and extras pages that still felt abstract
- add explicit `Failure pattern` walkthroughs across the remaining substantive English and Korean docs
- deepen advanced/testing pages with implementation sketches so only overview/index pages remain snippet-free by design

## Testing
- go test ./...
- npm run docs:build

## Linked Issue
- Closes #13
