### PR TITLE
Docs: add systems-level internals section

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ VitePress will print a local preview URL in the terminal, usually `http://localh
 - Map internals and Swiss Tables
 - Garbage collector and Green Tea GC
 
+## Included internals
+
+- Compiler and toolchain internals: escape analysis, SSA, and Plan 9 assembly
+- Allocator hierarchy and hybrid write barrier
+- Memory layout, padding, and false sharing
+- Generics implementation and interface runtime layout
+- unsafe, cgo, and `runtime.Pinner`
+- Modern performance tuning with PGO, execution tracing, and zero-copy I/O
+- Standard library anatomy for `sync.Pool` and `reflect`
+
 ## Included advanced topics
 
 - Structured concurrency with `errgroup`

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -23,6 +23,19 @@ const enSidebar = [
     ],
   },
   {
+    text: "Internals",
+    items: [
+      { text: "Overview", link: "/internals/" },
+      { text: "Compiler and Toolchain", link: "/internals/compiler-and-toolchain" },
+      { text: "Allocator and Hybrid Write Barrier", link: "/internals/allocator-and-write-barrier" },
+      { text: "Layout, Padding, and False Sharing", link: "/internals/layout-padding-false-sharing" },
+      { text: "Generics and Interfaces", link: "/internals/generics-and-interfaces" },
+      { text: "unsafe, cgo, and Pinner", link: "/internals/unsafe-cgo-pinner" },
+      { text: "Modern Performance Tuning", link: "/internals/modern-performance-tuning" },
+      { text: "Standard Library Anatomy", link: "/internals/stdlib-anatomy" },
+    ],
+  },
+  {
     text: "Patterns",
     items: [
       { text: "Overview", link: "/patterns/" },
@@ -94,6 +107,19 @@ const koSidebar = [
       { text: "Mutex와 런타임 세마포어 내부", link: "/ko/fundamentals/mutex-semaphore-internals" },
       { text: "맵 내부 구조와 Swiss Tables", link: "/ko/fundamentals/map-internals" },
       { text: "가비지 컬렉터와 Green Tea GC", link: "/ko/fundamentals/garbage-collector" },
+    ],
+  },
+  {
+    text: "내부 구조",
+    items: [
+      { text: "개요", link: "/ko/internals/" },
+      { text: "컴파일러와 툴체인", link: "/ko/internals/compiler-and-toolchain" },
+      { text: "할당기와 하이브리드 write barrier", link: "/ko/internals/allocator-and-write-barrier" },
+      { text: "레이아웃, 패딩, false sharing", link: "/ko/internals/layout-padding-false-sharing" },
+      { text: "제네릭과 인터페이스", link: "/ko/internals/generics-and-interfaces" },
+      { text: "unsafe, cgo, 그리고 Pinner", link: "/ko/internals/unsafe-cgo-pinner" },
+      { text: "현대 Go 성능 튜닝", link: "/ko/internals/modern-performance-tuning" },
+      { text: "표준 라이브러리 해부", link: "/ko/internals/stdlib-anatomy" },
     ],
   },
   {
@@ -197,6 +223,7 @@ export default defineConfig({
         nav: [
           { text: "Guide", link: "/guide/getting-started" },
           { text: "Fundamentals", link: "/fundamentals/" },
+          { text: "Internals", link: "/internals/" },
           { text: "Patterns", link: "/patterns/" },
           { text: "Advanced", link: "/advanced/" },
           { text: "Production", link: "/production/" },
@@ -232,6 +259,7 @@ export default defineConfig({
         nav: [
           { text: "가이드", link: "/ko/guide/getting-started" },
           { text: "기초 원리", link: "/ko/fundamentals/" },
+          { text: "내부 구조", link: "/ko/internals/" },
           { text: "패턴", link: "/ko/patterns/" },
           { text: "고급 주제", link: "/ko/advanced/" },
           { text: "프로덕션", link: "/ko/production/" },

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,18 +3,18 @@ layout: home
 
 hero:
   name: Go Concurrency Patterns
-  text: From runtime internals to production-safe patterns
-  tagline: Learn Go concurrency through deep fundamentals, tested examples, decision guides, and bilingual English/Korean docs.
+  text: From compiler internals to production-safe concurrency
+  tagline: Learn Go through deep fundamentals, systems internals, tested examples, decision guides, and bilingual English/Korean docs.
   actions:
     - theme: brand
       text: Start With Fundamentals
       link: /fundamentals/
     - theme: alt
+      text: Open Internals
+      link: /internals/
+    - theme: alt
       text: Browse Patterns
       link: /patterns/
-    - theme: alt
-      text: Production Guide
-      link: /production/
     - theme: alt
       text: Testing Playbook
       link: /testing/
@@ -27,6 +27,8 @@ features:
     details: "The site now has section overviews, reading tracks, and pattern selection guides instead of throwing readers into dense pages."
   - title: Runtime-first depth
     details: "The fundamentals section explains the scheduler, memory model, channel internals, and mutex/runtime semaphore behavior."
+  - title: Systems-level internals
+    details: "The site now covers escape analysis, SSA, allocator internals, generics, interface layout, unsafe, cgo, PGO, and sync.Pool internals."
   - title: Practical examples
     details: "Examples use realistic backend domains such as shipping, fraud analysis, inventory coordination, and cache-miss suppression."
   - title: Tested behavior
@@ -57,27 +59,32 @@ features:
     <p><a href="/fundamentals/">Open fundamentals</a></p>
   </div>
   <div class="path-card">
-    <h3>2. Practical Patterns</h3>
+    <h3>2. Internals</h3>
+    <p>Study escape analysis, SSA, allocator design, generics, interfaces, unsafe boundaries, and modern performance tooling.</p>
+    <p><a href="/internals/">Open internals</a></p>
+  </div>
+  <div class="path-card">
+    <h3>3. Practical Patterns</h3>
     <p>Move into worker pools, pipelines, fan-out/fan-in, and context cancellation when you are mapping code to real workloads.</p>
     <p><a href="/patterns/">Browse patterns</a></p>
   </div>
   <div class="path-card">
-    <h3>3. Advanced Topics</h3>
+    <h3>4. Advanced Topics</h3>
     <p>Study resource budgeting, structured lifetimes, duplicate suppression, ownership models, and overload behavior.</p>
     <p><a href="/advanced/">Go deeper</a></p>
   </div>
   <div class="path-card">
-    <h3>4. Testing</h3>
+    <h3>5. Testing</h3>
     <p>Learn how to prove cancellation, shutdown, race safety, and timeout behavior instead of relying on lucky sleeps.</p>
     <p><a href="/testing/">Open testing</a></p>
   </div>
   <div class="path-card">
-    <h3>5. Production</h3>
+    <h3>6. Production</h3>
     <p>Study queue budgets, overload policy, goroutine ownership, and open-source concurrency designs from real Go systems.</p>
     <p><a href="/production/">Open production</a></p>
   </div>
   <div class="path-card">
-    <h3>6. Extras</h3>
+    <h3>7. Extras</h3>
     <p>Compare Go's CSP-flavored model with Rust Tokio so your mental model holds across ecosystems.</p>
     <p><a href="/extras/">Open extras</a></p>
   </div>
@@ -88,6 +95,8 @@ features:
 | If you need to understand... | Start with |
 | --- | --- |
 | Why goroutines are cheap and how the scheduler actually runs them | [Go Runtime and Scheduler](/fundamentals/go-runtime-scheduler) |
+| Why a local value still ends up on the heap | [Compiler and Toolchain](/internals/compiler-and-toolchain) |
+| Why one allocation pattern hurts GC more than another | [Allocator and Hybrid Write Barrier](/internals/allocator-and-write-barrier) |
 | Why channels synchronize memory visibility | [Channels, Select, and the Memory Model](/fundamentals/channels-memory-model) |
 | How to cap parallelism across many independent tasks | [Worker Pool](/patterns/worker-pool) |
 | How to structure one request with several sibling tasks | [Structured Concurrency](/advanced/structured-concurrency) |
@@ -110,7 +119,7 @@ features:
   </div>
   <div class="signal">
     <strong>Not surface-level theory</strong>
-    <span>The fundamentals section goes down to runtime source concepts such as `hchan`, `sudog`, run queues, and starvation mode.</span>
+    <span>The site now goes from runtime source concepts such as `hchan`, `sudog`, run queues, and starvation mode down to compiler SSA, allocator tiers, and interface metadata.</span>
   </div>
 </div>
 
@@ -119,7 +128,8 @@ features:
 1. Read [Getting Started](/guide/getting-started) to understand the repo layout and validation commands.
 2. Read [How to Read the Examples](/guide/how-to-read) to set the review lens.
 3. Work through [Fundamentals Overview](/fundamentals/) before jumping into implementation patterns.
-4. Pick the practical pattern that matches your workload in [Patterns Overview](/patterns/).
-5. Read [Testing Overview](/testing/) before treating any concurrent component as production-ready.
-6. Read [Production Overview](/production/) for operating rules and open-source case studies.
-7. Finish with [Advanced Overview](/advanced/) and [Extras Overview](/extras/) for deeper design and ecosystem comparison.
+4. Read [Internals Overview](/internals/) when you want compiler, allocator, and type-system cost models rather than only runtime APIs.
+5. Pick the practical pattern that matches your workload in [Patterns Overview](/patterns/).
+6. Read [Testing Overview](/testing/) before treating any concurrent component as production-ready.
+7. Read [Production Overview](/production/) for operating rules and open-source case studies.
+8. Finish with [Advanced Overview](/advanced/) and [Extras Overview](/extras/) for deeper design and ecosystem comparison.

--- a/docs/internals/allocator-and-write-barrier.md
+++ b/docs/internals/allocator-and-write-barrier.md
@@ -1,0 +1,150 @@
+---
+title: Allocator and Hybrid Write Barrier
+description: Follow Go's allocator hierarchy and the hybrid write barrier that keeps concurrent GC correct.
+---
+
+# Allocator and Hybrid Write Barrier
+
+You cannot reason well about production Go performance if "allocation" is still a single mental bucket.
+
+Small-object allocation, span reuse, sweeping, large-object paths, and write barriers all interact with concurrency and GC latency.
+
+:::tip Quick takeaway
+Go's allocator is still inspired by TCMalloc, but the important production model is simpler: `mcache` is the fast per-P path, `mcentral` amortizes sharing by size class, `mheap` manages pages, and the hybrid write barrier keeps concurrent marking correct.
+:::
+
+## The allocator hierarchy
+
+The runtime comment in `malloc.go` gives the most useful summary:
+
+- `mcache`: per-P cache of spans with free slots,
+- `mcentral`: shared spans for one size class,
+- `mheap`: page-level heap manager,
+- `mspan`: a run of pages serving objects of one class.
+
+```mermaid
+flowchart LR
+    A["goroutine allocates"] --> B["P-local mcache"]
+    B --> C["size-class mspan"]
+    C --> D["shared mcentral"]
+    D --> E["global mheap"]
+    E --> F["OS pages"]
+```
+
+The design goal is obvious: keep the common path lock-free or close to it, and pay shared coordination only when local caches run dry.
+
+## Small allocations and size classes
+
+For small objects, the allocator rounds the request to a size class and tries to serve it from the current P's cache.
+
+That makes tiny short-lived allocations surprisingly cheap in isolation.
+
+It does **not** make a high-allocation-rate workload free once GC, pointer scanning, and cross-goroutine fan-out are involved.
+
+## Simplified allocation sketch
+
+```go
+func alloc(size uintptr) unsafe.Pointer {
+	if span := mcache.lookup(sizeClass(size)); span.hasFree() {
+		return span.alloc()
+	}
+	if span := mcentral.refill(sizeClass(size)); span != nil {
+		mcache.install(span)
+		return span.alloc()
+	}
+	span := mheap.allocPages(...)
+	mcentral.install(span)
+	mcache.install(span)
+	return span.alloc()
+}
+```
+
+This is not runtime code, but it is the right mental model.
+
+## Large objects are a different path
+
+Large allocations bypass much of the small-object machinery and hit the page allocator more directly.
+
+That means patterns like "each request allocates a fresh 64 KiB buffer in ten goroutines" are qualitatively different from churning many tiny structs.
+
+## Why the write barrier belongs here
+
+The allocator story and GC story are tied together.
+
+During concurrent marking, the runtime must prevent mutators from hiding reachable objects from the collector while pointers are being updated.
+
+That is what the write barrier is for.
+
+## The hybrid write barrier
+
+The runtime comment in `mbarrier.go` describes it directly:
+
+```go
+// conceptual, not the actual runtime function
+func writePointer(slot *unsafe.Pointer, ptr unsafe.Pointer) {
+	shade(*slot)
+	if currentStackIsGrey() {
+		shade(ptr)
+	}
+	*slot = ptr
+}
+```
+
+The combination matters:
+
+- the deletion side protects the old referent,
+- the insertion side protects the new referent while a stack is still grey,
+- once the stack is black, the insertion side is no longer needed for that stack.
+
+## Why memory ordering matters
+
+Go does not try to make the barrier conditional on the destination object's color in the fast path, because the memory-ordering cost would be too high.
+
+This is one of those runtime choices that looks slightly wasteful in a tiny benchmark and obviously correct in a real concurrent collector.
+
+## Practical consequence for application code
+
+You do not write barriers manually in ordinary Go.
+
+But you absolutely feel their consequences when you:
+
+- copy pointer-rich values at high rates,
+- mutate large shared heaps of graph-shaped data,
+- use reflection or `unsafe` helpers that ultimately funnel through typed memory moves,
+- create workloads where GC assist shows up in request latency.
+
+## Failure pattern
+
+This is the kind of code that looks merely "allocation heavy" and becomes a GC and allocator problem under load:
+
+```go
+for _, req := range batch {
+	go func(req Request) {
+		buf := make([]byte, 64<<10) // large allocation path
+		_ = handle(req, buf)
+	}(req)
+}
+```
+
+The problem is not just bytes allocated. The problem is:
+
+- large objects skip the cheapest path,
+- fan-out multiplies the pressure,
+- the collector and allocator become part of tail latency.
+
+## Source walk
+
+Start here:
+
+- [runtime/malloc.go](https://github.com/golang/go/blob/go1.26.0/src/runtime/malloc.go)
+- [runtime/mcache.go](https://github.com/golang/go/blob/go1.26.0/src/runtime/mcache.go)
+- [runtime/mcentral.go](https://github.com/golang/go/blob/go1.26.0/src/runtime/mcentral.go)
+- [runtime/mheap.go](https://github.com/golang/go/blob/go1.26.0/src/runtime/mheap.go)
+- [runtime/mbarrier.go](https://github.com/golang/go/blob/go1.26.0/src/runtime/mbarrier.go)
+- [Proposal: eliminate rescan with a hybrid write barrier](https://github.com/golang/proposal/blob/master/design/17503-eliminate-rescan.md)
+
+## Practical takeaway
+
+The cheapest Go allocation is not "free." It is "carefully engineered."
+
+Once you understand the allocator hierarchy and the hybrid barrier, you stop treating heap churn as a vague smell and start treating it as a concrete runtime budget.

--- a/docs/internals/compiler-and-toolchain.md
+++ b/docs/internals/compiler-and-toolchain.md
@@ -1,0 +1,165 @@
+---
+title: Compiler and Toolchain Internals
+description: Escape analysis, SSA, and Plan 9 assembly for engineers who want to see how Go source becomes machine code.
+---
+
+# Compiler and Toolchain Internals
+
+If runtime internals explain why goroutines and channels work, compiler internals explain why a seemingly harmless source change can add heap churn, block inlining, or change dispatch behavior.
+
+:::tip Quick takeaway
+The compiler is not just a code printer. It decides stack vs heap placement, simplifies high-level constructs, lowers them into SSA, and hands a semi-abstract instruction stream to the assembler.
+:::
+
+## The shortest mental model
+
+The modern Go compiler roughly moves through these phases:
+
+1. parsing,
+2. type checking,
+3. compiler IR construction,
+4. inlining, devirtualization, and escape analysis,
+5. walk/lowering of higher-level constructs,
+6. SSA construction and optimization,
+7. machine-specific lowering and final object code emission.
+
+That ordering matters. For example, escape analysis runs before SSA code generation, so by the time you look at assembly, many stack-vs-heap decisions are already made.
+
+## Escape analysis is about lifetime and reachability
+
+The most important misconception is that "local variable" means "stack variable."
+
+Not true.
+
+What matters is whether the value can outlive the current frame or whether the compiler cannot prove that it does not.
+
+```go
+type User struct {
+	ID   int
+	Name string
+}
+
+func NewUser() *User {
+	u := User{ID: 7, Name: "ops"}
+	return &u // escapes: returned beyond the frame
+}
+```
+
+The variable is syntactically local. The pointee is not frame-local from the compiler's point of view, so it must move to the heap.
+
+## A practical command loop
+
+The fastest way to build intuition is to inspect the compiler directly:
+
+```bash
+go build -gcflags='-m=2' ./...
+GOSSAFUNC=HandleBatch go build ./...
+go build -gcflags='-S' ./...
+```
+
+- `-m=2` shows escape and inlining decisions.
+- `GOSSAFUNC` writes `ssa.html` for one function.
+- `-S` shows assembly-like output after lowering.
+
+Treat these as one workflow, not three unrelated tricks.
+
+## Simplified escape sketch
+
+This pattern forces the backing array to survive beyond the frame:
+
+```go
+func HeaderBytes() []byte {
+	buf := [64]byte{}
+	return buf[:] // the returned slice needs storage that outlives the frame
+}
+```
+
+The compiler may keep the slice header on the stack, but the array storage must be reachable after return, so the data moves to the heap.
+
+## SSA is where optimizations become visible
+
+SSA, or Static Single Assignment form, gives the compiler a representation where each logical value is assigned once and transformed through explicit dataflow.
+
+That makes many optimizations easier:
+
+- dead code elimination,
+- bounds check elimination,
+- nil check elimination,
+- constant propagation,
+- devirtualization,
+- machine-specific rewrites.
+
+## Simplified SSA-oriented sketch
+
+```go
+func Sum(xs []int) int {
+	total := 0
+	for _, x := range xs {
+		total += x
+	}
+	return total
+}
+```
+
+At the source level this is tiny. In SSA it becomes explicit blocks, phi values for loop-carried state, bounds reasoning, and eventually architecture-specific operations. That is why `GOSSAFUNC=Sum` is so useful: it lets you see the control-flow graph the optimizer actually reasons about.
+
+## Plan 9 assembly is a toolchain interface, not a raw ISA dump
+
+Go's assembly syntax is based on the Plan 9 family, but the crucial point is deeper than syntax.
+
+The assembler works on a semi-abstract instruction set that fits the Go toolchain. It is not a 1:1 mirror of whatever `objdump` prints after linking.
+
+```asm
+TEXT ·add64(SB), NOSPLIT, $0-24
+	MOVQ a+0(FP), AX
+	ADDQ b+8(FP), AX
+	MOVQ AX, ret+16(FP)
+	RET
+```
+
+What matters here:
+
+- `SB` names package-level symbols,
+- `FP` addresses arguments/results in the virtual frame,
+- `NOSPLIT` changes stack-growth behavior and must be used with real care,
+- the toolchain may still rewrite or annotate surrounding instructions.
+
+## Why this matters for runtime-heavy code
+
+Compiler behavior leaks upward into performance work:
+
+- more escaping means more heap traffic,
+- less inlining can mean more interface or closure overhead,
+- missed devirtualization keeps indirect calls in hot loops,
+- assembly boundaries can block some optimizations entirely.
+
+That is why a production Go engineer should care about compiler output even if they never write assembly by hand.
+
+## Failure pattern
+
+A common mistake is assuming the source shape alone determines stack allocation:
+
+```go
+func ParseHeader() []byte {
+	header := [32]byte{}
+	return header[:]
+}
+```
+
+This "looks stacky" but is not. The returned slice forces the backing storage to outlive the frame. If you treat escape reports as compiler noise, you will miss heap pressure that shows up later as GC cost.
+
+## Source walk
+
+Start here:
+
+- [cmd/compile/README.md](https://github.com/golang/go/blob/go1.26.0/src/cmd/compile/README.md)
+- [cmd/compile/internal/escape](https://github.com/golang/go/tree/go1.26.0/src/cmd/compile/internal/escape)
+- [cmd/compile/internal/ssa](https://github.com/golang/go/tree/go1.26.0/src/cmd/compile/internal/ssa)
+- [cmd/compile/internal/ssagen](https://github.com/golang/go/tree/go1.26.0/src/cmd/compile/internal/ssagen)
+- [A Quick Guide to Go's Assembler](https://go.dev/doc/asm)
+
+## Practical takeaway
+
+If you want to understand why Go code allocates, inlines, or dispatches the way it does, compiler internals are not optional trivia.
+
+They are the layer that turns source-level intent into runtime-level cost.

--- a/docs/internals/generics-and-interfaces.md
+++ b/docs/internals/generics-and-interfaces.md
@@ -1,0 +1,146 @@
+---
+title: Generics and Interface Internals
+description: How Go implements generics and interface values, and why that matters for dispatch and performance.
+---
+
+# Generics and Interface Internals
+
+Go's type system now does much more than the pre-generics language did, but the runtime model is still intentionally pragmatic.
+
+The key is to understand what Go did **not** choose:
+
+- not pure C++-style full monomorphization for everything,
+- not Java-style type erasure,
+- not a magical "all interface calls are optimized away" model.
+
+:::tip Quick takeaway
+For generics, Go uses GC-shape-based code sharing plus dictionaries where type-specific operations are needed. For interfaces, the mental model is still two words: type metadata plus data, with an `itab` in the non-empty-interface case.
+:::
+
+## Generics: GC shape plus dictionaries
+
+The most useful expert-level summary is:
+
+- code may be shared across instantiations with the same relevant memory layout,
+- dictionaries carry type-specific operations and metadata where needed,
+- the result is a middle ground between code-size explosion and pure erasure.
+
+This is why generic code can sometimes behave "more shared" than C++ templates and still preserve the operations Go needs at runtime.
+
+## Simplified generic sketch
+
+```go
+func Clone[T any](in []T) []T {
+	out := make([]T, len(in))
+	copy(out, in)
+	return out
+}
+```
+
+Conceptually, the compiler may generate code around a GC shape for `T` and pass enough dictionary information to handle type-specific needs. The exact emitted form is compiler territory, but the right mental model is "shared where possible, specialized where necessary."
+
+## Interfaces are still metadata plus data
+
+The exact internal type names move between packages, but this conceptual model remains useful:
+
+```go
+type eface struct {
+	typ  *abi.Type
+	data unsafe.Pointer
+}
+
+type iface struct {
+	tab  *itab
+	data unsafe.Pointer
+}
+```
+
+- empty interfaces carry direct type metadata,
+- non-empty interfaces use an `itab` that connects a concrete type to an interface's method set,
+- data may be stored directly or indirectly depending on the type.
+
+That last point matters for copies, boxing cost, and escape behavior.
+
+## Why dynamic dispatch sometimes stays expensive
+
+Interface calls are indirect calls unless the compiler can prove more.
+
+That proof may come from:
+
+- static knowledge,
+- devirtualization,
+- inlining opportunities,
+- sometimes profile-guided information in modern toolchains.
+
+But if you write a tiny hot loop over a broad interface and expect it to optimize like a monomorphic concrete call, you are asking the compiler for evidence it may not have.
+
+## Simplified hot-path sketch
+
+```go
+type Hasher interface {
+	Hash([]byte) uint64
+}
+
+func SumHashes(h Hasher, xs [][]byte) uint64 {
+	var total uint64
+	for _, x := range xs {
+		total += h.Hash(x)
+	}
+	return total
+}
+```
+
+This is an elegant API shape. It is not automatically the cheapest possible dispatch shape.
+
+## Why generics and interfaces are related but not the same
+
+Generics let you keep type information available at compile time for each instantiation site.
+
+Interfaces let you abstract over behavior at runtime.
+
+In practice:
+
+- generics often help when the algorithm is shape-stable but the concrete type varies,
+- interfaces help when the implementation choice is a runtime policy decision,
+- mixing them is powerful, but it does not remove the cost model of either.
+
+## Failure pattern
+
+This kind of code is often written as if interface dispatch were free:
+
+```go
+type Matcher interface {
+	Match([]byte) bool
+}
+
+func Count(ms []Matcher, payload []byte) int {
+	n := 0
+	for _, m := range ms {
+		if m.Match(payload) {
+			n++
+		}
+	}
+	return n
+}
+```
+
+Sometimes that API is exactly right.
+
+Sometimes it becomes the hottest indirect-call site in the process. The mistake is not using interfaces. The mistake is assuming abstraction level and dispatch cost are unrelated.
+
+## Source walk
+
+Start here:
+
+- [Proposal: dictionaries for Go 1.18 generics](https://go.googlesource.com/proposal/+/master/design/generics-implementation-dictionaries-go1.18.md)
+- [Proposal: stenciling for Go 1.18 generics](https://go.googlesource.com/proposal/+/master/design/generics-implementation-stenciling.md)
+- [runtime/iface.go](https://github.com/golang/go/blob/go1.26.0/src/runtime/iface.go)
+- [internal/abi/type.go](https://github.com/golang/go/blob/go1.26.0/src/internal/abi/type.go)
+- [reflect/value.go](https://github.com/golang/go/blob/go1.26.0/src/reflect/value.go)
+- [cmd/compile/internal/devirtualize](https://github.com/golang/go/tree/go1.26.0/src/cmd/compile/internal/devirtualize)
+
+## Practical takeaway
+
+Go's type machinery is intentionally not ideological.
+
+It trades code size, runtime metadata, and optimizer opportunity against each other. If you understand that trade, you choose between generics, interfaces, and concrete code much more deliberately.

--- a/docs/internals/index.md
+++ b/docs/internals/index.md
@@ -1,0 +1,68 @@
+---
+title: Internals Overview
+description: Systems-level Go internals for compiler behavior, allocator design, type metadata, unsafe boundaries, and performance tooling.
+---
+
+# Internals Overview
+
+<div class="lead-panel">
+  <p>
+    Internals is where the site stops asking only "how do I use concurrency?" and starts asking
+    <strong>why the toolchain, runtime, allocator, and type system make certain designs fast, safe, or dangerous</strong>.
+  </p>
+</div>
+
+## What this section covers
+
+<div class="path-grid">
+  <div class="path-card">
+    <h3><a href="/internals/compiler-and-toolchain">Compiler and Toolchain</a></h3>
+    <p>Escape analysis, SSA, and Plan 9 assembly so you can connect source code to what the compiler actually emits.</p>
+  </div>
+  <div class="path-card">
+    <h3><a href="/internals/allocator-and-write-barrier">Allocator and Write Barrier</a></h3>
+    <p>Follow `mcache`, `mcentral`, `mheap`, `mspan`, and the hybrid write barrier behind concurrent GC correctness.</p>
+  </div>
+  <div class="path-card">
+    <h3><a href="/internals/layout-padding-false-sharing">Layout, Padding, and False Sharing</a></h3>
+    <p>See how alignment rules, struct layout, and cache lines affect contention even when your algorithm looks correct.</p>
+  </div>
+  <div class="path-card">
+    <h3><a href="/internals/generics-and-interfaces">Generics and Interfaces</a></h3>
+    <p>Understand GC shape stenciling, dictionaries, `eface`/`iface`-style layouts, and dynamic dispatch tradeoffs.</p>
+  </div>
+  <div class="path-card">
+    <h3><a href="/internals/unsafe-cgo-pinner">unsafe, cgo, and Pinner</a></h3>
+    <p>Learn the real boundary rules around raw pointers, scheduler handoff, pointer pinning, and zero-copy tricks.</p>
+  </div>
+  <div class="path-card">
+    <h3><a href="/internals/modern-performance-tuning">Modern Performance Tuning</a></h3>
+    <p>Profile-guided optimization, execution tracing, flight recording, and zero-copy I/O in modern Go releases.</p>
+  </div>
+  <div class="path-card">
+    <h3><a href="/internals/stdlib-anatomy">Standard Library Anatomy</a></h3>
+    <p>Study why `sync.Pool` scales, why `reflect` costs what it costs, and when code generation is the better trade.</p>
+  </div>
+</div>
+
+## Suggested reading order
+
+1. Read [Compiler and Toolchain](/internals/compiler-and-toolchain) first.
+2. Continue with [Allocator and Write Barrier](/internals/allocator-and-write-barrier).
+3. Read [Layout, Padding, and False Sharing](/internals/layout-padding-false-sharing).
+4. Move to [Generics and Interfaces](/internals/generics-and-interfaces).
+5. Then read [unsafe, cgo, and Pinner](/internals/unsafe-cgo-pinner).
+6. Finish with [Modern Performance Tuning](/internals/modern-performance-tuning) and [Standard Library Anatomy](/internals/stdlib-anatomy).
+
+## What you should be able to answer afterward
+
+- Why does a local variable sometimes still move to the heap?
+- What does `GOSSAFUNC` show that `go test -bench` cannot?
+- Why is the allocator hierarchy `mcache -> mcentral -> mheap` instead of one global lock?
+- Why does the GC need a hybrid write barrier in a concurrent collector?
+- Why can two correct atomic counters still fight each other on one cache line?
+- Why are Go generics neither pure C++-style monomorphization nor Java-style erasure?
+- Why is `uintptr` not a GC root?
+- When does `io.Copy` reach a zero-copy fast path, and when does it silently fall back?
+- Why does `sync.Pool` pad its per-P shards?
+- When is reflection flexible enough, and when is it simply the wrong cost model?

--- a/docs/internals/layout-padding-false-sharing.md
+++ b/docs/internals/layout-padding-false-sharing.md
@@ -1,0 +1,149 @@
+---
+title: Layout, Padding, and False Sharing
+description: Struct layout, alignment, and cache-line behavior for engineers who want to eliminate hidden contention.
+---
+
+# Layout, Padding, and False Sharing
+
+Correct concurrent code can still perform badly because of memory layout.
+
+Alignment rules, padding, and cache-line sharing can turn "independent" counters or shards into a coherence fight.
+
+:::tip Quick takeaway
+Go's alignment rules are simple enough to inspect with `unsafe`, but CPU cache behavior is where the real surprises live. A correct atomic update can still be slow if two hot fields bounce the same line between cores.
+:::
+
+## Start with what the compiler guarantees
+
+Go lays out struct fields in declaration order, adding padding so each field satisfies its alignment.
+
+You can inspect the result directly:
+
+```go
+type Bad struct {
+	Flag  byte
+	Count uint64
+	Tag   byte
+}
+
+fmt.Println(unsafe.Sizeof(Bad{}))
+fmt.Println(unsafe.Offsetof(Bad{}.Count))
+fmt.Println(unsafe.Alignof(Bad{}.Count))
+```
+
+This is the first layer. It explains wasted bytes.
+
+The second layer is cache lines, and that explains wasted throughput.
+
+## Reordering fields can shrink objects
+
+```go
+type Better struct {
+	Count uint64
+	Flag  byte
+	Tag   byte
+}
+```
+
+Field order changes:
+
+- total size,
+- offsets,
+- how many objects fit in cache,
+- sometimes whether a hot field shares a line with another hot field.
+
+Do not treat field order as cosmetic in performance-sensitive code.
+
+## False sharing is a coherence problem
+
+False sharing happens when two goroutines update different data that lives on the same cache line.
+
+No race is required.
+
+No lock bug is required.
+
+The program can be perfectly correct and still stall on cache invalidation traffic.
+
+## Simplified counter sketch
+
+```go
+type Counters struct {
+	OK  atomic.Int64
+	Err atomic.Int64
+}
+```
+
+If two cores hammer those fields independently and they land on the same line, every write can force line ownership traffic even though the counters are logically unrelated.
+
+## Padding is sometimes the right tool
+
+```go
+type PaddedCounter struct {
+	Value atomic.Int64
+	_     [56]byte // example padding for a 64-byte line minus the counter
+}
+```
+
+This is intentionally blunt. You do it only when:
+
+- the field is genuinely hot,
+- the contention is real,
+- profiling or benchmarking says the padding wins.
+
+## A real standard-library clue: `sync.Pool`
+
+`sync.Pool` uses padding in `poolLocal` precisely to avoid widespread false sharing across P-local shards.
+
+That is a strong signal from the standard library: layout is not an academic detail.
+
+## Failure pattern
+
+This looks harmless and can still waste CPU:
+
+```go
+type Shard struct {
+	Hits atomic.Int64
+}
+
+var shards [2]Shard
+
+go func() {
+	for {
+		shards[0].Hits.Add(1)
+	}
+}()
+
+go func() {
+	for {
+		shards[1].Hits.Add(1)
+	}
+}()
+```
+
+The fields are independent. The cache line may not be. If these land next to each other, throughput can collapse for reasons that do not show up in race detection.
+
+## How to study layout without guessing
+
+Use a combination of:
+
+- `unsafe.Sizeof`,
+- `unsafe.Alignof`,
+- `unsafe.Offsetof`,
+- focused benchmarks,
+- CPU profiles or hardware-counter tooling when available.
+
+For Go-only investigation, start with size/offset inspection and benchmark deltas before reaching for heroic low-level tools.
+
+## Source walk
+
+Start here:
+
+- [unsafe package docs](https://pkg.go.dev/unsafe)
+- [internal/abi/type.go](https://github.com/golang/go/blob/go1.26.0/src/internal/abi/type.go)
+- [sync/pool.go](https://github.com/golang/go/blob/go1.26.0/src/sync/pool.go)
+
+## Practical takeaway
+
+When a concurrent design is logically clean but still burns CPU, do not stop at mutexes and goroutines.
+
+Inspect the bytes.

--- a/docs/internals/modern-performance-tuning.md
+++ b/docs/internals/modern-performance-tuning.md
@@ -1,0 +1,126 @@
+---
+title: Modern Performance Tuning
+description: PGO, execution tracing, flight recording, and zero-copy paths in modern Go releases.
+---
+
+# Modern Performance Tuning
+
+Modern Go performance work is less about folklore and more about using the toolchain the way it was built to be used.
+
+That means profiles feeding the compiler, traces feeding runtime diagnosis, and understanding when the standard library can already reach kernel fast paths without bespoke code.
+
+:::tip Quick takeaway
+If you are still tuning hot paths with only microbenchmarks and intuition, you are under-using the modern Go toolchain. PGO, execution tracing, and zero-copy-aware standard-library paths are now first-class tools.
+:::
+
+## Profile-guided optimization
+
+PGO lets the compiler use real profile data when making some optimization decisions.
+
+The important outcome is not magic. It is better evidence for:
+
+- inlining budgets,
+- devirtualization opportunities,
+- hot-path layout decisions.
+
+## Practical PGO loop
+
+```bash
+go test -cpuprofile=cpu.pprof ./...
+go build -pgo=cpu.pprof ./cmd/service
+```
+
+For main packages, modern `go build` also supports `-pgo=auto`, which looks for `default.pgo` in the main package directory.
+
+## Execution tracing is for runtime truth, not just latency charts
+
+`runtime/trace` captures:
+
+- goroutine creation and blocking,
+- scheduler transitions,
+- syscall and netpoll activity,
+- GC events,
+- heap-goal changes,
+- user tasks, regions, and logs.
+
+That makes it the best tool when you need to answer "what was the runtime actually doing?"
+
+## Tiny instrumentation sketch
+
+```go
+ctx, task := trace.NewTask(ctx, "replicate-batch")
+defer task.End()
+
+trace.WithRegion(ctx, "fetch-primary", func() {
+	_ = fetchPrimary(ctx)
+})
+
+trace.Log(ctx, "tenant", tenantID)
+```
+
+Use user tasks and regions to put your application story on top of the runtime story.
+
+## Trace v2 and flight recording
+
+Recent Go releases use a v2 execution-trace wire format internally, and newer releases also added `trace.FlightRecorder` for a rolling in-memory window of recent runtime events.
+
+That matters operationally:
+
+- traces are more viable as ongoing diagnostics,
+- you can snapshot recent runtime behavior after a spike instead of reproducing everything under a one-shot trace,
+- you can connect runtime state to incidents with lower friction.
+
+## Zero-copy I/O is sometimes already in the standard library
+
+For the right file/socket combinations on supported platforms, standard-library paths can reach:
+
+- `sendfile`,
+- `copy_file_range`,
+- `splice`.
+
+In other words, sometimes `io.Copy` is already smarter than the hand-optimized code you were about to write.
+
+## Simplified I/O sketch
+
+```go
+f, _ := os.Open("payload.bin")
+defer f.Close()
+
+_, _ = io.Copy(conn, f)
+```
+
+Whether this hits a zero-copy path depends on the concrete descriptors and platform support. The important part is that the fast path is library- and kernel-driven, not source-code-shaped by wishful thinking.
+
+## Failure pattern
+
+This is not a performance strategy:
+
+```go
+func build() {
+	_ = exec.Command("go", "build").Run() // bad: no representative profile, no evidence
+}
+```
+
+Likewise, assuming every `io.Copy` is zero-copy is just as wrong as assuming none of them are. Performance tuning without checking the actual path is cargo culting in both directions.
+
+## Source walk
+
+Start here:
+
+- [Profile-guided optimization](https://go.dev/doc/pgo)
+- [cmd/internal/pgo](https://github.com/golang/go/tree/go1.26.0/src/cmd/internal/pgo)
+- [runtime/trace package docs](https://pkg.go.dev/runtime/trace)
+- [internal/trace/tracev2/doc.go](https://github.com/golang/go/blob/go1.26.0/src/internal/trace/tracev2/doc.go)
+- [Flight Recorder in Go 1.25](https://go.dev/blog/flight-recorder)
+- [os/zero_copy_linux.go](https://github.com/golang/go/blob/go1.26.0/src/os/zero_copy_linux.go)
+- [internal/poll/sendfile_unix.go](https://github.com/golang/go/blob/go1.26.0/src/internal/poll/sendfile_unix.go)
+- [internal/poll/splice_linux.go](https://github.com/golang/go/blob/go1.26.0/src/internal/poll/splice_linux.go)
+
+## Practical takeaway
+
+The modern Go stack wants you to close the loop:
+
+- collect real profiles,
+- feed the compiler,
+- capture traces around incidents,
+- verify fast paths instead of assuming them.

--- a/docs/internals/stdlib-anatomy.md
+++ b/docs/internals/stdlib-anatomy.md
@@ -1,0 +1,147 @@
+---
+title: Standard Library Anatomy
+description: sync.Pool internals, reflection cost, and the runtime tradeoffs hiding inside familiar packages.
+---
+
+# Standard Library Anatomy
+
+The standard library is one of the best places to study how the Go team itself balances abstraction, cache locality, GC pressure, and concurrency safety.
+
+Two especially useful case studies are `sync.Pool` and `reflect`.
+
+:::tip Quick takeaway
+`sync.Pool` is not a global bag with a lock. It is a per-P design with stealing and victim caches. `reflect` is not "slow because magic." It is slower because it carries runtime type metadata, indirection, checks, and often extra copying.
+:::
+
+## `sync.Pool`: per-P first, shared second
+
+`sync.Pool` is designed to reduce allocation pressure for temporary objects shared across many concurrent callers.
+
+Its critical design choices are:
+
+- one local shard per P,
+- a `private` slot for the fastest reuse,
+- a `shared` chain for additional values,
+- cross-P stealing,
+- a victim cache that lets values survive one GC cycle before aging out.
+
+## Simplified pool sketch
+
+```go
+var bufPool = sync.Pool{
+	New: func() any {
+		return new(bytes.Buffer)
+	},
+}
+
+func encode(v any) []byte {
+	buf := bufPool.Get().(*bytes.Buffer)
+	buf.Reset()
+	defer bufPool.Put(buf)
+
+	_ = json.NewEncoder(buf).Encode(v)
+	return append([]byte(nil), buf.Bytes()...)
+}
+```
+
+The important nuance is that pooled objects are temporary scratch, not durable ownership.
+
+## Why the pool is padded
+
+`sync.Pool`'s `poolLocal` includes explicit padding to avoid false sharing between P-local shards.
+
+That is a concrete example of the standard library optimizing for multicore cache behavior, not just algorithmic big-O.
+
+## Reflection cost is mostly explicit runtime work
+
+`reflect.Value` carries:
+
+- type metadata,
+- pointer/data representation,
+- flag bits describing addressability, indirection, method values, and read-only state.
+
+Every reflective operation may involve:
+
+- kind checks,
+- metadata traversal,
+- interface packing/unpacking,
+- indirect loads,
+- extra copying when values must be materialized safely.
+
+None of that is mysterious. It is simply not free.
+
+## Simplified reflection sketch
+
+```go
+func nonZeroFields(v any) []string {
+	rv := reflect.ValueOf(v)
+	rt := rv.Type()
+	out := make([]string, 0, rv.NumField())
+
+	for i := 0; i < rv.NumField(); i++ {
+		if !rv.Field(i).IsZero() {
+			out = append(out, rt.Field(i).Name)
+		}
+	}
+	return out
+}
+```
+
+This is fine for control planes, admin tools, configuration, or low-rate paths.
+
+It is a very different proposition in a tight per-record hot loop.
+
+## A practical alternative: typed code or generation
+
+Often the fastest replacement for reflection is not clever unsafe code.
+
+It is one of:
+
+- concrete hand-written typed code,
+- generic code where compile-time shape is enough,
+- generated code for serializers, validators, or mappers.
+
+The point is to shift work from runtime inspection to compile-time structure.
+
+## Failure pattern
+
+These are both common mistakes:
+
+```go
+var pool sync.Pool
+
+func storeHuge(x *BigBuffer) {
+	pool.Put(x) // bad: using Pool like a permanent cache
+}
+```
+
+```go
+func hot(items []any) {
+	for _, item := range items {
+		_ = reflect.TypeOf(item).Kind() // bad: metadata path in a tiny hot loop
+	}
+}
+```
+
+The first mistakes lifetime and cache semantics.
+
+The second mistakes flexibility for zero-cost abstraction.
+
+## Source walk
+
+Start here:
+
+- [sync/pool.go](https://github.com/golang/go/blob/go1.26.0/src/sync/pool.go)
+- [sync/poolqueue.go](https://github.com/golang/go/blob/go1.26.0/src/sync/poolqueue.go)
+- [reflect/value.go](https://github.com/golang/go/blob/go1.26.0/src/reflect/value.go)
+- [internal/abi/type.go](https://github.com/golang/go/blob/go1.26.0/src/internal/abi/type.go)
+
+## Practical takeaway
+
+When you read the standard library closely, you see the same pattern over and over:
+
+- keep the common path local,
+- make lifetime explicit,
+- pay metadata cost only when flexibility justifies it.
+
+That is as much a production design rule as it is a library implementation detail.

--- a/docs/internals/unsafe-cgo-pinner.md
+++ b/docs/internals/unsafe-cgo-pinner.md
@@ -1,0 +1,120 @@
+---
+title: unsafe, cgo, and runtime.Pinner
+description: Raw-pointer rules, cgo boundaries, and pinning semantics for engineers working near the metal.
+---
+
+# unsafe, cgo, and runtime.Pinner
+
+This is the boundary where Go stops protecting you by default.
+
+The reward is power: zero-copy tricks, C interop, direct memory views.
+
+The cost is that the garbage collector, scheduler, and pointer rules still exist even if your code looks like C.
+
+:::tip Quick takeaway
+`unsafe.Pointer` is still part of Go's pointer world. `uintptr` is just an integer. cgo crossings change scheduler behavior. `runtime.Pinner` exists so C can safely retain Go pointers when the referenced objects are explicitly pinned.
+:::
+
+## `unsafe.Pointer` and `uintptr` are not interchangeable
+
+This is the expert rule to remember:
+
+- `unsafe.Pointer` participates in pointer semantics,
+- `uintptr` does not keep objects alive and does not tell the GC anything.
+
+If you turn a Go pointer into an integer and expect the runtime to preserve object validity on that basis, you are outside the contract.
+
+## Small but important safe helper APIs
+
+Modern Go added helpers that are easier to reason about than older header-casting tricks:
+
+- `unsafe.String`,
+- `unsafe.StringData`,
+- `unsafe.Slice`,
+- `unsafe.SliceData`,
+- `unsafe.Add`.
+
+These are still unsafe. They are just more explicit and less fragile than hand-rolling `reflect.SliceHeader` manipulations.
+
+## Simplified pinning sketch
+
+```go
+buf := make([]byte, 4096)
+
+var p runtime.Pinner
+p.Pin(&buf[0])
+defer p.Unpin()
+
+// Pass buf's address to C here, or let C retain it briefly.
+runtime.KeepAlive(buf)
+```
+
+The important detail is not the syntax. It is the contract:
+
+- the object is pinned until `Unpin`,
+- if the object contains Go pointers that C will follow, those referents must be pinned separately,
+- the `Pinner` itself must stay alive for the duration of C's use.
+
+## Why cgo changes concurrency behavior
+
+A cgo call is not just "another function call."
+
+It affects:
+
+- scheduler accounting,
+- stack transitions and pointer checks,
+- how transparently the runtime can observe blocking,
+- how easy it is to reason about latency from Go-side traces alone.
+
+Pure Go network I/O benefits from netpoll integration. Opaque C calls do not fit that model nearly as well.
+
+## A practical cgo rule
+
+Cross the boundary in chunks, not droplets.
+
+One larger call with a clear ownership contract is usually easier to operate than a per-record or per-packet crossing that destroys batching and observability.
+
+## Failure pattern
+
+This is a classic bug:
+
+```go
+func firstByteAddr(buf []byte) uintptr {
+	return uintptr(unsafe.Pointer(&buf[0]))
+}
+```
+
+Once the pointer is reduced to `uintptr`, it is no longer a Go pointer in the eyes of the runtime. Treating that integer as if it preserved liveness or pinning is wrong.
+
+## A safer zero-copy mental model
+
+If you use unsafe helpers for zero-copy conversions:
+
+- keep the original backing storage alive,
+- keep ownership obvious,
+- do not let mutable and immutable views outlive the same assumptions,
+- do not mix "no-copy" with "no-lifetime-management."
+
+## Where `runtime.Pinner` fits
+
+`runtime.Pinner` exists for a narrow class of problems:
+
+- C needs to retain a Go pointer after a cgo call returns,
+- or C needs to follow Go pointers stored inside a Go object that was itself passed across the boundary.
+
+It is not a general excuse to abandon ownership discipline.
+
+## Source walk
+
+Start here:
+
+- [unsafe package docs](https://pkg.go.dev/unsafe)
+- [cmd/cgo package docs](https://pkg.go.dev/cmd/cgo)
+- [runtime/pinner.go](https://github.com/golang/go/blob/go1.26.0/src/runtime/pinner.go)
+- [runtime/mbarrier.go](https://github.com/golang/go/blob/go1.26.0/src/runtime/mbarrier.go)
+
+## Practical takeaway
+
+The right way to use `unsafe` is not to pretend the runtime disappeared.
+
+The right way is to know exactly which runtime guarantees you are depending on, and which ones you just stepped outside.

--- a/docs/ko/index.md
+++ b/docs/ko/index.md
@@ -3,18 +3,18 @@ layout: home
 
 hero:
   name: Go Concurrency Patterns
-  text: 런타임 내부부터 실전 패턴까지
-  tagline: Go 동시성을 기초 원리, 테스트된 예제, 패턴 선택 가이드, 영문/국문 동시 문서로 깊게 학습합니다.
+  text: 컴파일러 내부부터 실전 동시성 패턴까지
+  tagline: Go를 기초 원리, 시스템 내부 구조, 테스트된 예제, 패턴 선택 가이드, 영문/국문 동시 문서로 깊게 학습합니다.
   actions:
     - theme: brand
       text: 기초 원리부터 시작
       link: /ko/fundamentals/
     - theme: alt
+      text: 내부 구조 보기
+      link: /ko/internals/
+    - theme: alt
       text: 패턴 둘러보기
       link: /ko/patterns/
-    - theme: alt
-      text: 프로덕션 가이드
-      link: /ko/production/
     - theme: alt
       text: 테스트 플레이북
       link: /ko/testing/
@@ -27,6 +27,8 @@ features:
     details: "섹션 개요, 학습 경로, 패턴 선택 가이드를 추가해서 처음 들어와도 어디서 시작할지 바로 보이게 만들었습니다."
   - title: 런타임까지 깊게 설명
     details: "스케줄러, 메모리 모델, 채널 내부, mutex/runtime semaphore까지 Go 내부 원리를 설명합니다."
+  - title: 시스템 레벨 내부 구조 포함
+    details: "Escape analysis, SSA, allocator, generics, interface layout, unsafe, cgo, PGO, sync.Pool 내부까지 추가로 다룹니다."
   - title: 실용 예제 중심
     details: "배송, 부정거래 분석, 재고, 중복 요청 억제처럼 실제 백엔드 문제에 가까운 예제를 사용합니다."
   - title: 테스트로 검증
@@ -57,27 +59,32 @@ features:
     <p><a href="/ko/fundamentals/">기초 원리 보기</a></p>
   </div>
   <div class="path-card">
-    <h3>2. 실전 패턴</h3>
+    <h3>2. 내부 구조</h3>
+    <p>Escape analysis, SSA, allocator 설계, generics, interfaces, unsafe 경계, 현대 성능 도구를 같이 봅니다.</p>
+    <p><a href="/ko/internals/">내부 구조 보기</a></p>
+  </div>
+  <div class="path-card">
+    <h3>3. 실전 패턴</h3>
     <p>워커 풀, 파이프라인, 팬아웃/팬인, 컨텍스트 취소를 실제 workload 관점으로 읽습니다.</p>
     <p><a href="/ko/patterns/">패턴 보기</a></p>
   </div>
   <div class="path-card">
-    <h3>3. 고급 주제</h3>
+    <h3>4. 고급 주제</h3>
     <p>자원 예산, 수명 관리, 중복 억제, 소유권 모델, 과부하 제어까지 확장합니다.</p>
     <p><a href="/ko/advanced/">고급 주제 보기</a></p>
   </div>
   <div class="path-card">
-    <h3>4. 테스트</h3>
+    <h3>5. 테스트</h3>
     <p>cancellation, shutdown, race safety, timeout behavior를 lucky sleep 없이 검증하는 법을 익힙니다.</p>
     <p><a href="/ko/testing/">테스트 보기</a></p>
   </div>
   <div class="path-card">
-    <h3>5. 프로덕션</h3>
+    <h3>6. 프로덕션</h3>
     <p>queue budget, overload policy, goroutine ownership, 실제 오픈소스의 concurrency 구조를 같이 봅니다.</p>
     <p><a href="/ko/production/">프로덕션 보기</a></p>
   </div>
   <div class="path-card">
-    <h3>6. 비교 / 확장</h3>
+    <h3>7. 비교 / 확장</h3>
     <p>Go의 CSP 계열 모델을 Rust Tokio와 비교해 mental model을 더 넓힙니다.</p>
     <p><a href="/ko/extras/">비교 / 확장 보기</a></p>
   </div>
@@ -88,6 +95,8 @@ features:
 | 이런 게 궁금하면 | 여기부터 읽기 |
 | --- | --- |
 | 고루틴이 왜 싸고, 스케줄러가 실제로 뭘 하는지 | [Go 런타임과 스케줄러](/ko/fundamentals/go-runtime-scheduler) |
+| 지역 값이 왜 여전히 힙으로 가는지 | [컴파일러와 툴체인](/ko/internals/compiler-and-toolchain) |
+| 어떤 allocation 패턴이 왜 GC를 더 힘들게 하는지 | [할당기와 하이브리드 write barrier](/ko/internals/allocator-and-write-barrier) |
 | 채널이 왜 메모리 가시성 경계를 만드는지 | [Channels, Select, 그리고 Memory Model](/ko/fundamentals/channels-memory-model) |
 | 많은 독립 작업의 병렬 수를 어떻게 제한하는지 | [워커 풀](/ko/patterns/worker-pool) |
 | 하나의 요청 안에서 여러 sibling task를 어떻게 관리하는지 | [구조화된 동시성](/ko/advanced/structured-concurrency) |
@@ -110,7 +119,7 @@ features:
   </div>
   <div class="signal">
     <strong>이론도 표면적이지 않음</strong>
-    <span>`hchan`, `sudog`, run queue, starvation mode 같은 런타임 개념까지 내려갑니다.</span>
+    <span>`hchan`, `sudog`, run queue, starvation mode 같은 런타임 개념뿐 아니라 SSA, allocator tier, interface metadata까지 내려갑니다.</span>
   </div>
 </div>
 
@@ -119,7 +128,8 @@ features:
 1. [시작하기](/ko/guide/getting-started)에서 저장소 구조와 검증 명령을 확인합니다.
 2. [예제 읽는 법](/ko/guide/how-to-read)으로 읽는 기준을 맞춥니다.
 3. [기초 원리 개요](/ko/fundamentals/)부터 읽습니다.
-4. 자기 workload에 맞는 패턴을 [패턴 개요](/ko/patterns/)에서 고릅니다.
-5. concurrent component를 production-ready로 보기 전에 [테스트 개요](/ko/testing/)를 읽습니다.
-6. 운영 규칙과 오픈소스 사례를 보려면 [프로덕션 개요](/ko/production/)를 읽습니다.
-7. 운영 설계와 비교 관점까지 확장할 때 [고급 주제 개요](/ko/advanced/), [비교 / 확장 개요](/ko/extras/)로 넘어갑니다.
+4. runtime API 너머의 cost model이 궁금하면 [내부 구조 개요](/ko/internals/)를 읽습니다.
+5. 자기 workload에 맞는 패턴을 [패턴 개요](/ko/patterns/)에서 고릅니다.
+6. concurrent component를 production-ready로 보기 전에 [테스트 개요](/ko/testing/)를 읽습니다.
+7. 운영 규칙과 오픈소스 사례를 보려면 [프로덕션 개요](/ko/production/)를 읽습니다.
+8. 운영 설계와 비교 관점까지 확장할 때 [고급 주제 개요](/ko/advanced/), [비교 / 확장 개요](/ko/extras/)로 넘어갑니다.

--- a/docs/ko/internals/allocator-and-write-barrier.md
+++ b/docs/ko/internals/allocator-and-write-barrier.md
@@ -1,0 +1,150 @@
+---
+title: 할당기와 하이브리드 write barrier
+description: Go 할당기 계층과 concurrent GC correctness를 지키는 hybrid write barrier를 따라갑니다.
+---
+
+# 할당기와 하이브리드 write barrier
+
+"allocation"을 아직도 하나의 뭉뚱그린 비용으로 생각하고 있다면, 프로덕션 Go 성능을 제대로 해석하기 어렵습니다.
+
+작은 객체 할당, span 재사용, sweeping, 큰 객체 경로, write barrier는 concurrency와 GC latency 안에서 함께 움직입니다.
+
+:::tip Quick takeaway
+Go 할당기는 여전히 TCMalloc의 영향을 받았지만, 실전에서 필요한 모델은 더 단순합니다. `mcache`가 per-P fast path이고, `mcentral`이 size class별 공유 계층이며, `mheap`이 page를 관리하고, hybrid write barrier가 concurrent marking correctness를 지킵니다.
+:::
+
+## 할당기 계층
+
+`malloc.go`의 런타임 주석이 가장 좋은 요약입니다.
+
+- `mcache`: free slot이 남은 span을 가진 per-P cache
+- `mcentral`: 한 size class를 위한 shared span 집합
+- `mheap`: page 단위 heap manager
+- `mspan`: 객체를 담는 page run
+
+```mermaid
+flowchart LR
+    A["goroutine allocates"] --> B["P-local mcache"]
+    B --> C["size-class mspan"]
+    C --> D["shared mcentral"]
+    D --> E["global mheap"]
+    E --> F["OS pages"]
+```
+
+핵심 목표는 분명합니다. common path는 lock-free에 가깝게 두고, 공유 coordination 비용은 local cache가 비었을 때만 치르게 만드는 것입니다.
+
+## 작은 할당과 size class
+
+작은 객체는 요청 크기를 size class로 반올림한 뒤 현재 P의 cache에서 처리하려고 시도합니다.
+
+이 덕분에 짧게 사는 작은 객체는 개별적으로 보면 꽤 싸게 보입니다.
+
+하지만 GC, pointer scan, goroutine fan-out이 얽히면 "작다"는 사실이 비용을 없애주지는 않습니다.
+
+## 단순화한 할당 스케치
+
+```go
+func alloc(size uintptr) unsafe.Pointer {
+	if span := mcache.lookup(sizeClass(size)); span.hasFree() {
+		return span.alloc()
+	}
+	if span := mcentral.refill(sizeClass(size)); span != nil {
+		mcache.install(span)
+		return span.alloc()
+	}
+	span := mheap.allocPages(...)
+	mcentral.install(span)
+	mcache.install(span)
+	return span.alloc()
+}
+```
+
+실제 runtime 코드는 아니지만, 머릿속 모델로는 이게 맞습니다.
+
+## 큰 객체는 다른 경로를 탄다
+
+큰 할당은 small-object machinery를 상당 부분 우회하고 page allocator에 더 직접적으로 닿습니다.
+
+그래서 "요청마다 64 KiB buffer를 10개 goroutine에서 새로 만든다" 같은 패턴은 작은 struct churn과 질적으로 다른 문제입니다.
+
+## 왜 write barrier를 같이 봐야 하나
+
+할당기와 GC는 분리된 이야기가 아닙니다.
+
+concurrent marking 중에는 mutator가 pointer를 바꾸는 동안 reachable object를 collector에게서 숨기지 못하게 해야 합니다.
+
+그 역할이 write barrier입니다.
+
+## 하이브리드 write barrier
+
+`mbarrier.go`의 런타임 주석을 단순화하면 이렇습니다.
+
+```go
+// conceptual, not the actual runtime function
+func writePointer(slot *unsafe.Pointer, ptr unsafe.Pointer) {
+	shade(*slot)
+	if currentStackIsGrey() {
+		shade(ptr)
+	}
+	*slot = ptr
+}
+```
+
+각 부분의 의미는 분명합니다.
+
+- deletion 쪽은 old referent를 보호하고,
+- insertion 쪽은 stack이 아직 grey일 때 new referent를 보호하고,
+- stack이 black이 되면 그 stack에 대해서는 insertion 쪽이 더 이상 필요하지 않습니다.
+
+## 왜 메모리 ordering이 중요한가
+
+Go는 destination object 색을 fast path에서 매번 확인하는 조건부 barrier를 쓰지 않습니다. 그렇게 하면 memory-ordering 비용이 너무 커지기 때문입니다.
+
+작은 벤치마크에서는 약간 낭비처럼 보여도, 실제 concurrent collector에서는 correctness와 전체 비용 구조가 더 중요합니다.
+
+## 애플리케이션 코드에 주는 의미
+
+보통의 Go 코드에서 barrier를 직접 쓰지는 않습니다.
+
+하지만 다음 상황에서는 그 결과를 분명히 체감합니다.
+
+- pointer-rich value를 고속으로 복사할 때
+- 큰 shared graph를 계속 갱신할 때
+- reflection이나 `unsafe` helper가 결국 typed memmove로 흘러갈 때
+- GC assist가 request latency 안에 들어오는 workload를 만들 때
+
+## 실패 패턴
+
+다음 코드는 그저 "allocation-heavy"처럼 보이지만, 실제로는 GC와 allocator 문제를 함께 만듭니다.
+
+```go
+for _, req := range batch {
+	go func(req Request) {
+		buf := make([]byte, 64<<10) // large allocation path
+		_ = handle(req, buf)
+	}(req)
+}
+```
+
+문제는 단순히 바이트 수가 아닙니다.
+
+- 큰 객체는 가장 싼 경로를 타지 않고,
+- fan-out이 pressure를 배수로 늘리고,
+- collector와 allocator가 tail latency의 일부가 됩니다.
+
+## 소스 읽기 포인트
+
+여기서 시작하면 됩니다.
+
+- [runtime/malloc.go](https://github.com/golang/go/blob/go1.26.0/src/runtime/malloc.go)
+- [runtime/mcache.go](https://github.com/golang/go/blob/go1.26.0/src/runtime/mcache.go)
+- [runtime/mcentral.go](https://github.com/golang/go/blob/go1.26.0/src/runtime/mcentral.go)
+- [runtime/mheap.go](https://github.com/golang/go/blob/go1.26.0/src/runtime/mheap.go)
+- [runtime/mbarrier.go](https://github.com/golang/go/blob/go1.26.0/src/runtime/mbarrier.go)
+- [Proposal: eliminate rescan with a hybrid write barrier](https://github.com/golang/proposal/blob/master/design/17503-eliminate-rescan.md)
+
+## 실전 요약
+
+Go에서 가장 싼 allocation은 "공짜"가 아니라 "정교하게 설계된 fast path"입니다.
+
+할당기 계층과 hybrid barrier를 이해하면, heap churn을 막연한 냄새가 아니라 구체적인 런타임 예산으로 보게 됩니다.

--- a/docs/ko/internals/compiler-and-toolchain.md
+++ b/docs/ko/internals/compiler-and-toolchain.md
@@ -1,0 +1,165 @@
+---
+title: 컴파일러와 툴체인 내부 구조
+description: Escape analysis, SSA, Plan 9 assembly를 통해 Go 소스가 머신 코드로 내려가는 과정을 이해합니다.
+---
+
+# 컴파일러와 툴체인 내부 구조
+
+런타임 내부 구조가 goroutine과 channel이 왜 동작하는지 설명한다면, 컴파일러 내부 구조는 왜 사소해 보이는 소스 변경이 heap churn, inlining 실패, dispatch 비용으로 이어지는지 설명합니다.
+
+:::tip Quick takeaway
+컴파일러는 단순한 코드 출력기가 아닙니다. stack vs heap 배치, 고수준 문법 분해, SSA lowering, assembler에 넘길 semi-abstract instruction stream까지 모두 결정합니다.
+:::
+
+## 가장 짧은 기본 모델
+
+현대 Go 컴파일러는 대략 이런 단계로 갑니다.
+
+1. parsing
+2. type checking
+3. compiler IR 구성
+4. inlining, devirtualization, escape analysis
+5. walk/lowering
+6. SSA 생성과 최적화
+7. machine-specific lowering과 object code 생성
+
+이 순서는 중요합니다. 예를 들어 escape analysis는 SSA 이전에 일어나므로, assembly를 보기 시작할 때쯤이면 stack vs heap 결정은 이미 상당 부분 끝난 상태입니다.
+
+## Escape analysis는 lifetime 문제다
+
+가장 흔한 오해는 "지역 변수면 stack"이라는 생각입니다.
+
+그렇지 않습니다.
+
+핵심은 그 값이 현재 frame 밖으로 나갈 수 있는지, 혹은 컴파일러가 그렇지 않음을 증명할 수 있는지입니다.
+
+```go
+type User struct {
+	ID   int
+	Name string
+}
+
+func NewUser() *User {
+	u := User{ID: 7, Name: "ops"}
+	return &u // escapes: frame 밖으로 반환됨
+}
+```
+
+문법상 지역 변수이지만, pointee는 frame-local 하지 않습니다. 따라서 힙으로 이동해야 합니다.
+
+## 실전에서 가장 유용한 명령 조합
+
+직관을 빠르게 키우는 방법은 컴파일러 출력을 직접 보는 것입니다.
+
+```bash
+go build -gcflags='-m=2' ./...
+GOSSAFUNC=HandleBatch go build ./...
+go build -gcflags='-S' ./...
+```
+
+- `-m=2`는 escape/inlining 결정을 보여주고,
+- `GOSSAFUNC`는 함수 하나의 `ssa.html`을 만들고,
+- `-S`는 lowering 이후의 assembly 비슷한 출력을 보여줍니다.
+
+이 셋은 따로 노는 요령이 아니라 하나의 분석 루프입니다.
+
+## 단순화한 escape 예시
+
+이 패턴은 backing array를 frame 밖으로 밀어냅니다.
+
+```go
+func HeaderBytes() []byte {
+	buf := [64]byte{}
+	return buf[:] // 반환된 slice는 frame 이후에도 살아 있어야 함
+}
+```
+
+slice header 자체는 stack에 남을 수 있어도, 실제 데이터는 반환 이후에도 도달 가능해야 하므로 heap으로 갑니다.
+
+## SSA는 최적화가 보이는 곳이다
+
+SSA, 즉 Static Single Assignment form은 각 논리적 값이 한 번씩만 할당되는 표현입니다.
+
+이 표현이 중요한 이유는 다음 최적화가 쉬워지기 때문입니다.
+
+- dead code elimination
+- bounds check elimination
+- nil check elimination
+- constant propagation
+- devirtualization
+- machine-specific rewrite
+
+## 단순화한 SSA 관점 예시
+
+```go
+func Sum(xs []int) int {
+	total := 0
+	for _, x := range xs {
+		total += x
+	}
+	return total
+}
+```
+
+소스 수준에서는 작아 보이지만, SSA에서는 explicit block, loop-carried phi value, bounds reasoning, architecture-specific op로 바뀝니다. 그래서 `GOSSAFUNC=Sum`이 강력합니다. 컴파일러가 실제로 reasoning 하는 control-flow graph를 보여주기 때문입니다.
+
+## Plan 9 assembly는 raw ISA dump가 아니다
+
+Go assembly 문법은 Plan 9 계열이지만, 핵심은 문법보다 도구체인 인터페이스라는 점입니다.
+
+Go assembler는 툴체인에 맞는 semi-abstract instruction set 위에서 동작합니다. 최종 링크 후 `objdump`가 보여주는 실제 기계어와 1:1 대응이라고 생각하면 안 됩니다.
+
+```asm
+TEXT ·add64(SB), NOSPLIT, $0-24
+	MOVQ a+0(FP), AX
+	ADDQ b+8(FP), AX
+	MOVQ AX, ret+16(FP)
+	RET
+```
+
+여기서 중요한 포인트는:
+
+- `SB`는 package-level symbol,
+- `FP`는 virtual frame에서 argument/result를 가리키고,
+- `NOSPLIT`은 stack growth behavior를 바꾸며 매우 조심해서 써야 하고,
+- 주변 instruction은 툴체인이 추가로 재작성하거나 annotate 할 수 있다는 점입니다.
+
+## 왜 런타임 중심 코드에서 이게 중요한가
+
+컴파일러 동작은 위로 새어 나옵니다.
+
+- escape가 많아지면 heap traffic이 늘고,
+- inlining이 막히면 interface/closure 비용이 남고,
+- devirtualization을 놓치면 hot loop에 간접 호출이 남고,
+- assembly 경계는 일부 최적화를 막기도 합니다.
+
+그래서 assembly를 직접 쓰지 않더라도, 프로덕션 Go 엔지니어는 컴파일러 출력을 읽을 줄 알아야 합니다.
+
+## 실패 패턴
+
+다음 코드는 "stack 같아 보인다"는 직관을 쉽게 깨뜨립니다.
+
+```go
+func ParseHeader() []byte {
+	header := [32]byte{}
+	return header[:]
+}
+```
+
+겉으로는 작고 지역적이지만, 반환되는 slice 때문에 backing storage는 heap으로 갑니다. escape report를 그냥 컴파일러 잡음으로 취급하면, 나중에 GC 비용으로 돌아올 힙 pressure를 놓치게 됩니다.
+
+## 소스 읽기 포인트
+
+여기서 시작하면 됩니다.
+
+- [cmd/compile/README.md](https://github.com/golang/go/blob/go1.26.0/src/cmd/compile/README.md)
+- [cmd/compile/internal/escape](https://github.com/golang/go/tree/go1.26.0/src/cmd/compile/internal/escape)
+- [cmd/compile/internal/ssa](https://github.com/golang/go/tree/go1.26.0/src/cmd/compile/internal/ssa)
+- [cmd/compile/internal/ssagen](https://github.com/golang/go/tree/go1.26.0/src/cmd/compile/internal/ssagen)
+- [A Quick Guide to Go's Assembler](https://go.dev/doc/asm)
+
+## 실전 요약
+
+Go 코드가 왜 할당하고, 왜 inline되고, 왜 특정 방식으로 dispatch되는지 이해하고 싶다면 컴파일러 내부 구조는 선택 사항이 아닙니다.
+
+이 레이어가 source-level intent를 runtime-level cost로 바꿉니다.

--- a/docs/ko/internals/generics-and-interfaces.md
+++ b/docs/ko/internals/generics-and-interfaces.md
@@ -1,0 +1,146 @@
+---
+title: 제네릭과 인터페이스 내부 구조
+description: Go가 제네릭과 인터페이스 값을 어떻게 구현하는지, 그리고 그것이 dispatch와 성능에 왜 중요한지 설명합니다.
+---
+
+# 제네릭과 인터페이스 내부 구조
+
+제네릭 이후 Go 타입 시스템은 훨씬 강해졌지만, 런타임 모델은 여전히 매우 실용주의적입니다.
+
+핵심은 Go가 무엇을 선택하지 않았는지 이해하는 것입니다.
+
+- 순수한 C++식 full monomorphization도 아니고,
+- Java식 type erasure도 아니고,
+- "인터페이스 호출은 알아서 다 최적화된다"는 모델도 아닙니다.
+
+:::tip Quick takeaway
+제네릭은 GC-shape 기반 code sharing과 dictionary를 함께 쓰고, 인터페이스는 여전히 type metadata + data라는 두 단어 모델이 핵심입니다. non-empty interface에서는 `itab`이 그 연결고리 역할을 합니다.
+:::
+
+## 제네릭: GC shape와 dictionary
+
+실전에서 가장 유용한 요약은 이렇습니다.
+
+- 같은 중요한 메모리 레이아웃을 공유하는 instantiation은 코드를 공유할 수 있고,
+- type-specific operation이나 metadata가 필요할 때는 dictionary를 쓰며,
+- 결과적으로 code size 폭증과 pure erasure 사이의 절충점을 택합니다.
+
+그래서 Go 제네릭은 C++ template보다 더 공유적으로 보일 수 있고, 동시에 런타임이 필요한 연산은 그대로 지원할 수 있습니다.
+
+## 단순화한 generic 예시
+
+```go
+func Clone[T any](in []T) []T {
+	out := make([]T, len(in))
+	copy(out, in)
+	return out
+}
+```
+
+개념적으로는 `T`의 GC shape를 기준으로 코드를 공유하고, 필요한 경우 dictionary 정보를 추가로 넘긴다고 이해하면 됩니다. 실제 emitted form은 컴파일러의 영역이지만, 머릿속 모델은 "가능한 한 공유하고, 필요할 때만 specialize"입니다.
+
+## 인터페이스는 여전히 metadata + data다
+
+정확한 내부 타입 이름은 패키지마다 조금씩 다르지만, 이 개념 모델은 계속 유효합니다.
+
+```go
+type eface struct {
+	typ  *abi.Type
+	data unsafe.Pointer
+}
+
+type iface struct {
+	tab  *itab
+	data unsafe.Pointer
+}
+```
+
+- empty interface는 direct type metadata를 들고 있고,
+- non-empty interface는 concrete type과 interface method set을 잇는 `itab`을 쓰고,
+- 값은 type 특성에 따라 direct 또는 indirect로 저장됩니다.
+
+이 마지막 점은 copy 비용, boxing, escape behavior와 직접 연결됩니다.
+
+## 왜 dynamic dispatch 비용이 남는가
+
+인터페이스 호출은 컴파일러가 더 많은 사실을 증명하지 못하면 간접 호출로 남습니다.
+
+그 증거는 다음에서 올 수 있습니다.
+
+- 정적인 타입 정보,
+- devirtualization,
+- inlining 기회,
+- 최신 툴체인에서는 profile-guided 정보.
+
+따라서 아주 작은 hot loop를 넓은 인터페이스 위에 얹고 concrete call처럼 최적화되길 기대하면, 컴파일러에게 없는 증거를 요구하는 셈이 됩니다.
+
+## 단순화한 hot-path 예시
+
+```go
+type Hasher interface {
+	Hash([]byte) uint64
+}
+
+func SumHashes(h Hasher, xs [][]byte) uint64 {
+	var total uint64
+	for _, x := range xs {
+		total += h.Hash(x)
+	}
+	return total
+}
+```
+
+이건 우아한 API입니다. 하지만 자동으로 가장 싼 dispatch shape가 되지는 않습니다.
+
+## 왜 제네릭과 인터페이스는 비슷하지만 다른가
+
+제네릭은 type information을 compile-time에 더 오래 유지하게 해 줍니다.
+
+인터페이스는 behavior abstraction을 runtime 정책으로 넘깁니다.
+
+실전에서는:
+
+- 알고리즘 구조는 같고 concrete type만 바뀌면 제네릭이 유리하고,
+- 구현 선택 자체가 runtime policy면 인터페이스가 유리하고,
+- 둘을 섞는 것은 강력하지만 각자의 cost model을 없애주지는 않습니다.
+
+## 실패 패턴
+
+다음 코드는 인터페이스 dispatch가 거의 공짜라고 생각할 때 자주 나옵니다.
+
+```go
+type Matcher interface {
+	Match([]byte) bool
+}
+
+func Count(ms []Matcher, payload []byte) int {
+	n := 0
+	for _, m := range ms {
+		if m.Match(payload) {
+			n++
+		}
+	}
+	return n
+}
+```
+
+이 API가 정확히 맞을 때도 있습니다.
+
+하지만 때로는 프로세스 전체에서 가장 뜨거운 indirect call site가 됩니다. 인터페이스를 쓴 것이 문제라기보다, 추상화 수준과 dispatch 비용이 무관하다고 가정한 것이 문제입니다.
+
+## 소스 읽기 포인트
+
+여기서 시작하면 됩니다.
+
+- [Proposal: dictionaries for Go 1.18 generics](https://go.googlesource.com/proposal/+/master/design/generics-implementation-dictionaries-go1.18.md)
+- [Proposal: stenciling for Go 1.18 generics](https://go.googlesource.com/proposal/+/master/design/generics-implementation-stenciling.md)
+- [runtime/iface.go](https://github.com/golang/go/blob/go1.26.0/src/runtime/iface.go)
+- [internal/abi/type.go](https://github.com/golang/go/blob/go1.26.0/src/internal/abi/type.go)
+- [reflect/value.go](https://github.com/golang/go/blob/go1.26.0/src/reflect/value.go)
+- [cmd/compile/internal/devirtualize](https://github.com/golang/go/tree/go1.26.0/src/cmd/compile/internal/devirtualize)
+
+## 실전 요약
+
+Go의 타입 내부 구조는 이념적이지 않습니다.
+
+code size, runtime metadata, optimizer opportunity 사이에서 현실적인 절충을 합니다. 이 절충을 이해하면 제네릭, 인터페이스, concrete code를 훨씬 더 의도적으로 고르게 됩니다.

--- a/docs/ko/internals/index.md
+++ b/docs/ko/internals/index.md
@@ -1,0 +1,68 @@
+---
+title: 내부 구조 개요
+description: 컴파일러, 할당기, 타입 메타데이터, unsafe 경계, 성능 도구까지 다루는 시스템 레벨 Go 내부 구조.
+---
+
+# 내부 구조 개요
+
+<div class="lead-panel">
+  <p>
+    이 섹션은 "동시성을 어떻게 쓰는가"에서 한 단계 더 내려가
+    <strong>컴파일러, 런타임, 할당기, 타입 시스템이 왜 특정 설계를 빠르게 혹은 위험하게 만드는가</strong>를 다룹니다.
+  </p>
+</div>
+
+## 이 섹션이 다루는 것
+
+<div class="path-grid">
+  <div class="path-card">
+    <h3><a href="/ko/internals/compiler-and-toolchain">컴파일러와 툴체인</a></h3>
+    <p>Escape analysis, SSA, Plan 9 assembly를 통해 소스 코드가 실제로 어떤 형태로 빌드되는지 봅니다.</p>
+  </div>
+  <div class="path-card">
+    <h3><a href="/ko/internals/allocator-and-write-barrier">할당기와 하이브리드 write barrier</a></h3>
+    <p>`mcache`, `mcentral`, `mheap`, `mspan`과 concurrent GC correctness를 지키는 barrier를 따라갑니다.</p>
+  </div>
+  <div class="path-card">
+    <h3><a href="/ko/internals/layout-padding-false-sharing">레이아웃, 패딩, false sharing</a></h3>
+    <p>정렬 규칙, struct layout, cache line이 알고리즘과는 별개로 성능을 어떻게 바꾸는지 봅니다.</p>
+  </div>
+  <div class="path-card">
+    <h3><a href="/ko/internals/generics-and-interfaces">제네릭과 인터페이스</a></h3>
+    <p>GC shape stenciling, dictionary, `eface`/`iface` 계열 레이아웃, dynamic dispatch tradeoff를 설명합니다.</p>
+  </div>
+  <div class="path-card">
+    <h3><a href="/ko/internals/unsafe-cgo-pinner">unsafe, cgo, 그리고 Pinner</a></h3>
+    <p>raw pointer 규칙, 스케줄러 handoff, memory pinning, zero-copy 기법의 실제 경계를 다룹니다.</p>
+  </div>
+  <div class="path-card">
+    <h3><a href="/ko/internals/modern-performance-tuning">현대 Go 성능 튜닝</a></h3>
+    <p>PGO, execution trace, flight recorder, zero-copy I/O를 최신 Go 기준으로 정리합니다.</p>
+  </div>
+  <div class="path-card">
+    <h3><a href="/ko/internals/stdlib-anatomy">표준 라이브러리 해부</a></h3>
+    <p>`sync.Pool`이 왜 잘 확장되는지, `reflect`가 왜 느린지, code generation이 언제 더 나은지 봅니다.</p>
+  </div>
+</div>
+
+## 추천 읽기 순서
+
+1. [컴파일러와 툴체인](/ko/internals/compiler-and-toolchain)부터 읽습니다.
+2. 이어서 [할당기와 하이브리드 write barrier](/ko/internals/allocator-and-write-barrier)를 봅니다.
+3. [레이아웃, 패딩, false sharing](/ko/internals/layout-padding-false-sharing)으로 메모리 레벨 비용을 정리합니다.
+4. [제네릭과 인터페이스](/ko/internals/generics-and-interfaces)로 타입 시스템 내부를 봅니다.
+5. 그 다음 [unsafe, cgo, 그리고 Pinner](/ko/internals/unsafe-cgo-pinner)를 읽습니다.
+6. 마지막으로 [현대 Go 성능 튜닝](/ko/internals/modern-performance-tuning)과 [표준 라이브러리 해부](/ko/internals/stdlib-anatomy)를 마무리합니다.
+
+## 이 섹션을 읽고 답할 수 있어야 하는 질문
+
+- 왜 지역 변수처럼 보여도 힙으로 가는 값이 있는가?
+- `GOSSAFUNC`는 벤치마크만으로는 보이지 않는 무엇을 보여주는가?
+- 왜 할당기 계층이 `mcache -> mcentral -> mheap`인가?
+- 왜 concurrent GC는 hybrid write barrier를 필요로 하는가?
+- race도 없고 lock bug도 없는데 왜 cache line 때문에 느려질 수 있는가?
+- 왜 Go 제네릭은 순수 monomorphization도 아니고 type erasure도 아닌가?
+- 왜 `uintptr`는 GC root가 아닌가?
+- 언제 `io.Copy`가 zero-copy fast path를 타고, 언제 조용히 fallback 하는가?
+- 왜 `sync.Pool`은 per-P shard에 padding을 넣는가?
+- 언제 reflection은 충분히 유연하고, 언제 cost model 자체가 틀린 선택이 되는가?

--- a/docs/ko/internals/layout-padding-false-sharing.md
+++ b/docs/ko/internals/layout-padding-false-sharing.md
@@ -1,0 +1,147 @@
+---
+title: 레이아웃, 패딩, false sharing
+description: Struct layout, alignment, cache line이 숨어 있는 contention을 어떻게 만드는지 설명합니다.
+---
+
+# 레이아웃, 패딩, false sharing
+
+동시성 코드가 논리적으로 올바르다고 해서 빠르다는 뜻은 아닙니다.
+
+alignment 규칙, padding, cache line sharing은 "독립적인" 카운터나 shard조차 coherence 비용으로 묶어버릴 수 있습니다.
+
+:::tip Quick takeaway
+Go의 alignment 규칙은 `unsafe`로 직접 확인할 수 있을 정도로 단순하지만, 진짜 놀라운 비용은 CPU cache behavior에서 나옵니다. race가 없는 atomic update도 같은 cache line을 튕기면 느려질 수 있습니다.
+:::
+
+## 먼저 컴파일러가 보장하는 것부터 본다
+
+Go는 struct field를 선언 순서대로 배치하되, 각 field의 alignment를 만족시키기 위해 padding을 삽입합니다.
+
+직접 확인할 수 있습니다.
+
+```go
+type Bad struct {
+	Flag  byte
+	Count uint64
+	Tag   byte
+}
+
+fmt.Println(unsafe.Sizeof(Bad{}))
+fmt.Println(unsafe.Offsetof(Bad{}.Count))
+fmt.Println(unsafe.Alignof(Bad{}.Count))
+```
+
+이 단계는 "낭비된 바이트"를 설명합니다.
+
+그 다음 단계인 cache line은 "낭비된 throughput"을 설명합니다.
+
+## field 순서를 바꾸면 객체 크기가 줄 수 있다
+
+```go
+type Better struct {
+	Count uint64
+	Flag  byte
+	Tag   byte
+}
+```
+
+field 순서는 다음을 바꿉니다.
+
+- 전체 크기,
+- offset,
+- cache에 들어가는 객체 수,
+- 경우에 따라 hot field가 다른 hot field와 같은 line을 쓰는지 여부.
+
+성능 민감한 코드에서 field 순서를 cosmetic으로 보면 안 됩니다.
+
+## False sharing은 coherence 문제다
+
+false sharing은 두 goroutine이 다른 데이터를 갱신하는데도 같은 cache line을 두고 싸우는 현상입니다.
+
+race가 없어도 되고,
+lock bug가 없어도 되고,
+프로그램은 완전히 올바를 수 있습니다.
+
+그래도 cache invalidation traffic 때문에 느려질 수 있습니다.
+
+## 단순화한 counter 예시
+
+```go
+type Counters struct {
+	OK  atomic.Int64
+	Err atomic.Int64
+}
+```
+
+두 코어가 이 field를 독립적으로 계속 두드리고, 둘이 같은 line에 놓이면 write마다 line ownership traffic이 생길 수 있습니다.
+
+## padding이 맞는 도구일 때가 있다
+
+```go
+type PaddedCounter struct {
+	Value atomic.Int64
+	_     [56]byte // 예시: 64-byte line 기준 counter 나머지 공간
+}
+```
+
+이런 패딩은 일부러 둔합니다. 다음 조건에서만 씁니다.
+
+- field가 정말 hot하고,
+- contention이 실제로 있고,
+- 프로파일과 벤치마크가 padding 이득을 보여줄 때.
+
+## 표준 라이브러리의 단서: `sync.Pool`
+
+`sync.Pool`은 `poolLocal`에 명시적 padding을 둡니다. per-P shard 사이 false sharing을 피하기 위해서입니다.
+
+표준 라이브러리가 이렇게까지 한다는 사실은, layout이 결코 사소한 구현 디테일이 아니라는 강한 신호입니다.
+
+## 실패 패턴
+
+다음 코드는 멀쩡해 보여도 CPU를 낭비할 수 있습니다.
+
+```go
+type Shard struct {
+	Hits atomic.Int64
+}
+
+var shards [2]Shard
+
+go func() {
+	for {
+		shards[0].Hits.Add(1)
+	}
+}()
+
+go func() {
+	for {
+		shards[1].Hits.Add(1)
+	}
+}()
+```
+
+필드는 논리적으로 독립적이지만, cache line은 아닐 수 있습니다. 둘이 붙어 배치되면 race detector가 알려주지 않는 이유로 throughput이 무너질 수 있습니다.
+
+## 추측하지 않고 layout을 보는 방법
+
+다음을 조합해서 보면 됩니다.
+
+- `unsafe.Sizeof`
+- `unsafe.Alignof`
+- `unsafe.Offsetof`
+- focused benchmark
+- 가능하다면 CPU profile이나 hardware counter 도구
+
+Go 내부만으로 조사할 때는 size/offset 확인과 benchmark 변화부터 보는 것이 가장 현실적입니다.
+
+## 소스 읽기 포인트
+
+여기서 시작하면 됩니다.
+
+- [unsafe package docs](https://pkg.go.dev/unsafe)
+- [internal/abi/type.go](https://github.com/golang/go/blob/go1.26.0/src/internal/abi/type.go)
+- [sync/pool.go](https://github.com/golang/go/blob/go1.26.0/src/sync/pool.go)
+
+## 실전 요약
+
+동시성 설계가 논리적으로 깔끔한데도 CPU를 많이 쓴다면, mutex와 goroutine에서 멈추지 말고 바이트 배치를 봐야 합니다.

--- a/docs/ko/internals/modern-performance-tuning.md
+++ b/docs/ko/internals/modern-performance-tuning.md
@@ -1,0 +1,126 @@
+---
+title: 현대 Go 성능 튜닝
+description: PGO, execution trace, flight recorder, zero-copy 경로를 최신 Go 기준으로 설명합니다.
+---
+
+# 현대 Go 성능 튜닝
+
+현대 Go 성능 튜닝은 예전처럼 folklore나 감에 기대는 일이 아닙니다.
+
+프로파일을 컴파일러에 먹이고, trace로 런타임 진실을 보고, 표준 라이브러리가 이미 커널 fast path를 타는지 확인하는 일이 더 중요합니다.
+
+:::tip Quick takeaway
+아직도 microbenchmark와 감만으로 hot path를 튜닝하고 있다면, 현대 Go 툴체인을 절반밖에 안 쓰고 있는 것입니다. PGO, execution tracing, zero-copy-aware standard-library path는 이제 1급 도구입니다.
+:::
+
+## Profile-guided optimization
+
+PGO는 실제 프로파일 데이터를 바탕으로 컴파일러가 일부 최적화 결정을 더 잘 하게 만듭니다.
+
+핵심은 마법이 아니라 더 좋은 증거입니다.
+
+- inlining budget
+- devirtualization 기회
+- hot-path layout
+
+## 실전 PGO 루프
+
+```bash
+go test -cpuprofile=cpu.pprof ./...
+go build -pgo=cpu.pprof ./cmd/service
+```
+
+현대 `go build`는 `-pgo=auto`도 지원합니다. main package 디렉터리에 `default.pgo`가 있으면 이를 자동으로 적용합니다.
+
+## Execution trace는 runtime truth를 보는 도구다
+
+`runtime/trace`는 다음을 잡습니다.
+
+- goroutine 생성/블로킹
+- scheduler 전환
+- syscall과 netpoll 활동
+- GC 이벤트
+- heap goal 변화
+- user task, region, log
+
+그래서 "런타임이 실제로 무엇을 하고 있었는가?"를 묻는 상황에서는 가장 강력한 도구입니다.
+
+## 작은 instrumentation 예시
+
+```go
+ctx, task := trace.NewTask(ctx, "replicate-batch")
+defer task.End()
+
+trace.WithRegion(ctx, "fetch-primary", func() {
+	_ = fetchPrimary(ctx)
+})
+
+trace.Log(ctx, "tenant", tenantID)
+```
+
+user task와 region을 쓰면 애플리케이션 관점의 이야기 위에 런타임 관점의 이야기를 겹쳐서 볼 수 있습니다.
+
+## Trace v2와 flight recording
+
+최근 Go는 내부적으로 v2 execution-trace wire format을 쓰고, 더 최근 릴리스에서는 `trace.FlightRecorder`로 최근 런타임 이벤트의 rolling window를 메모리에 유지할 수 있게 됐습니다.
+
+운영에서 중요한 이유는 분명합니다.
+
+- trace가 지속 진단 도구에 더 가까워지고,
+- 스파이크 직후 최근 몇 초를 snapshot 할 수 있고,
+- one-shot trace를 미리 켜 두지 않아도 incident와 runtime 상태를 연결하기 쉬워집니다.
+
+## Zero-copy I/O는 이미 표준 라이브러리에 있을 수 있다
+
+올바른 file/socket 조합과 지원 플랫폼에서는 표준 라이브러리 경로가 다음에 도달할 수 있습니다.
+
+- `sendfile`
+- `copy_file_range`
+- `splice`
+
+즉, 때로는 `io.Copy`가 당신이 직접 쓰려던 hand-optimized code보다 이미 더 똑똑합니다.
+
+## 단순화한 I/O 예시
+
+```go
+f, _ := os.Open("payload.bin")
+defer f.Close()
+
+_, _ = io.Copy(conn, f)
+```
+
+이게 실제로 zero-copy fast path를 타는지는 concrete descriptor 조합과 플랫폼에 달려 있습니다. 중요한 건, fast path는 소스 코드 모양이 아니라 라이브러리와 커널 조건에 의해 결정된다는 점입니다.
+
+## 실패 패턴
+
+다음은 성능 전략이 아닙니다.
+
+```go
+func build() {
+	_ = exec.Command("go", "build").Run() // bad: 대표성 있는 profile도 없고 근거도 없음
+}
+```
+
+마찬가지로 모든 `io.Copy`가 zero-copy일 거라고 믿는 것도, 아무 것도 zero-copy가 아닐 거라고 믿는 것도 둘 다 cargo cult입니다. 실제 경로를 확인하지 않는 튜닝은 튜닝이 아닙니다.
+
+## 소스 읽기 포인트
+
+여기서 시작하면 됩니다.
+
+- [Profile-guided optimization](https://go.dev/doc/pgo)
+- [cmd/internal/pgo](https://github.com/golang/go/tree/go1.26.0/src/cmd/internal/pgo)
+- [runtime/trace package docs](https://pkg.go.dev/runtime/trace)
+- [internal/trace/tracev2/doc.go](https://github.com/golang/go/blob/go1.26.0/src/internal/trace/tracev2/doc.go)
+- [Flight Recorder in Go 1.25](https://go.dev/blog/flight-recorder)
+- [os/zero_copy_linux.go](https://github.com/golang/go/blob/go1.26.0/src/os/zero_copy_linux.go)
+- [internal/poll/sendfile_unix.go](https://github.com/golang/go/blob/go1.26.0/src/internal/poll/sendfile_unix.go)
+- [internal/poll/splice_linux.go](https://github.com/golang/go/blob/go1.26.0/src/internal/poll/splice_linux.go)
+
+## 실전 요약
+
+현대 Go 스택은 분명한 루프를 요구합니다.
+
+- 실제 프로파일을 수집하고,
+- 그것을 컴파일러에 넣고,
+- incident 주변 trace를 잡고,
+- fast path를 추측하지 말고 확인해야 합니다.

--- a/docs/ko/internals/stdlib-anatomy.md
+++ b/docs/ko/internals/stdlib-anatomy.md
@@ -1,0 +1,146 @@
+---
+title: 표준 라이브러리 해부
+description: sync.Pool 내부 구조, reflection 비용, 그리고 표준 라이브러리가 드러내는 런타임 tradeoff를 설명합니다.
+---
+
+# 표준 라이브러리 해부
+
+표준 라이브러리는 Go 팀이 abstraction, cache locality, GC pressure, concurrency safety를 실제로 어떻게 균형 잡는지 보여주는 최고의 교재입니다.
+
+그중 특히 좋은 사례가 `sync.Pool`과 `reflect`입니다.
+
+:::tip Quick takeaway
+`sync.Pool`은 global bag + lock이 아닙니다. per-P shard, stealing, victim cache 구조입니다. `reflect`가 느린 이유도 "마법이라서"가 아니라 type metadata, indirection, check, copy 비용을 실제로 수행하기 때문입니다.
+:::
+
+## `sync.Pool`: per-P가 먼저다
+
+`sync.Pool`은 많은 concurrent caller가 잠깐 쓰는 temporary object의 allocation pressure를 줄이기 위한 구조입니다.
+
+핵심 설계는 다음과 같습니다.
+
+- P마다 local shard
+- 가장 빠른 reuse를 위한 `private` slot
+- 추가 값을 담는 `shared` chain
+- cross-P stealing
+- 한 GC cycle 동안 값을 살려 두는 victim cache
+
+## 단순화한 pool 예시
+
+```go
+var bufPool = sync.Pool{
+	New: func() any {
+		return new(bytes.Buffer)
+	},
+}
+
+func encode(v any) []byte {
+	buf := bufPool.Get().(*bytes.Buffer)
+	buf.Reset()
+	defer bufPool.Put(buf)
+
+	_ = json.NewEncoder(buf).Encode(v)
+	return append([]byte(nil), buf.Bytes()...)
+}
+```
+
+중요한 점은 pooled object가 durable ownership이 아니라 temporary scratch라는 사실입니다.
+
+## 왜 pool은 padding을 두는가
+
+`sync.Pool`의 `poolLocal`에는 P-local shard 사이 false sharing을 피하기 위한 명시적 padding이 있습니다.
+
+표준 라이브러리가 이런 선택을 했다는 것은, multicore cache behavior가 알고리즘보다 덜 중요한 문제가 아니라는 뜻입니다.
+
+## Reflection 비용은 대부분 명시적 런타임 작업이다
+
+`reflect.Value`는 다음을 들고 있습니다.
+
+- type metadata
+- pointer/data 표현
+- addressable 여부, indirection, method value, read-only 상태를 나타내는 flag bit
+
+따라서 reflective operation은 종종 다음을 수행합니다.
+
+- kind check
+- metadata traversal
+- interface pack/unpack
+- indirect load
+- 안전한 materialization을 위한 추가 copy
+
+즉, 느린 이유는 신비해서가 아니라 실제로 더 많은 런타임 작업을 하기 때문입니다.
+
+## 단순화한 reflection 예시
+
+```go
+func nonZeroFields(v any) []string {
+	rv := reflect.ValueOf(v)
+	rt := rv.Type()
+	out := make([]string, 0, rv.NumField())
+
+	for i := 0; i < rv.NumField(); i++ {
+		if !rv.Field(i).IsZero() {
+			out = append(out, rt.Field(i).Name)
+		}
+	}
+	return out
+}
+```
+
+이건 control plane, admin tool, config, 저속 경로에서는 충분히 괜찮습니다.
+
+하지만 per-record hot loop에서는 전혀 다른 cost model이 됩니다.
+
+## 실전 대안: typed code나 code generation
+
+reflection을 대체하는 가장 빠른 방법은 보통 교묘한 unsafe가 아닙니다.
+
+대부분은 다음 중 하나입니다.
+
+- concrete hand-written typed code
+- compile-time shape만으로 충분한 generic code
+- serializer, validator, mapper를 위한 generated code
+
+핵심은 runtime inspection 비용을 compile-time structure로 옮기는 것입니다.
+
+## 실패 패턴
+
+다음 두 가지는 특히 자주 보입니다.
+
+```go
+var pool sync.Pool
+
+func storeHuge(x *BigBuffer) {
+	pool.Put(x) // bad: Pool을 permanent cache처럼 사용
+}
+```
+
+```go
+func hot(items []any) {
+	for _, item := range items {
+		_ = reflect.TypeOf(item).Kind() // bad: 작은 hot loop에 metadata path를 올림
+	}
+}
+```
+
+첫 번째는 lifetime semantics를 잘못 이해한 것이고,
+두 번째는 flexibility를 zero-cost abstraction으로 착각한 것입니다.
+
+## 소스 읽기 포인트
+
+여기서 시작하면 됩니다.
+
+- [sync/pool.go](https://github.com/golang/go/blob/go1.26.0/src/sync/pool.go)
+- [sync/poolqueue.go](https://github.com/golang/go/blob/go1.26.0/src/sync/poolqueue.go)
+- [reflect/value.go](https://github.com/golang/go/blob/go1.26.0/src/reflect/value.go)
+- [internal/abi/type.go](https://github.com/golang/go/blob/go1.26.0/src/internal/abi/type.go)
+
+## 실전 요약
+
+표준 라이브러리를 자세히 읽으면 같은 패턴이 반복됩니다.
+
+- common path는 local하게 두고,
+- lifetime은 명확히 하고,
+- flexibility가 정당화될 때만 metadata 비용을 지불합니다.
+
+이건 라이브러리 구현 팁이 아니라 프로덕션 설계 원칙입니다.

--- a/docs/ko/internals/unsafe-cgo-pinner.md
+++ b/docs/ko/internals/unsafe-cgo-pinner.md
@@ -1,0 +1,120 @@
+---
+title: unsafe, cgo, 그리고 runtime.Pinner
+description: raw pointer 규칙, cgo 경계, memory pinning semantics를 시스템 레벨에서 설명합니다.
+---
+
+# unsafe, cgo, 그리고 runtime.Pinner
+
+여기는 Go가 기본적으로 보호해 주는 범위를 넘어서는 경계입니다.
+
+보상은 분명합니다. zero-copy 트릭, C interop, 직접적인 메모리 뷰.
+
+대가도 분명합니다. 코드가 C처럼 보여도 GC, 스케줄러, pointer 규칙은 그대로 살아 있습니다.
+
+:::tip Quick takeaway
+`unsafe.Pointer`는 여전히 Go pointer world 안에 있습니다. `uintptr`는 그냥 정수입니다. cgo crossing은 scheduler model을 바꿉니다. `runtime.Pinner`는 C가 Go pointer를 안전하게 유지해야 할 때 그 주소를 명시적으로 고정하기 위해 존재합니다.
+:::
+
+## `unsafe.Pointer`와 `uintptr`는 같지 않다
+
+전문가 수준에서 꼭 기억해야 할 규칙은 이렇습니다.
+
+- `unsafe.Pointer`는 pointer semantics 안에 있고,
+- `uintptr`는 객체를 살려 두지 않으며 GC에 아무 신호도 주지 않습니다.
+
+Go pointer를 정수로 바꿔 놓고 런타임이 그 주소 유효성을 알아서 지켜주길 기대하면 계약 밖입니다.
+
+## 최근 helper API가 더 안전한 이유
+
+현대 Go는 예전의 `reflect.SliceHeader` 트릭보다 덜 깨지기 쉬운 helper를 제공합니다.
+
+- `unsafe.String`
+- `unsafe.StringData`
+- `unsafe.Slice`
+- `unsafe.SliceData`
+- `unsafe.Add`
+
+여전히 unsafe입니다. 다만 header-casting보다 의도가 더 명확하고 실수 여지가 적습니다.
+
+## 단순화한 pinning 예시
+
+```go
+buf := make([]byte, 4096)
+
+var p runtime.Pinner
+p.Pin(&buf[0])
+defer p.Unpin()
+
+// 여기서 buf 주소를 C에 넘기거나, 잠시 retained 하게 만들 수 있다.
+runtime.KeepAlive(buf)
+```
+
+중요한 것은 문법이 아니라 계약입니다.
+
+- `Unpin` 전까지 객체 주소가 고정되고,
+- 그 객체 안에 C가 따라갈 Go pointer가 더 있으면 별도로 pin 해야 하며,
+- `Pinner` 자체도 C가 쓰는 동안 살아 있어야 합니다.
+
+## 왜 cgo는 concurrency 모델을 바꿔 놓는가
+
+cgo 호출은 그냥 함수 호출이 아닙니다.
+
+다음에 영향을 줍니다.
+
+- scheduler accounting
+- stack transition과 pointer check
+- runtime이 blocking을 얼마나 투명하게 관측할 수 있는지
+- Go trace만 보고 latency를 해석하기 쉬운지 여부
+
+pure Go network I/O는 netpoll과 잘 맞지만, opaque C 호출은 그렇지 않습니다.
+
+## 실전 cgo 규칙 하나
+
+경계를 물방울처럼 자주 넘지 말고, 덩어리로 넘겨야 합니다.
+
+ownership contract가 분명한 큰 호출 한 번이, 레코드마다 C 경계를 넘나드는 설계보다 batching과 observability 측면에서 훨씬 낫습니다.
+
+## 실패 패턴
+
+이건 대표적인 버그입니다.
+
+```go
+func firstByteAddr(buf []byte) uintptr {
+	return uintptr(unsafe.Pointer(&buf[0]))
+}
+```
+
+`uintptr`로 바꾸는 순간, 그 값은 더 이상 런타임 입장에서 Go pointer가 아닙니다. 그 정수가 liveness나 pinning을 보존한다고 생각하면 틀립니다.
+
+## zero-copy를 안전하게 생각하는 방법
+
+unsafe helper로 zero-copy 변환을 할 때는:
+
+- 원본 backing storage를 살아 있게 두고,
+- ownership을 명확히 하고,
+- mutable/immutable view의 lifetime 가정을 섞지 말고,
+- "copy가 없다"를 "lifetime 관리도 필요 없다"로 오해하지 말아야 합니다.
+
+## `runtime.Pinner`가 필요한 정확한 상황
+
+`runtime.Pinner`는 아주 좁은 문제를 위해 존재합니다.
+
+- cgo call이 끝난 뒤에도 C가 Go pointer를 계속 들고 있어야 하거나,
+- Go object 안에 든 Go pointer를 C가 따라가야 하는 경우.
+
+이건 ownership discipline을 버리라는 뜻이 아닙니다. 오히려 더 명시적으로 하라는 뜻입니다.
+
+## 소스 읽기 포인트
+
+여기서 시작하면 됩니다.
+
+- [unsafe package docs](https://pkg.go.dev/unsafe)
+- [cmd/cgo package docs](https://pkg.go.dev/cmd/cgo)
+- [runtime/pinner.go](https://github.com/golang/go/blob/go1.26.0/src/runtime/pinner.go)
+- [runtime/mbarrier.go](https://github.com/golang/go/blob/go1.26.0/src/runtime/mbarrier.go)
+
+## 실전 요약
+
+`unsafe`를 제대로 쓰는 방법은 런타임이 사라졌다고 믿는 것이 아닙니다.
+
+어떤 런타임 보장에 기대고 있고, 어떤 보장 밖으로 나갔는지를 정확히 아는 것이 핵심입니다.


### PR DESCRIPTION
## Summary
- add a new bilingual `Internals` section that expands the site beyond concurrency/runtime into compiler, allocator, type-system, unsafe/cgo, performance, and stdlib deep dives
- add 7 English and 7 Korean internals pages covering escape analysis, SSA, Plan 9 assembly, allocator hierarchy, hybrid write barrier, layout/padding/false sharing, generics, interface layout, `runtime.Pinner`, PGO, trace v2, zero-copy I/O, `sync.Pool`, and `reflect`
- update VitePress navigation, sidebars, homepage learning paths, and the README so the new systems-level content is discoverable in both languages

## Testing
- npm run docs:build
- go test ./...

## Linked Issue
- Closes #15
