### PR TITLE
Docs: add standard library deep dive section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Go Concurrency Patterns
 
-Expert-level Go concurrency fundamentals, practical patterns, testing guidance, and bilingual English/Korean documentation built with VitePress.
+Expert-level Go concurrency fundamentals, standard library deep dives, practical patterns, testing guidance, and bilingual English/Korean documentation built with VitePress.
 
 ## Where to view it
 
@@ -69,6 +69,13 @@ VitePress will print a local preview URL in the terminal, usually `http://localh
 - unsafe, cgo, and `runtime.Pinner`
 - Modern performance tuning with PGO, execution tracing, and zero-copy I/O
 - Standard library anatomy for `sync.Pool` and `reflect`
+
+## Included standard library topics
+
+- `context`: cancellation trees, `cancelCtx`, `timerCtx`, `Cause`, `AfterFunc`, and `WithoutCancel`
+- `net/http`: server timeout boundaries, request lifetimes, transport pooling, `persistConn`, and response-body ownership
+- `database/sql`: pool internals, waiters, cleaner lifecycle, `DB.Stats`, and cancellation boundaries
+- `time`: monotonic time, timer/ticker ownership, Go 1.23 timer semantics, and retry-loop design
 
 ## Included advanced topics
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -36,6 +36,16 @@ const enSidebar = [
     ],
   },
   {
+    text: "Standard Library",
+    items: [
+      { text: "Overview", link: "/stdlib/" },
+      { text: "context Package Internals", link: "/stdlib/context-internals" },
+      { text: "net/http Server and Transport", link: "/stdlib/net-http-server-transport" },
+      { text: "database/sql Pool Internals", link: "/stdlib/database-sql-pool" },
+      { text: "time, Timers, and Tickers", link: "/stdlib/time-timers-tickers" },
+    ],
+  },
+  {
     text: "Patterns",
     items: [
       { text: "Overview", link: "/patterns/" },
@@ -120,6 +130,16 @@ const koSidebar = [
       { text: "unsafe, cgo, 그리고 Pinner", link: "/ko/internals/unsafe-cgo-pinner" },
       { text: "현대 Go 성능 튜닝", link: "/ko/internals/modern-performance-tuning" },
       { text: "표준 라이브러리 해부", link: "/ko/internals/stdlib-anatomy" },
+    ],
+  },
+  {
+    text: "표준 라이브러리",
+    items: [
+      { text: "개요", link: "/ko/stdlib/" },
+      { text: "context 패키지 내부", link: "/ko/stdlib/context-internals" },
+      { text: "net/http 서버와 Transport 내부", link: "/ko/stdlib/net-http-server-transport" },
+      { text: "database/sql 풀 내부", link: "/ko/stdlib/database-sql-pool" },
+      { text: "time, Timers, Tickers", link: "/ko/stdlib/time-timers-tickers" },
     ],
   },
   {
@@ -224,6 +244,7 @@ export default defineConfig({
           { text: "Guide", link: "/guide/getting-started" },
           { text: "Fundamentals", link: "/fundamentals/" },
           { text: "Internals", link: "/internals/" },
+          { text: "Standard Library", link: "/stdlib/" },
           { text: "Patterns", link: "/patterns/" },
           { text: "Advanced", link: "/advanced/" },
           { text: "Production", link: "/production/" },
@@ -260,6 +281,7 @@ export default defineConfig({
           { text: "가이드", link: "/ko/guide/getting-started" },
           { text: "기초 원리", link: "/ko/fundamentals/" },
           { text: "내부 구조", link: "/ko/internals/" },
+          { text: "표준 라이브러리", link: "/ko/stdlib/" },
           { text: "패턴", link: "/ko/patterns/" },
           { text: "고급 주제", link: "/ko/advanced/" },
           { text: "프로덕션", link: "/ko/production/" },

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,9 @@ hero:
       text: Open Internals
       link: /internals/
     - theme: alt
+      text: Standard Library
+      link: /stdlib/
+    - theme: alt
       text: Browse Patterns
       link: /patterns/
     - theme: alt
@@ -29,6 +32,8 @@ features:
     details: "The fundamentals section explains the scheduler, memory model, channel internals, and mutex/runtime semaphore behavior."
   - title: Systems-level internals
     details: "The site now covers escape analysis, SSA, allocator internals, generics, interface layout, unsafe, cgo, PGO, and sync.Pool internals."
+  - title: Standard library deep dives
+    details: "The site now treats `context`, `net/http`, `database/sql`, and `time` as first-class learning tracks instead of assuming they are already understood."
   - title: Practical examples
     details: "Examples use realistic backend domains such as shipping, fraud analysis, inventory coordination, and cache-miss suppression."
   - title: Tested behavior
@@ -64,27 +69,32 @@ features:
     <p><a href="/internals/">Open internals</a></p>
   </div>
   <div class="path-card">
-    <h3>3. Practical Patterns</h3>
+    <h3>3. Standard Library</h3>
+    <p>Learn how `context`, `net/http`, `database/sql`, and `time` turn runtime guarantees into request lifetimes, connection reuse, and deadline behavior.</p>
+    <p><a href="/stdlib/">Open standard library</a></p>
+  </div>
+  <div class="path-card">
+    <h3>4. Practical Patterns</h3>
     <p>Move into worker pools, pipelines, fan-out/fan-in, and context cancellation when you are mapping code to real workloads.</p>
     <p><a href="/patterns/">Browse patterns</a></p>
   </div>
   <div class="path-card">
-    <h3>4. Advanced Topics</h3>
+    <h3>5. Advanced Topics</h3>
     <p>Study resource budgeting, structured lifetimes, duplicate suppression, ownership models, and overload behavior.</p>
     <p><a href="/advanced/">Go deeper</a></p>
   </div>
   <div class="path-card">
-    <h3>5. Testing</h3>
+    <h3>6. Testing</h3>
     <p>Learn how to prove cancellation, shutdown, race safety, and timeout behavior instead of relying on lucky sleeps.</p>
     <p><a href="/testing/">Open testing</a></p>
   </div>
   <div class="path-card">
-    <h3>6. Production</h3>
+    <h3>7. Production</h3>
     <p>Study queue budgets, overload policy, goroutine ownership, and open-source concurrency designs from real Go systems.</p>
     <p><a href="/production/">Open production</a></p>
   </div>
   <div class="path-card">
-    <h3>7. Extras</h3>
+    <h3>8. Extras</h3>
     <p>Compare Go's CSP-flavored model with Rust Tokio so your mental model holds across ecosystems.</p>
     <p><a href="/extras/">Open extras</a></p>
   </div>
@@ -97,6 +107,10 @@ features:
 | Why goroutines are cheap and how the scheduler actually runs them | [Go Runtime and Scheduler](/fundamentals/go-runtime-scheduler) |
 | Why a local value still ends up on the heap | [Compiler and Toolchain](/internals/compiler-and-toolchain) |
 | Why one allocation pattern hurts GC more than another | [Allocator and Hybrid Write Barrier](/internals/allocator-and-write-barrier) |
+| How request-scoped cancellation actually propagates | [context Package Internals](/stdlib/context-internals) |
+| How Go's HTTP server and client transport really own connections | [net/http Server and Transport](/stdlib/net-http-server-transport) |
+| Why `sql.DB` is a pool instead of a connection | [database/sql Pool Internals](/stdlib/database-sql-pool) |
+| Why `time.After` is not always the right loop primitive | [time, Timers, and Tickers](/stdlib/time-timers-tickers) |
 | Why channels synchronize memory visibility | [Channels, Select, and the Memory Model](/fundamentals/channels-memory-model) |
 | How to cap parallelism across many independent tasks | [Worker Pool](/patterns/worker-pool) |
 | How to structure one request with several sibling tasks | [Structured Concurrency](/advanced/structured-concurrency) |
@@ -129,7 +143,8 @@ features:
 2. Read [How to Read the Examples](/guide/how-to-read) to set the review lens.
 3. Work through [Fundamentals Overview](/fundamentals/) before jumping into implementation patterns.
 4. Read [Internals Overview](/internals/) when you want compiler, allocator, and type-system cost models rather than only runtime APIs.
-5. Pick the practical pattern that matches your workload in [Patterns Overview](/patterns/).
-6. Read [Testing Overview](/testing/) before treating any concurrent component as production-ready.
-7. Read [Production Overview](/production/) for operating rules and open-source case studies.
-8. Finish with [Advanced Overview](/advanced/) and [Extras Overview](/extras/) for deeper design and ecosystem comparison.
+5. Read [Standard Library Overview](/stdlib/) when you want to understand how real Go services express lifetime, I/O, SQL, and time semantics.
+6. Pick the practical pattern that matches your workload in [Patterns Overview](/patterns/).
+7. Read [Testing Overview](/testing/) before treating any concurrent component as production-ready.
+8. Read [Production Overview](/production/) for operating rules and open-source case studies.
+9. Finish with [Advanced Overview](/advanced/) and [Extras Overview](/extras/) for deeper design and ecosystem comparison.

--- a/docs/ko/index.md
+++ b/docs/ko/index.md
@@ -13,6 +13,9 @@ hero:
       text: 내부 구조 보기
       link: /ko/internals/
     - theme: alt
+      text: 표준 라이브러리
+      link: /ko/stdlib/
+    - theme: alt
       text: 패턴 둘러보기
       link: /ko/patterns/
     - theme: alt
@@ -29,6 +32,8 @@ features:
     details: "스케줄러, 메모리 모델, 채널 내부, mutex/runtime semaphore까지 Go 내부 원리를 설명합니다."
   - title: 시스템 레벨 내부 구조 포함
     details: "Escape analysis, SSA, allocator, generics, interface layout, unsafe, cgo, PGO, sync.Pool 내부까지 추가로 다룹니다."
+  - title: 표준 라이브러리까지 깊게
+    details: "`context`, `net/http`, `database/sql`, `time`를 따로 빼서 실제 서비스 코드가 돌아가는 경계를 자세히 설명합니다."
   - title: 실용 예제 중심
     details: "배송, 부정거래 분석, 재고, 중복 요청 억제처럼 실제 백엔드 문제에 가까운 예제를 사용합니다."
   - title: 테스트로 검증
@@ -64,27 +69,32 @@ features:
     <p><a href="/ko/internals/">내부 구조 보기</a></p>
   </div>
   <div class="path-card">
-    <h3>3. 실전 패턴</h3>
+    <h3>3. 표준 라이브러리</h3>
+    <p>`context`, `net/http`, `database/sql`, `time`를 통해 런타임 보장이 실제 request lifetime, connection reuse, deadline behavior로 어떻게 드러나는지 봅니다.</p>
+    <p><a href="/ko/stdlib/">표준 라이브러리 보기</a></p>
+  </div>
+  <div class="path-card">
+    <h3>4. 실전 패턴</h3>
     <p>워커 풀, 파이프라인, 팬아웃/팬인, 컨텍스트 취소를 실제 workload 관점으로 읽습니다.</p>
     <p><a href="/ko/patterns/">패턴 보기</a></p>
   </div>
   <div class="path-card">
-    <h3>4. 고급 주제</h3>
+    <h3>5. 고급 주제</h3>
     <p>자원 예산, 수명 관리, 중복 억제, 소유권 모델, 과부하 제어까지 확장합니다.</p>
     <p><a href="/ko/advanced/">고급 주제 보기</a></p>
   </div>
   <div class="path-card">
-    <h3>5. 테스트</h3>
+    <h3>6. 테스트</h3>
     <p>cancellation, shutdown, race safety, timeout behavior를 lucky sleep 없이 검증하는 법을 익힙니다.</p>
     <p><a href="/ko/testing/">테스트 보기</a></p>
   </div>
   <div class="path-card">
-    <h3>6. 프로덕션</h3>
+    <h3>7. 프로덕션</h3>
     <p>queue budget, overload policy, goroutine ownership, 실제 오픈소스의 concurrency 구조를 같이 봅니다.</p>
     <p><a href="/ko/production/">프로덕션 보기</a></p>
   </div>
   <div class="path-card">
-    <h3>7. 비교 / 확장</h3>
+    <h3>8. 비교 / 확장</h3>
     <p>Go의 CSP 계열 모델을 Rust Tokio와 비교해 mental model을 더 넓힙니다.</p>
     <p><a href="/ko/extras/">비교 / 확장 보기</a></p>
   </div>
@@ -97,6 +107,10 @@ features:
 | 고루틴이 왜 싸고, 스케줄러가 실제로 뭘 하는지 | [Go 런타임과 스케줄러](/ko/fundamentals/go-runtime-scheduler) |
 | 지역 값이 왜 여전히 힙으로 가는지 | [컴파일러와 툴체인](/ko/internals/compiler-and-toolchain) |
 | 어떤 allocation 패턴이 왜 GC를 더 힘들게 하는지 | [할당기와 하이브리드 write barrier](/ko/internals/allocator-and-write-barrier) |
+| request-scoped cancellation이 실제로 어떻게 전파되는지 | [context 패키지 내부](/ko/stdlib/context-internals) |
+| Go HTTP 서버와 클라이언트 transport가 connection을 어떻게 소유하는지 | [net/http 서버와 Transport 내부](/ko/stdlib/net-http-server-transport) |
+| 왜 `sql.DB`는 connection이 아니라 pool인지 | [database/sql 풀 내부](/ko/stdlib/database-sql-pool) |
+| 왜 `time.After`가 항상 좋은 loop primitive는 아닌지 | [time, Timers, Tickers](/ko/stdlib/time-timers-tickers) |
 | 채널이 왜 메모리 가시성 경계를 만드는지 | [Channels, Select, 그리고 Memory Model](/ko/fundamentals/channels-memory-model) |
 | 많은 독립 작업의 병렬 수를 어떻게 제한하는지 | [워커 풀](/ko/patterns/worker-pool) |
 | 하나의 요청 안에서 여러 sibling task를 어떻게 관리하는지 | [구조화된 동시성](/ko/advanced/structured-concurrency) |
@@ -129,7 +143,8 @@ features:
 2. [예제 읽는 법](/ko/guide/how-to-read)으로 읽는 기준을 맞춥니다.
 3. [기초 원리 개요](/ko/fundamentals/)부터 읽습니다.
 4. runtime API 너머의 cost model이 궁금하면 [내부 구조 개요](/ko/internals/)를 읽습니다.
-5. 자기 workload에 맞는 패턴을 [패턴 개요](/ko/patterns/)에서 고릅니다.
-6. concurrent component를 production-ready로 보기 전에 [테스트 개요](/ko/testing/)를 읽습니다.
-7. 운영 규칙과 오픈소스 사례를 보려면 [프로덕션 개요](/ko/production/)를 읽습니다.
-8. 운영 설계와 비교 관점까지 확장할 때 [고급 주제 개요](/ko/advanced/), [비교 / 확장 개요](/ko/extras/)로 넘어갑니다.
+5. 실제 Go 서비스가 lifetime, I/O, SQL, time을 어떻게 표현하는지 보려면 [표준 라이브러리 개요](/ko/stdlib/)를 읽습니다.
+6. 자기 workload에 맞는 패턴을 [패턴 개요](/ko/patterns/)에서 고릅니다.
+7. concurrent component를 production-ready로 보기 전에 [테스트 개요](/ko/testing/)를 읽습니다.
+8. 운영 규칙과 오픈소스 사례를 보려면 [프로덕션 개요](/ko/production/)를 읽습니다.
+9. 운영 설계와 비교 관점까지 확장할 때 [고급 주제 개요](/ko/advanced/), [비교 / 확장 개요](/ko/extras/)로 넘어갑니다.

--- a/docs/ko/stdlib/context-internals.md
+++ b/docs/ko/stdlib/context-internals.md
@@ -1,0 +1,264 @@
+---
+title: context 패키지 내부
+description: context의 cancellation, deadline, cause, value가 표준 라이브러리 내부에서 어떻게 동작하는지 설명합니다.
+---
+
+# context 패키지 내부
+
+많은 Go 동시성 실패는 goroutine 자체 때문에 생기지 않습니다.
+
+유효한 소유자가 없어졌는데도 일이 계속 돌아가는 것이 더 큰 문제입니다.
+
+`context` 패키지는 그 문제에 대한 Go의 기본 해법입니다.
+
+## 왜 이 패키지가 존재하는가
+
+`context`는 하나의 operation tree에 공통 lifetime을 부여합니다.
+
+- 요청이 만료될 수 있고,
+- 부모가 자식 작업을 취소할 수 있고,
+- deadline이 I/O나 DB 대기를 멈출 수 있고,
+- request-scoped metadata가 call graph를 따라 흐를 수 있습니다.
+
+공통 lifetime이 없으면 동시성 코드는 쉽게 detached work와 cleanup bug로 무너집니다.
+
+## 예제 시나리오
+
+```mermaid
+flowchart LR
+    A["들어온 요청 context"] --> B["WithTimeoutCause"]
+    B --> C1["가격 조회"]
+    B --> C2["재고 조회"]
+    B --> C3["배송비 조회"]
+    C1 --> D["results channel"]
+    C2 --> D
+    C3 --> D
+    D --> E["응답 조합"]
+    B --> F["deadline 초과 또는 caller 취소"]
+    F --> C1
+    F --> C2
+    F --> C3
+```
+
+## 실전 코드 스케치
+
+```go
+func (svc CheckoutService) Quote(ctx context.Context, sku string) (Quote, error) {
+	ctx, cancel := context.WithTimeoutCause(ctx, 150*time.Millisecond, ErrQuoteTimeout)
+	defer cancel()
+
+	results := make(chan quoteResult, 3)
+
+	go func() { results <- svc.fetchPrice(ctx, sku) }()
+	go func() { results <- svc.fetchInventory(ctx, sku) }()
+	go func() { results <- svc.fetchShipping(ctx, sku) }()
+
+	var quote Quote
+
+	for range 3 {
+		select {
+		case <-ctx.Done():
+			return Quote{}, context.Cause(ctx)
+		case result := <-results:
+			if result.err != nil {
+				cancel()
+				return Quote{}, result.err
+			}
+			quote.Merge(result.partial)
+		}
+	}
+
+	return quote, nil
+}
+```
+
+여기서 중요한 건 문법이 아니라 소유권 모델입니다.
+
+- 부모 lifetime 하나,
+- 여러 자식 작업,
+- 전체 subtree를 언제 멈출지 결정하는 지점 하나.
+
+## Mental model
+
+`context`는 스케줄러가 아니고, 전역 값을 넣는 가방도 아닙니다.
+
+이 패키지는 파생된 노드들의 트리입니다.
+
+- `cancelCtx`: cancellation 추가
+- `timerCtx`: timer 기반 deadline 추가
+- `valueCtx`: key-value 하나 추가
+- `withoutCancelCtx`: value는 유지하고 cancellation은 제거
+
+즉:
+
+- cancellation은 아래로 흐르고,
+- value 조회는 위로 거슬러 올라가며,
+- deadline은 결국 timed cancellation이고,
+- `Done()`은 shared stop signal이지 work queue가 아닙니다.
+
+## 단순화한 내부 코드 예시
+
+정확한 원문은 아니지만 구조를 이해하기엔 충분합니다.
+
+```go
+type cancelCtx struct {
+	parent   context.Context
+	mu       sync.Mutex
+	done     chan struct{}
+	children map[canceler]struct{}
+	err      error
+	cause    error
+}
+
+func (c *cancelCtx) cancel(err error, cause error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.err != nil {
+		return
+	}
+
+	c.err = err
+	c.cause = cause
+
+	if c.done == nil {
+		c.done = closedChan
+	} else {
+		close(c.done)
+	}
+
+	for child := range c.children {
+		child.cancel(err, cause)
+	}
+	c.children = nil
+}
+
+type timerCtx struct {
+	cancelCtx
+	timer    *time.Timer
+	deadline time.Time
+}
+
+type valueCtx struct {
+	parent context.Context
+	key    any
+	value  any
+}
+```
+
+실제 구현은 atomic, lazy channel 생성, fast path가 더 들어가지만 핵심 흐름은 위와 같습니다.
+
+## 런타임/소스 코드 관점에서 보면
+
+Go 1.26 소스에서 특히 중요한 부분은 이렇습니다.
+
+- `cancelCtx`는 lazy `done` channel, `children` set, 첫 cancellation error/cause를 가집니다.
+- `Err()`는 hot loop에서도 자주 불릴 수 있어서 atomic fast path를 씁니다.
+- `propagateCancel`은 가능하면 helper goroutine을 만들지 않고 부모 `cancelCtx`에 직접 child를 연결합니다.
+- `timerCtx`는 `cancelCtx`를 embed하고, cancel 시 timer를 멈춥니다.
+- `valueCtx`는 linked chain이라서 깊어질수록 `Value` lookup은 선형 비용이 듭니다.
+- `WithoutCancel`은 `Done() == nil`, `Err() == nil`이지만 value는 계속 전달합니다.
+
+실제 읽을 만한 지점:
+
+- [`context.go` `cancelCtx`](https://github.com/golang/go/blob/go1.26.0/src/context/context.go#L431)
+- [`context.go` `propagateCancel`](https://github.com/golang/go/blob/go1.26.0/src/context/context.go#L469)
+- [`context.go` `WithoutCancel`](https://github.com/golang/go/blob/go1.26.0/src/context/context.go#L585)
+- [`context.go` `timerCtx`](https://github.com/golang/go/blob/go1.26.0/src/context/context.go#L662)
+- [`context.go` `valueCtx`](https://github.com/golang/go/blob/go1.26.0/src/context/context.go#L742)
+
+## 최근 API 중 특히 중요한 것
+
+### `Cause`와 `WithCancelCause`
+
+취소 이유가 business logic에 중요하다면 `context.Cause`는 `context.Canceled` 하나로 뭉개는 것보다 훨씬 낫습니다.
+
+예를 들어:
+
+- client disconnect,
+- 내부 budget 초과,
+- upstream timeout,
+- 수동 shutdown
+
+을 구분할 수 있어야 합니다.
+
+### `AfterFunc`
+
+`AfterFunc`는 cancellation이 발생했을 때 cleanup이나 보상 작업을 연결할 수 있게 해줍니다.
+
+```go
+stopRollback := context.AfterFunc(ctx, func() {
+	_ = tx.Rollback()
+})
+defer stopRollback()
+```
+
+유용하지만 과용하기도 쉽습니다. cleanup은 가급적 local하고 명확하게 두는 편이 낫습니다.
+
+### `WithoutCancel`
+
+`WithoutCancel`은 좁은 용도의 도구입니다.
+
+request의 value는 유지하되 request cancellation에서는 분리하고 싶을 때만 쓰는 게 맞습니다. 예를 들어 graceful handoff 중 audit log를 마저 남기는 경우입니다. 습관처럼 쓰면 lifetime ownership을 거짓으로 만들 가능성이 큽니다.
+
+## 실패 패턴
+
+### `cancel`을 호출하지 않음
+
+```go
+ctx, cancel := context.WithTimeout(parent, 200*time.Millisecond)
+_ = cancel // bug: timer와 child reference가 parent 취소 전까지 남음
+```
+
+leak되는 건 timer만이 아닙니다. parent가 child를 계속 붙잡고 있게 됩니다.
+
+### request tree를 `context.Background()`로 바꿔버림
+
+```go
+go svc.writeAuditLog(context.Background(), event) // caller와 shutdown에서 분리됨
+```
+
+이렇게 하면 request lifetime, shutdown propagation, budget control이 조용히 사라집니다.
+
+### value를 optional parameter처럼 사용
+
+```go
+ctx = context.WithValue(ctx, "retries", 3)
+ctx = context.WithValue(ctx, "region", "eu-west-1")
+ctx = context.WithValue(ctx, "debug", true)
+```
+
+weakly typed이고 남용하기 쉽고, 함수 계약이 더 읽기 어려워집니다.
+
+### hot path에서 깊은 value chain 만들기
+
+`WithValue`를 쓸 때마다 노드가 하나 더 생깁니다. `Value`는 체인을 따라가며 찾습니다. 한두 번은 괜찮지만, middleware나 RPC hot path에 과도하게 쌓이면 공짜가 아닙니다.
+
+### cancellation이 모든 작업을 즉시 멈춘다고 착각
+
+cancellation은 `Done()`을 닫을 뿐입니다. CPU loop를 선점하거나 context를 무시하는 라이브러리를 강제로 멈추지는 못합니다.
+
+## 프로덕션에서의 의미
+
+- request마다 context tree를 만드는 건 충분히 싸지만, ownership 없이 뿌릴 정도로 공짜는 아닙니다.
+- `cancel()` 누락은 timer retention, child retention, shutdown 혼란으로 이어집니다.
+- `Cause`는 `ctx.Err()`보다 세부 정보를 보존해서 observability에 유리합니다.
+- `context.Context`는 거의 항상 함수의 첫 번째 인자여야 하고, struct field가 되면 안 됩니다.
+
+## 어떻게 테스트/관측할까
+
+- 짧은 deadline으로 테스트하고 `context.DeadlineExceeded` 또는 `context.Cause`를 검증합니다.
+- return value만 보지 말고 child goroutine이 실제로 종료되는지 확인합니다.
+- request abort, timeout, shutdown 경로에 leak test를 붙입니다.
+- 많은 작업이 하나의 budget에 묶인다면 timeout cause별 trace/metric을 남깁니다.
+
+## 공식 자료
+
+- [`context` 패키지 문서](https://pkg.go.dev/context)
+- [Go blog: Context](https://go.dev/blog/context)
+- [Go blog: Contexts and structs](https://go.dev/blog/context-and-structs)
+- [Go 1.26 `context` 소스](https://github.com/golang/go/blob/go1.26.0/src/context/context.go)
+
+## Practical takeaway
+
+`context`를 단순한 API 인자가 아니라 lifetime tree로 이해하면, 많은 goroutine leak와 shutdown bug를 훨씬 명확하게 다룰 수 있습니다.

--- a/docs/ko/stdlib/database-sql-pool.md
+++ b/docs/ko/stdlib/database-sql-pool.md
@@ -1,0 +1,240 @@
+---
+title: database/sql 풀 내부
+description: sql.DB가 프로덕션 Go 시스템에서 pooling, waiting, lifetime, cancellation boundary를 어떻게 관리하는지 설명합니다.
+---
+
+# database/sql 풀 내부
+
+`database/sql`에서 가장 흔한 오해는 간단합니다.
+
+`sql.DB`는 하나의 connection이 아니라 concurrent pool manager입니다.
+
+이 점을 놓치면 풀 크기를 잘못 잡고, 잘못된 시점에 닫고, query 압력을 시스템 전체 지연으로 바꿔버리게 됩니다.
+
+## 왜 이 패키지가 중요한가
+
+프로덕션에서 데이터베이스 동시성은 대개 goroutine 수로 제한되지 않습니다.
+
+보통은:
+
+- 풀 크기,
+- 드라이버 동작,
+- transaction lifetime,
+- query duration,
+- cancellation 지원,
+- rows와 statement cleanup discipline
+
+에 의해 제한됩니다.
+
+`database/sql`은 그 문제를 한데 모아 다루는 지점입니다.
+
+## 예제 시나리오
+
+```mermaid
+flowchart LR
+    A["들어온 요청"] --> B["sql.DB pool"]
+    B --> C["idle connections"]
+    B --> D["새 connection 열기"]
+    B --> E["waiter queue"]
+    C --> F["QueryContext"]
+    D --> F
+    E --> F
+    F --> G["Rows / Tx / Conn"]
+    G --> H["Close / Commit / Rollback으로 용량 반환"]
+```
+
+## 실전 코드 스케치
+
+```go
+db, err := sql.Open("pgx", dsn)
+if err != nil {
+	return err
+}
+
+db.SetMaxOpenConns(64)
+db.SetMaxIdleConns(16)
+db.SetConnMaxIdleTime(5 * time.Minute)
+db.SetConnMaxLifetime(30 * time.Minute)
+
+ctx, cancel := context.WithTimeout(r.Context(), 200*time.Millisecond)
+defer cancel()
+
+rows, err := db.QueryContext(ctx, query, tenantID)
+if err != nil {
+	return err
+}
+defer rows.Close()
+```
+
+여기서 바로 드러나는 두 가지 규칙이 있습니다.
+
+- `sql.Open`은 보통 프로세스 전체에서 오래 살아야 하는 pool handle을 반환합니다.
+- query lifetime은 request마다 다시 제한해야 합니다.
+
+## Mental model
+
+`sql.DB`는 몇 가지 움직이는 부품을 같이 관리합니다.
+
+- idle connection,
+- 열려 있거나 열리는 중인 connection 수,
+- 풀이 가득 찼을 때 기다리는 waiter,
+- opener goroutine,
+- idle time과 lifetime 만료를 정리하는 cleaner goroutine.
+
+`Conn`, `Tx`, `Rows`, `Stmt`는 소유권을 더 좁힙니다.
+
+- `Conn`은 하나의 physical connection을 pin하고,
+- `Tx`는 transaction 동안 connection을 붙잡고,
+- `Rows`는 반드시 닫혀야 자원이 풀리며,
+- `Stmt`는 concurrent하게 쓸 수 있어도 driver-side state를 가집니다.
+
+## 단순화한 내부 코드 예시
+
+```go
+type DB struct {
+	mu           sync.Mutex
+	freeConn     []*driverConn
+	numOpen      int
+	maxOpen      int
+	maxIdleCount int
+	openerCh     chan struct{}
+	waitCount    int64
+	maxLifetime  time.Duration
+	maxIdleTime  time.Duration
+}
+
+func (db *DB) conn(ctx context.Context) (*driverConn, error) {
+	if c := takeIdle(db.freeConn); c != nil {
+		return c, nil
+	}
+	if db.maxOpen > 0 && db.numOpen >= db.maxOpen {
+		return waitForReturnedConnOrContext(ctx)
+	}
+	return openNewConn(ctx)
+}
+
+func (db *DB) putConn(c *driverConn, err error) {
+	if bad(err) || expired(c) {
+		c.Close()
+		return
+	}
+	if waiter := takeWaitingRequest(); waiter != nil {
+		waiter <- c
+		return
+	}
+	db.freeConn = append(db.freeConn, c)
+}
+```
+
+핵심 모양은 단순합니다. 가능하면 재사용하고, cap에 걸리면 기다리고, 열 수 있으면 열고, 반환은 신중하게 처리합니다.
+
+## 소스 코드에서 봐야 할 지점
+
+Go 1.26 소스에서:
+
+- `DB`는 idle connection, waiter 상태, open count, pool limit을 저장합니다.
+- `OpenDB`는 즉시 `connectionOpener` goroutine을 띄웁니다.
+- `conn`은 idle reuse를 우선하고, 아니면 기다리거나 새로 엽니다.
+- `putConn`은 waiter를 깨우거나 idle pool에 돌려보내거나, bad/expired connection을 닫습니다.
+- `connectionCleaner`는 idle time과 max lifetime 기준으로 정리합니다.
+
+핵심 진입점:
+
+- [`sql.go` `DB`](https://github.com/golang/go/blob/go1.26.0/src/database/sql/sql.go#L507)
+- [`sql.go` `Open`](https://github.com/golang/go/blob/go1.26.0/src/database/sql/sql.go#L863)
+- [`sql.go` `connectionOpener`](https://github.com/golang/go/blob/go1.26.0/src/database/sql/sql.go#L1259)
+- [`sql.go` `conn`](https://github.com/golang/go/blob/go1.26.0/src/database/sql/sql.go#L1316)
+- [`sql.go` `putConn`](https://github.com/golang/go/blob/go1.26.0/src/database/sql/sql.go#L1481)
+- [`sql.go` `Tx`](https://github.com/golang/go/blob/go1.26.0/src/database/sql/sql.go#L2166)
+- [`sql.go` `Rows`](https://github.com/golang/go/blob/go1.26.0/src/database/sql/sql.go#L2929)
+
+## pool 설정이 실제로 의미하는 것
+
+### `SetMaxOpenConns`
+
+데이터베이스를 향한 hard parallelism cap입니다.
+
+너무 낮으면 애플리케이션에서 요청이 줄 서고, 너무 높으면 데이터베이스가 병목이 됩니다.
+
+### `SetMaxIdleConns`
+
+얼마나 많은 warm capacity를 유지할지 정합니다.
+
+너무 낮으면 자주 재연결하고, 너무 높으면 필요 이상으로 서버 자원을 붙잡습니다.
+
+### `SetConnMaxLifetime`, `SetConnMaxIdleTime`
+
+이건 throughput 기능이 아니라 hygiene 기능입니다.
+
+- 너무 오래 사는 connection을 재순환시키고,
+- stale server-side state 위험을 줄이고,
+- idle retention을 무한정 늘리지 않게 합니다.
+
+## 실패 패턴
+
+### 요청마다 새 `sql.DB` 생성
+
+```go
+func handle(w http.ResponseWriter, r *http.Request) {
+	db, _ := sql.Open("pgx", dsn) // bug: 요청 하나를 위한 새 pool
+	defer db.Close()
+}
+```
+
+pooling을 망가뜨리고, 불필요한 connection churn을 만듭니다.
+
+### rows를 닫지 않음
+
+```go
+rows, err := db.QueryContext(ctx, query)
+if err != nil {
+	return err
+}
+return scanAll(rows) // rows를 닫지 않음
+```
+
+`Rows.Close`를 호출하거나 iteration을 끝까지 비우기 전까지 connection이 예상보다 오래 pin될 수 있습니다.
+
+### transaction 안에서 느린 외부 작업 수행
+
+```go
+tx, _ := db.BeginTx(ctx, nil)
+defer tx.Rollback()
+
+callSlowExternalAPI()
+```
+
+transaction은 대개 connection 하나를 pin합니다. transaction 내부에 느린 작업을 넣으면 풀의 실효 용량이 줄어듭니다.
+
+### context cancellation이 항상 서버 쿼리를 중단한다고 가정
+
+드라이버가 context cancellation을 지원하지 않으면 쿼리가 끝날 때까지 돌아오지 않을 수 있습니다. 패키지 문서도 이 점을 명시합니다.
+
+### `DB.Stats`를 보지 않음
+
+`WaitCount`, `WaitDuration`, `OpenConnections`, `InUse`, `Idle`를 한 번도 안 본다면, 풀 압력을 추측으로만 판단하고 있는 셈입니다.
+
+## 프로덕션에서의 의미
+
+- 보통 프로세스마다 DSN과 policy boundary별로 long-lived `*sql.DB` 하나가 필요합니다.
+- query context는 바깥 request budget보다 짧거나 같아야지 더 길면 안 됩니다.
+- transaction scope는 가능한 한 좁게 유지합니다.
+- pool 설정은 애플리케이션 단독 결정이 아니라 데이터베이스 용량과의 조율 문제입니다.
+
+## 어떻게 테스트/관측할까
+
+- handler가 `Rows`를 닫고 실패한 transaction을 rollback하는지 검증합니다.
+- 아주 작은 `MaxOpenConns`로 integration test를 돌려 waiter behavior를 강제로 드러냅니다.
+- load test 중 `DB.Stats()`를 확인해 latency가 pool wait인지 query execution time인지 구분합니다.
+- 드라이버별 cancellation 동작은 추측하지 말고 직접 테스트합니다.
+
+## 공식 자료
+
+- [`database/sql` 패키지 문서](https://pkg.go.dev/database/sql)
+- [Go SQL drivers overview](https://golang.org/s/sqldrivers)
+- [Go wiki: SQLInterface](https://tip.golang.org/wiki/SQLInterface)
+- [Go 1.26 `database/sql` 소스](https://github.com/golang/go/blob/go1.26.0/src/database/sql/sql.go)
+
+## Practical takeaway
+
+`sql.DB`를 convenience handle이 아니라 shared concurrency governor로 취급하면, 많은 데이터베이스 지연 문제를 프로덕션 전에 더 일찍 볼 수 있습니다.

--- a/docs/ko/stdlib/index.md
+++ b/docs/ko/stdlib/index.md
@@ -1,0 +1,55 @@
+---
+title: 표준 라이브러리 개요
+description: 실전 Go 서비스의 동시성, 수명 관리, I/O, 시간을 결정하는 표준 라이브러리 패키지를 설명합니다.
+---
+
+# 표준 라이브러리 개요
+
+프로덕션 Go 서비스는 커스텀 동시성 헬퍼보다 표준 라이브러리 안에서 더 많은 시간을 보냅니다.
+
+이 섹션은 실제 시스템의 동작을 조용히 결정하는 패키지에 집중합니다.
+
+- `context`: 수명 관리와 취소 전파
+- `net/http`: 서버와 클라이언트 I/O
+- `database/sql`: 풀링과 역압력
+- `time`: deadline, retry, timer correctness
+
+## 이 섹션이 다루는 것
+
+<div class="path-grid">
+  <div class="path-card">
+    <h3><a href="/ko/stdlib/context-internals">context</a></h3>
+    <p>cancellation tree, `cancelCtx`, `timerCtx`, `valueCtx`, `Cause`, 그리고 request 작업을 leak시키는 실수를 봅니다.</p>
+  </div>
+  <div class="path-card">
+    <h3><a href="/ko/stdlib/net-http-server-transport">net/http</a></h3>
+    <p>서버 connection 모델, request lifetime, transport pool, keep-alive reuse, timeout boundary를 이해합니다.</p>
+  </div>
+  <div class="path-card">
+    <h3><a href="/ko/stdlib/database-sql-pool">database/sql</a></h3>
+    <p>`sql.DB`가 왜 pool인지, waiter와 cleaner가 어떻게 동작하는지, cancellation과 pool sizing이 어디서 깨지는지 설명합니다.</p>
+  </div>
+  <div class="path-card">
+    <h3><a href="/ko/stdlib/time-timers-tickers">time</a></h3>
+    <p>monotonic time, timers, tickers, `Stop`/`Reset`, retry loop를 안전하게 다루는 mental model을 잡습니다.</p>
+  </div>
+</div>
+
+## 추천 읽기 순서
+
+1. 먼저 [context](/ko/stdlib/context-internals)를 읽습니다. lifetime ownership이 이 섹션의 나머지 주제 전부에 영향을 주기 때문입니다.
+2. 다음으로 [time, timers, tickers](/ko/stdlib/time-timers-tickers)를 읽습니다. deadline과 retry는 시간 모델이 정확해야 안전합니다.
+3. 그 다음 [net/http 서버와 transport 내부](/ko/stdlib/net-http-server-transport)를 읽습니다. 여기서 context와 timer가 실제 네트워크 I/O와 만납니다.
+4. 마지막으로 [database/sql pool 내부](/ko/stdlib/database-sql-pool)를 읽습니다. 여기서는 cancellation, waiting, resource limit이 운영 문제로 드러납니다.
+
+## 읽고 나면 답할 수 있어야 하는 질문
+
+- 왜 `cancel()`을 빠뜨리면 timer만이 아니라 더 많은 것이 leak되는가?
+- 왜 `http.Client`는 response body 처리를 잘못하면 reuse가 무너지는가?
+- 왜 `sql.DB`는 per-request 객체가 아니라 long-lived shared handle인가?
+- 왜 `time.Time`은 wall-clock과 monotonic reading을 같이 들고 있는가?
+- 왜 Go 1.23의 timer channel semantics 변화가 중요한가?
+
+## Practical takeaway
+
+기초 원리가 Go 동시성이 왜 가능한지 설명한다면, 이 섹션은 실제 프로덕션 Go 코드가 그 동시성을 어떻게 매일 표현하는지 설명합니다.

--- a/docs/ko/stdlib/net-http-server-transport.md
+++ b/docs/ko/stdlib/net-http-server-transport.md
@@ -1,0 +1,231 @@
+---
+title: net/http 서버와 Transport 내부
+description: Go 표준 HTTP 서버와 클라이언트 transport가 goroutine, deadline, connection reuse와 어떻게 연결되는지 설명합니다.
+---
+
+# net/http 서버와 Transport 내부
+
+`net/http`는 많은 Go 서비스가 동시성 예산의 대부분을 쓰는 곳입니다.
+
+이 패키지가 잘 동작하는 이유는, 런타임이 blocking network I/O를 direct style로 표현할 수 있을 만큼 싸게 만들어 주고, 패키지 자체는 connection ownership, keep-alive reuse, request lifetime을 관리하기 때문입니다.
+
+## 왜 이 패키지가 중요한가
+
+Go 서비스를 운영한다면 거의 항상 다음에 의존합니다.
+
+- inbound request마다 하나의 goroutine tree,
+- outbound dependency마다 하나의 transport pool,
+- request-scoped context cancellation,
+- 요청마다 TCP를 새로 여는 대신 connection reuse.
+
+이 경계를 잘못 이해하면 시스템은 부하에서 느려지고, leak되고, 예측하기 어려워집니다.
+
+## 전체 mental model
+
+```mermaid
+flowchart LR
+    A["Listener accept loop"] --> B["Server connection goroutine"]
+    B --> C["Request context"]
+    C --> D["Handler tree"]
+    D --> E["Outbound http.Client"]
+    E --> F["Transport"]
+    F --> G["Idle pool / persistConn"]
+    G --> H["readLoop / writeLoop"]
+```
+
+서버 쪽에서 `net/http`는 socket을 handler 실행으로 바꾸고,
+
+클라이언트 쪽에서 `Transport`는 요청을 pooled reusable connection으로 바꿉니다.
+
+둘 다 결국 lifetime 문제의 양쪽 절반입니다.
+
+## 실전 코드 스케치
+
+```go
+srv := &http.Server{
+	Addr:              ":8080",
+	Handler:           mux,
+	ReadHeaderTimeout: 2 * time.Second,
+	WriteTimeout:      10 * time.Second,
+	IdleTimeout:       60 * time.Second,
+	BaseContext: func(net.Listener) context.Context {
+		return appCtx
+	},
+}
+
+transport := &http.Transport{
+	MaxIdleConns:          256,
+	MaxIdleConnsPerHost:   64,
+	MaxConnsPerHost:       128,
+	IdleConnTimeout:       90 * time.Second,
+	ResponseHeaderTimeout: 2 * time.Second,
+}
+
+client := &http.Client{
+	Transport: transport,
+	Timeout:   3 * time.Second,
+}
+```
+
+여기서 중요한 건 필드 수가 아닙니다. lifetime과 budget을 코드에 명시했다는 점입니다.
+
+## 서버 쪽 mental model
+
+서버는 “전역 handler goroutine 하나”가 아닙니다.
+
+대략 이런 흐름입니다.
+
+1. connection accept,
+2. server/connection context 부착,
+3. request 읽기,
+4. handler 실행,
+5. keep-alive 여부 판단,
+6. 반복 또는 종료.
+
+HTTP/1.x에서는 connection 재사용이 직렬적으로 더 잘 드러나고, HTTP/2에서는 multiplexing 때문에 모양이 달라지지만 lifetime과 deadline 문제는 그대로 남습니다.
+
+## 단순화한 내부 코드 예시
+
+```go
+type Server struct {
+	Handler           Handler
+	ReadHeaderTimeout time.Duration
+	WriteTimeout      time.Duration
+	IdleTimeout       time.Duration
+	BaseContext       func(net.Listener) context.Context
+	ConnContext       func(context.Context, net.Conn) context.Context
+}
+
+type Transport struct {
+	idleMu           sync.Mutex
+	idleConn         map[connectMethodKey][]*persistConn
+	reqCanceler      map[*Request]context.CancelCauseFunc
+	connsPerHost     map[connectMethodKey]int
+	connsPerHostWait map[connectMethodKey]wantConnQueue
+}
+
+type persistConn struct {
+	conn net.Conn
+	// 한 goroutine은 응답을 읽고
+	// 한 goroutine은 요청을 쓴다
+}
+```
+
+실제 구현은 더 복잡하지만 설계 압력은 이미 드러납니다.
+
+- 서버 필드는 timeout과 ownership boundary를 정의하고,
+- transport 필드는 pooling과 cancellation boundary를 정의하며,
+- `persistConn`은 실제 요청이 흐르는 reusable connection 객체입니다.
+
+## 소스 코드에서 봐야 할 지점
+
+### 서버 쪽
+
+`Server` 타입에는 다음이 들어 있습니다.
+
+- `ReadHeaderTimeout`, `ReadTimeout`, `WriteTimeout`, `IdleTimeout`
+- `BaseContext`, `ConnContext`
+- shutdown과 active connection bookkeeping
+
+이건 장식 옵션이 아니라 inbound traffic의 운영 계약입니다.
+
+읽을 만한 진입점:
+
+- [`server.go` `Server`](https://github.com/golang/go/blob/go1.26.0/src/net/http/server.go#L2964)
+- [`server.go` `Serve`](https://github.com/golang/go/blob/go1.26.0/src/net/http/server.go#L3444)
+
+### 클라이언트 쪽
+
+`http.Client`는 얇은 래퍼이고, 실제 동시성 동작은 대부분 `Transport`에 있습니다.
+
+- idle connection map
+- per-host connection limit
+- request cancellation bookkeeping
+- dial/handshake timeout
+- `persistConn` read/write loop
+
+읽을 만한 진입점:
+
+- [`transport.go` `Transport`](https://github.com/golang/go/blob/go1.26.0/src/net/http/transport.go#L97)
+- [`transport.go` `roundTrip`](https://github.com/golang/go/blob/go1.26.0/src/net/http/transport.go#L590)
+- [`transport.go` `persistConn`](https://github.com/golang/go/blob/go1.26.0/src/net/http/transport.go#L2115)
+- [`transport.go` `readLoop`](https://github.com/golang/go/blob/go1.26.0/src/net/http/transport.go#L2291)
+- [`transport.go` `writeLoop`](https://github.com/golang/go/blob/go1.26.0/src/net/http/transport.go#L2649)
+
+## Response body ownership도 동시성 문제다
+
+아주 흔한 실수입니다.
+
+```go
+resp, err := client.Do(req)
+if err != nil {
+	return err
+}
+defer resp.Body.Close()
+```
+
+body를 닫는 건 단순 cleanup 예절이 아닙니다.
+
+transport가 connection을 안전하게 재사용할 수 있는지 판단하는 핵심 신호입니다. 여기서 실수하면 pool이 connection을 재활용하지 못하고 계속 churn합니다.
+
+## 실패 패턴
+
+### 프로덕션 hot path에서 `http.Get` 사용
+
+```go
+resp, err := http.Get(url)
+```
+
+이 코드는 transport 설정, timeout 정책, per-host limit, proxy 동작, connection budget을 읽는 사람에게 숨깁니다. 스크립트에는 괜찮아도 서비스 경계에는 부족합니다.
+
+### response body를 닫지 않음
+
+```go
+resp, err := client.Do(req)
+if err != nil {
+	return err
+}
+return decode(resp.Body) // leak: body를 닫지 않음
+```
+
+이러면 connection reuse가 깨지고 socket/file descriptor가 고갈될 수 있습니다.
+
+### timeout knob 하나로 충분하다고 생각
+
+`Client.Timeout`, transport header timeout, request context deadline, server-side read/write timeout은 서로 다른 경계를 다룹니다.
+
+보통은 하나의 거대한 timeout보다, 의도된 조합이 필요합니다.
+
+### `TimeoutHandler`를 전체 제어 수단으로 착각
+
+`TimeoutHandler`는 거친 래퍼입니다. 응답 시간을 제한하는 데 도움이 되지만, handler 내부의 context discipline, outbound deadline, shutdown 설계를 대체하진 못합니다.
+
+### 요청마다 새 transport 생성
+
+pooling을 버리고 dial churn을 늘려서, 대개 latency와 자원 사용을 모두 악화시킵니다.
+
+## 프로덕션에서의 의미
+
+- request마다가 아니라 policy boundary마다 하나의 long-lived `Transport`를 둡니다.
+- hot code에서 ad hoc client를 만들지 말고, transport policy마다 `http.Client`를 재사용합니다.
+- 서버, request, transport 레이어 각각에 timeout을 명시합니다.
+- handler와 outbound call에서 request context cancellation을 first-class signal로 취급합니다.
+- code review에서 body close discipline을 mutex ownership만큼 진지하게 봐야 합니다.
+
+## 어떻게 테스트/관측할까
+
+- `httptest.Server`와 느린 handler를 이용해 client timeout을 검증합니다.
+- `Server.Shutdown`과 in-flight request로 graceful shutdown을 검증합니다.
+- reuse, dial timing, connection setup이 궁금하면 `httptrace`를 씁니다.
+- handler CPU가 아니라 connection churn이 의심되면 runtime trace나 socket-level metric을 봅니다.
+
+## 공식 자료
+
+- [`net/http` 패키지 문서](https://pkg.go.dev/net/http)
+- [`net/http/httptrace` 패키지 문서](https://pkg.go.dev/net/http/httptrace)
+- [Go 1.26 `net/http` server 소스](https://github.com/golang/go/blob/go1.26.0/src/net/http/server.go)
+- [Go 1.26 `net/http` transport 소스](https://github.com/golang/go/blob/go1.26.0/src/net/http/transport.go)
+
+## Practical takeaway
+
+`net/http`는 단순한 편의 API가 아닙니다. Go 런타임, deadline, connection reuse 정책이 실제 프로덕션 동작으로 드러나는 핵심 경계입니다.

--- a/docs/ko/stdlib/time-timers-tickers.md
+++ b/docs/ko/stdlib/time-timers-tickers.md
@@ -1,0 +1,199 @@
+---
+title: time, Timers, Tickers
+description: Go가 monotonic time, timer channel, ticker loop, deadline correctness를 어떻게 모델링하는지 설명합니다.
+---
+
+# time, Timers, Tickers
+
+시간 버그는 동시성 버그인데 더 그럴듯하게 숨어 있을 뿐입니다.
+
+retry, deadline, shutdown, backoff, request budget, idle cleanup은 모두 시간 의미론을 정확히 이해해야 안전합니다.
+
+## 왜 이 패키지가 중요한가
+
+`time`은 단순히 포맷팅과 sleep만 담당하지 않습니다.
+
+이 패키지는:
+
+- deadline을 어떻게 재는지,
+- timer가 어떻게 작업을 다시 깨우는지,
+- 주기 작업을 어떻게 스케줄하는지,
+- wall time과 monotonic time이 어떻게 섞이는지
+
+를 정의합니다.
+
+여기서 실수하면 cancellation은 시끄러워지고, retry loop는 드리프트하고, shutdown 로직은 flaky해집니다.
+
+## 예제 시나리오
+
+```mermaid
+flowchart LR
+    A["retry loop"] --> B["Timer.Reset(backoff)"]
+    B --> C["runtime timer heap"]
+    C --> D["timer fires"]
+    D --> E["outbound call 시도"]
+    E --> F["성공하면 backoff 초기화"]
+    E --> G["실패하면 backoff 증가"]
+```
+
+## 실전 코드 스케치
+
+```go
+timer := time.NewTimer(0)
+defer timer.Stop()
+
+backoff := 100 * time.Millisecond
+
+for {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		if err := syncOnce(ctx); err != nil {
+			backoff = min(backoff*2, 2*time.Second)
+		} else {
+			backoff = 100 * time.Millisecond
+		}
+		timer.Reset(backoff)
+	}
+}
+```
+
+loop가 timer lifecycle을 소유하고 명시적으로 reset해야 할 때 선호할 만한 모양입니다.
+
+## Mental model
+
+세 가지가 특히 중요합니다.
+
+1. `time.Time`은 wall-clock 데이터를 들고 있고, 경우에 따라 monotonic reading도 같이 가집니다.
+2. `Timer`는 미래의 한 번의 이벤트를 예약합니다.
+3. `Ticker`는 반복 이벤트를 예약합니다.
+
+핵심은 wall-clock은 “현재 시각”을 말하는 데 쓰이고, monotonic time은 “경과 시간”을 재는 데 쓰인다는 점입니다.
+
+그래서 `time.Since(start)`가 서로 다른 프로세스에서 직렬화된 timestamp를 빼는 것보다 안전합니다.
+
+## 단순화한 내부 코드 예시
+
+```go
+type Time struct {
+	wall uint64
+	ext  int64
+	loc  *Location
+}
+
+type Timer struct {
+	C <-chan time.Time
+}
+
+func After(d time.Duration) <-chan time.Time {
+	return NewTimer(d).C
+}
+
+func retryLoop(ctx context.Context, timer *time.Timer) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-timer.C:
+			// 작업 후 timer.Reset(nextDelay)
+		}
+	}
+}
+```
+
+저수준 timer machinery는 runtime이 담당하고, `time` 패키지는 일반 Go 코드에 맞는 API 모양으로 감쌉니다.
+
+## 소스 코드에서 봐야 할 지점
+
+Go 1.26 소스에서 중요한 점은 이렇습니다.
+
+- `Time`은 wall-clock과 optional monotonic data를 `wall`, `ext`에 인코딩합니다.
+- `NewTimer`와 `AfterFunc`는 둘 다 runtime timer 생성으로 위임합니다.
+- Go 1.23부터 timer channel은 synchronous semantics를 가지며, unreferenced timer는 GC가 회수할 수 있습니다.
+- `Ticker`는 반복 timer이므로, owner가 끝날 때 여전히 명시적 `Stop`이 필요합니다.
+
+읽을 만한 진입점:
+
+- [`time.go` `Time`](https://github.com/golang/go/blob/go1.26.0/src/time/time.go#L140)
+- [`sleep.go` `Timer`](https://github.com/golang/go/blob/go1.26.0/src/time/sleep.go#L89)
+- [`sleep.go` `NewTimer`](https://github.com/golang/go/blob/go1.26.0/src/time/sleep.go#L143)
+- [`sleep.go` `After`](https://github.com/golang/go/blob/go1.26.0/src/time/sleep.go#L202)
+- [`sleep.go` `AfterFunc`](https://github.com/golang/go/blob/go1.26.0/src/time/sleep.go#L210)
+- [`tick.go` `Ticker`](https://github.com/golang/go/blob/go1.26.0/src/time/tick.go#L16)
+
+## 현대 Go에서 달라진 점
+
+최근 버전에서 가장 중요한 timer semantic 변화는 Go 1.23입니다.
+
+- unreferenced timer를 GC가 회수할 수 있고,
+- timer channel이 synchronous하게 동작하며,
+- `Stop` 또는 `Reset` 뒤의 stale timer value 문제가 기본 동작에서 크게 줄었습니다.
+
+즉, 과거의 “항상 drain해야 한다”는 timer folklore는 Go 버전을 고려해서 읽어야 합니다.
+
+## 실패 패턴
+
+### hot loop에서 ownership 없이 `time.After` 사용
+
+```go
+for {
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(100 * time.Millisecond):
+		poll()
+	}
+}
+```
+
+짧지만 매 iteration마다 새 timer를 만듭니다. hot loop나 adaptive backoff에는 재사용 가능한 `Timer`가 더 잘 맞는 경우가 많습니다.
+
+### ticker를 멈추지 않음
+
+```go
+ticker := time.NewTicker(5 * time.Second)
+go func() {
+	for range ticker.C {
+		refresh()
+	}
+}()
+```
+
+누가 이 ticker의 shutdown을 소유하는지 없으면, goroutine과 periodic wakeup이 기능 lifetime을 넘어 계속 살아남을 수 있습니다.
+
+### `time.Time`을 `==`로 비교
+
+`==`는 instant만 비교하지 않습니다. location과 monotonic metadata까지 비교합니다. “같은 순간”을 의미할 때는 `Equal`을 쓰는 게 맞습니다.
+
+### 직렬화된 시간이 monotonic 데이터를 유지한다고 가정
+
+`MarshalJSON`, `Unix`, `Parse` 등은 monotonic reading을 보존하지 않습니다. 그래서 elapsed-time 계산은 대체로 같은 프로세스 안에서 해야 안전합니다.
+
+### timer ownership 없이 여러 goroutine이 Reset/Stop
+
+여러 goroutine이 같은 timer를 stop, drain, reset하고 있다면 문제는 API 문법보다 ownership 설계입니다.
+
+## 프로덕션에서의 의미
+
+- elapsed-time 추론에는 `Since`, `Until`, context deadline처럼 monotonic time 기반 API를 선호합니다.
+- adaptive retry loop에는 owner가 분명한 `Timer` 하나를 재사용합니다.
+- `Ticker`는 “작업이 끝난 뒤 다시 기다리기”가 아니라 “고정 주기”가 필요할 때만 씁니다.
+- 오래된 timer folklore는 현재 Go 버전과 함께 다시 검토해야 합니다.
+
+## 어떻게 테스트/관측할까
+
+- timeout 로직은 가능한 한 `testing/synctest`로 결정적 virtual time 위에서 검증합니다.
+- real sleep에 기대지 말고 backoff progression을 table test로 검증합니다.
+- ticker shutdown은 leak test로 확인합니다.
+- timer storm나 bursty wakeup이 의심되면 trace를 봅니다.
+
+## 공식 자료
+
+- [`time` 패키지 문서](https://pkg.go.dev/time)
+- [Go 1.26 `time` 소스](https://github.com/golang/go/blob/go1.26.0/src/time)
+- [Go 1.23 release notes](https://go.dev/doc/go1.23)
+
+## Practical takeaway
+
+정확한 시간 모델은 retry, deadline, periodic work가 올바른 동시성 코드를 flaky한 프로덕션 동작으로 바꾸지 않게 막아주는 기반입니다.

--- a/docs/stdlib/context-internals.md
+++ b/docs/stdlib/context-internals.md
@@ -1,0 +1,262 @@
+---
+title: context Package Internals
+description: Learn how context cancellation, deadlines, causes, and values work inside the standard library.
+---
+
+# context Package Internals
+
+Many Go concurrency failures are not caused by goroutines themselves.
+
+They are caused by work that no longer has a valid owner but keeps running anyway.
+
+The `context` package is Go's main answer to that problem.
+
+## Why this package exists
+
+`context` gives one operation tree a shared lifetime:
+
+- a request can expire,
+- a parent can cancel child work,
+- deadlines can stop I/O or database waits,
+- request-scoped metadata can flow through the call graph.
+
+Without that shared lifetime, concurrent code tends to turn into detached work plus cleanup bugs.
+
+## Example scenario
+
+```mermaid
+flowchart LR
+    A["Incoming request context"] --> B["WithTimeoutCause"]
+    B --> C1["Load pricing"]
+    B --> C2["Load inventory"]
+    B --> C3["Load shipping quote"]
+    C1 --> D["results channel"]
+    C2 --> D
+    C3 --> D
+    D --> E["compose response"]
+    B --> F["deadline fires or caller cancels"]
+    F --> C1
+    F --> C2
+    F --> C3
+```
+
+## Production sketch
+
+```go
+func (svc CheckoutService) Quote(ctx context.Context, sku string) (Quote, error) {
+	ctx, cancel := context.WithTimeoutCause(ctx, 150*time.Millisecond, ErrQuoteTimeout)
+	defer cancel()
+
+	results := make(chan quoteResult, 3)
+
+	go func() { results <- svc.fetchPrice(ctx, sku) }()
+	go func() { results <- svc.fetchInventory(ctx, sku) }()
+	go func() { results <- svc.fetchShipping(ctx, sku) }()
+
+	var quote Quote
+
+	for range 3 {
+		select {
+		case <-ctx.Done():
+			return Quote{}, context.Cause(ctx)
+		case result := <-results:
+			if result.err != nil {
+				cancel()
+				return Quote{}, result.err
+			}
+			quote.Merge(result.partial)
+		}
+	}
+
+	return quote, nil
+}
+```
+
+The important part is not the syntax. It is the ownership model:
+
+- one parent lifetime,
+- many children,
+- one place that decides when the whole subtree stops.
+
+## Mental model
+
+`context` is not a scheduler and not a general-purpose bag of globals.
+
+It is a tree of derived nodes:
+
+- `cancelCtx` adds cancellation,
+- `timerCtx` adds a timer-driven deadline,
+- `valueCtx` adds one key-value pair,
+- `withoutCancelCtx` keeps values but drops cancellation.
+
+That means:
+
+- cancellation flows downward,
+- values are found by walking upward,
+- deadlines are just timed cancellation,
+- `Done()` is a shared stop signal, not a work queue.
+
+## Simplified internal sketch
+
+This is not the exact source, but it is close enough to explain the shape:
+
+```go
+type cancelCtx struct {
+	parent   context.Context
+	mu       sync.Mutex
+	done     chan struct{}
+	children map[canceler]struct{}
+	err      error
+	cause    error
+}
+
+func (c *cancelCtx) cancel(err error, cause error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.err != nil {
+		return
+	}
+
+	c.err = err
+	c.cause = cause
+
+	if c.done == nil {
+		c.done = closedChan
+	} else {
+		close(c.done)
+	}
+
+	for child := range c.children {
+		child.cancel(err, cause)
+	}
+	c.children = nil
+}
+
+type timerCtx struct {
+	cancelCtx
+	timer    *time.Timer
+	deadline time.Time
+}
+
+type valueCtx struct {
+	parent context.Context
+	key    any
+	value  any
+}
+```
+
+The real package adds atomics, lazy channel creation, and several fast paths, but the control flow above is the core idea.
+
+## Runtime source walk
+
+The Go 1.26 source is worth reading directly:
+
+- `cancelCtx` stores a lazy `done` channel, a `children` set, and the first cancellation error and cause.
+- `Err()` uses an atomic fast path because it may be called in hot loops.
+- `propagateCancel` avoids spawning a helper goroutine when it can attach the child directly to a parent `cancelCtx`.
+- `timerCtx` embeds `cancelCtx` and stops its timer during cancel.
+- `valueCtx` is just a linked chain, so deep value stacks cost linear lookup time.
+- `WithoutCancel` returns a wrapper with `Done() == nil` and `Err() == nil`, but it still forwards values.
+
+In the real source, the most important functions and types are:
+
+- [`context.go` `cancelCtx`](https://github.com/golang/go/blob/go1.26.0/src/context/context.go#L431)
+- [`context.go` `propagateCancel`](https://github.com/golang/go/blob/go1.26.0/src/context/context.go#L469)
+- [`context.go` `WithoutCancel`](https://github.com/golang/go/blob/go1.26.0/src/context/context.go#L585)
+- [`context.go` `timerCtx`](https://github.com/golang/go/blob/go1.26.0/src/context/context.go#L662)
+- [`context.go` `valueCtx`](https://github.com/golang/go/blob/go1.26.0/src/context/context.go#L742)
+
+## Newer APIs that matter
+
+### `Cause` and `WithCancelCause`
+
+If cancellation reason matters to business logic, `context.Cause` is much better than collapsing everything to `context.Canceled`.
+
+That matters when you need to distinguish:
+
+- client disconnected,
+- internal budget exhausted,
+- upstream timeout,
+- manual shutdown.
+
+### `AfterFunc`
+
+`AfterFunc` lets the context trigger cleanup or compensation work when cancellation happens:
+
+```go
+stopRollback := context.AfterFunc(ctx, func() {
+	_ = tx.Rollback()
+})
+defer stopRollback()
+```
+
+This is useful, but it is still easy to overuse. Keep the cleanup local and obvious.
+
+### `WithoutCancel`
+
+`WithoutCancel` is a narrow tool.
+
+Use it when you intentionally want to preserve values from a request while detaching from request cancellation, such as background audit logging during a graceful handoff. If you use it casually, you are usually lying about lifetime ownership.
+
+## Failure patterns
+
+### Forgetting to call `cancel`
+
+```go
+ctx, cancel := context.WithTimeout(parent, 200*time.Millisecond)
+_ = cancel // bug: timer and child reference are kept until parent cancels
+```
+
+The leak is not only the timer. The parent also keeps a reference to the child until cancellation removes it.
+
+### Replacing the request tree with `context.Background()`
+
+```go
+go svc.writeAuditLog(context.Background(), event) // detached from caller and shutdown
+```
+
+This silently discards request lifetime, shutdown propagation, and budget control.
+
+### Treating values as optional parameters
+
+```go
+ctx = context.WithValue(ctx, "retries", 3)
+ctx = context.WithValue(ctx, "region", "eu-west-1")
+ctx = context.WithValue(ctx, "debug", true)
+```
+
+This is weakly typed, easy to abuse, and makes the call contract harder to read.
+
+### Deep value chains in hot paths
+
+Every `WithValue` adds another node. `Value` lookup walks the chain. That usually does not matter once or twice, but it is not free inside hot middleware or RPC paths.
+
+### Assuming cancellation kills arbitrary work immediately
+
+Cancellation closes `Done()`. It does not preempt CPU loops or magically stop libraries that ignore the context.
+
+## Production consequences
+
+- Context trees are cheap enough to use per request, but not free enough to spray without ownership discipline.
+- Missing `cancel()` calls show up as timer retention, child retention, and muddy shutdown behavior.
+- `Cause` is valuable for observability because `ctx.Err()` loses detail.
+- A `context.Context` should almost always be the first function parameter, not a field on a struct.
+
+## How to test and observe it
+
+- Use short deadlines in tests and assert `context.DeadlineExceeded` or `context.Cause`.
+- Verify that child goroutines exit on parent cancellation instead of only checking return values.
+- Add leak tests around request abort, timeout, and shutdown paths.
+- Use traces or metrics around timeout causes if many operations converge on one budget.
+
+## Official reading
+
+- [Package docs for `context`](https://pkg.go.dev/context)
+- [Go blog: Context](https://go.dev/blog/context)
+- [Go blog: Contexts and structs](https://go.dev/blog/context-and-structs)
+- [Go 1.26 `context` source](https://github.com/golang/go/blob/go1.26.0/src/context/context.go)
+
+## Practical takeaway
+
+If you treat `context` as a lifetime tree instead of just a parameter to satisfy APIs, a large class of goroutine leaks and shutdown bugs becomes easier to reason about.

--- a/docs/stdlib/database-sql-pool.md
+++ b/docs/stdlib/database-sql-pool.md
@@ -1,0 +1,238 @@
+---
+title: database/sql Pool Internals
+description: Learn how sql.DB manages pooling, waiting, lifetimes, and cancellation boundaries in production Go systems.
+---
+
+# database/sql Pool Internals
+
+The biggest `database/sql` misconception is simple:
+
+`sql.DB` is not one connection. It is a concurrent pool manager.
+
+If you miss that, you will size it badly, close it at the wrong time, or accidentally turn query pressure into system-wide latency.
+
+## Why this package matters
+
+In production, database concurrency is rarely limited by goroutines.
+
+It is limited by:
+
+- pool size,
+- driver behavior,
+- transaction lifetime,
+- query duration,
+- cancellation support,
+- cleanup discipline for rows and statements.
+
+`database/sql` is where those concerns are centralized.
+
+## Example scenario
+
+```mermaid
+flowchart LR
+    A["Incoming request"] --> B["sql.DB pool"]
+    B --> C["idle connections"]
+    B --> D["open new connection"]
+    B --> E["waiter queue"]
+    C --> F["QueryContext"]
+    D --> F
+    E --> F
+    F --> G["Rows / Tx / Conn"]
+    G --> H["Close / Commit / Rollback returns capacity"]
+```
+
+## Production sketch
+
+```go
+db, err := sql.Open("pgx", dsn)
+if err != nil {
+	return err
+}
+
+db.SetMaxOpenConns(64)
+db.SetMaxIdleConns(16)
+db.SetConnMaxIdleTime(5 * time.Minute)
+db.SetConnMaxLifetime(30 * time.Minute)
+
+ctx, cancel := context.WithTimeout(r.Context(), 200*time.Millisecond)
+defer cancel()
+
+rows, err := db.QueryContext(ctx, query, tenantID)
+if err != nil {
+	return err
+}
+defer rows.Close()
+```
+
+Two rules matter immediately:
+
+- `sql.Open` returns a pool handle that should usually live for the whole process,
+- query lifetime must still be bounded per request.
+
+## Mental model
+
+`sql.DB` owns several moving pieces:
+
+- free idle connections,
+- the count of open and opening connections,
+- waiters that block when the pool is full,
+- an opener goroutine,
+- a cleaner goroutine for idle-time and lifetime expiry.
+
+`Conn`, `Tx`, `Rows`, and `Stmt` narrow ownership further:
+
+- `Conn` pins one physical connection,
+- `Tx` pins a connection for the whole transaction,
+- `Rows` must be closed to release resources,
+- `Stmt` can be concurrent, but still holds driver-side state.
+
+## Simplified internal sketch
+
+```go
+type DB struct {
+	mu           sync.Mutex
+	freeConn     []*driverConn
+	numOpen      int
+	maxOpen      int
+	maxIdleCount int
+	openerCh     chan struct{}
+	waitCount    int64
+	maxLifetime  time.Duration
+	maxIdleTime  time.Duration
+}
+
+func (db *DB) conn(ctx context.Context) (*driverConn, error) {
+	if c := takeIdle(db.freeConn); c != nil {
+		return c, nil
+	}
+	if db.maxOpen > 0 && db.numOpen >= db.maxOpen {
+		return waitForReturnedConnOrContext(ctx)
+	}
+	return openNewConn(ctx)
+}
+
+func (db *DB) putConn(c *driverConn, err error) {
+	if bad(err) || expired(c) {
+		c.Close()
+		return
+	}
+	if waiter := takeWaitingRequest(); waiter != nil {
+		waiter <- c
+		return
+	}
+	db.freeConn = append(db.freeConn, c)
+}
+```
+
+That is the shape to remember: reuse if possible, wait if capped, open if allowed, return carefully.
+
+## Source walk
+
+In the Go 1.26 source:
+
+- `DB` stores idle connections, waiter state, open counts, and pool limits.
+- `OpenDB` launches a `connectionOpener` goroutine immediately.
+- `conn` prefers idle reuse, otherwise waits or opens.
+- `putConn` either satisfies a waiter, returns to idle, or closes bad/expired connections.
+- `connectionCleaner` trims by idle time and max lifetime.
+
+The key source entry points are:
+
+- [`sql.go` `DB`](https://github.com/golang/go/blob/go1.26.0/src/database/sql/sql.go#L507)
+- [`sql.go` `Open`](https://github.com/golang/go/blob/go1.26.0/src/database/sql/sql.go#L863)
+- [`sql.go` `connectionOpener`](https://github.com/golang/go/blob/go1.26.0/src/database/sql/sql.go#L1259)
+- [`sql.go` `conn`](https://github.com/golang/go/blob/go1.26.0/src/database/sql/sql.go#L1316)
+- [`sql.go` `putConn`](https://github.com/golang/go/blob/go1.26.0/src/database/sql/sql.go#L1481)
+- [`sql.go` `Tx`](https://github.com/golang/go/blob/go1.26.0/src/database/sql/sql.go#L2166)
+- [`sql.go` `Rows`](https://github.com/golang/go/blob/go1.26.0/src/database/sql/sql.go#L2929)
+
+## What pool settings really mean
+
+### `SetMaxOpenConns`
+
+This is your hard parallelism cap against the database.
+
+Too low and requests pile up in the application. Too high and the database becomes the bottleneck instead.
+
+### `SetMaxIdleConns`
+
+This controls how much warm capacity you keep.
+
+Too low and the service redials often. Too high and the app holds more server resources than needed.
+
+### `SetConnMaxLifetime` and `SetConnMaxIdleTime`
+
+These are not throughput features. They are hygiene features:
+
+- rebalance long-lived connections,
+- reduce risk from stale server-side state,
+- avoid unbounded idle retention.
+
+## Failure patterns
+
+### Opening a new `sql.DB` per request
+
+```go
+func handle(w http.ResponseWriter, r *http.Request) {
+	db, _ := sql.Open("pgx", dsn) // bug: new pool for one request
+	defer db.Close()
+}
+```
+
+That defeats pooling and creates avoidable connection churn.
+
+### Forgetting to close rows
+
+```go
+rows, err := db.QueryContext(ctx, query)
+if err != nil {
+	return err
+}
+return scanAll(rows) // rows never closed
+```
+
+Until `Rows.Close` happens or iteration drains fully, the connection may stay pinned longer than expected.
+
+### Holding transactions open across unrelated work
+
+```go
+tx, _ := db.BeginTx(ctx, nil)
+defer tx.Rollback()
+
+callSlowExternalAPI()
+```
+
+A transaction usually pins one connection. Slow work inside the transaction shrinks effective pool capacity.
+
+### Assuming context cancellation always aborts the query on the server
+
+Drivers that do not support context cancellation may not return until the query completes. The package docs state this explicitly.
+
+### Ignoring `DB.Stats`
+
+If you never inspect `WaitCount`, `WaitDuration`, `OpenConnections`, `InUse`, and `Idle`, you are guessing about pool pressure.
+
+## Production consequences
+
+- One process usually needs one long-lived `*sql.DB` per distinct DSN and policy boundary.
+- Query contexts should be shorter than the outer request budget, not longer.
+- Transaction scope should be kept as narrow as possible.
+- Pool configuration is a coordination problem with database capacity, not an app-only decision.
+
+## How to test and observe it
+
+- Assert that handlers close `Rows` and roll back failed transactions.
+- Use integration tests with a deliberately tiny `MaxOpenConns` to exercise waiter behavior.
+- Inspect `DB.Stats()` during load tests to confirm whether latency is pool wait or database execution time.
+- Test driver-specific cancellation behavior explicitly instead of assuming it works.
+
+## Official reading
+
+- [Package docs for `database/sql`](https://pkg.go.dev/database/sql)
+- [Go SQL drivers overview](https://golang.org/s/sqldrivers)
+- [Go wiki: SQLInterface](https://tip.golang.org/wiki/SQLInterface)
+- [Go 1.26 `database/sql` source](https://github.com/golang/go/blob/go1.26.0/src/database/sql/sql.go)
+
+## Practical takeaway
+
+Treat `sql.DB` as a shared concurrency governor, not a convenience handle, and many database latency bugs become easier to see before production sees them.

--- a/docs/stdlib/index.md
+++ b/docs/stdlib/index.md
@@ -1,0 +1,55 @@
+---
+title: Standard Library Overview
+description: Learn the standard library packages that shape real Go concurrency, lifetimes, I/O, and time.
+---
+
+# Standard Library Overview
+
+Most production Go services spend more time in the standard library than in custom concurrency helpers.
+
+This section focuses on the packages that quietly define how real systems behave under load:
+
+- `context` for lifetime and cancellation,
+- `net/http` for server and client I/O,
+- `database/sql` for pooling and backpressure,
+- `time` for deadlines, retries, and timer correctness.
+
+## What this section covers
+
+<div class="path-grid">
+  <div class="path-card">
+    <h3><a href="/stdlib/context-internals">context</a></h3>
+    <p>Follow cancellation trees, `cancelCtx`, `timerCtx`, `valueCtx`, `Cause`, and the mistakes that leak request work.</p>
+  </div>
+  <div class="path-card">
+    <h3><a href="/stdlib/net-http-server-transport">net/http</a></h3>
+    <p>Understand the server connection model, request lifetimes, transport pooling, keep-alive reuse, and timeout boundaries.</p>
+  </div>
+  <div class="path-card">
+    <h3><a href="/stdlib/database-sql-pool">database/sql</a></h3>
+    <p>See why `sql.DB` is a pool, how waiters and cleaners work, and where cancellation or pool sizing assumptions fail.</p>
+  </div>
+  <div class="path-card">
+    <h3><a href="/stdlib/time-timers-tickers">time</a></h3>
+    <p>Build a correct model for monotonic time, timers, tickers, `Stop`/`Reset`, and retry loops that do not quietly rot.</p>
+  </div>
+</div>
+
+## Suggested reading order
+
+1. Start with [context](/stdlib/context-internals), because lifetime ownership affects every other package in this section.
+2. Continue with [time, timers, and tickers](/stdlib/time-timers-tickers), because deadlines and retries depend on correct clock and timer usage.
+3. Read [net/http server and transport internals](/stdlib/net-http-server-transport), where context and timers meet real network I/O.
+4. Finish with [database/sql pool internals](/stdlib/database-sql-pool), where cancellation, waiting, and resource limits become operating concerns.
+
+## What you should be able to answer afterward
+
+- Why does forgetting `cancel()` leak more than a timer?
+- Why can `http.Client` reuse collapse if you mishandle response bodies?
+- Why is `sql.DB` a long-lived shared handle instead of a per-request object?
+- Why does `time.Time` carry both wall-clock and monotonic readings?
+- Why did timer channel semantics change materially in Go 1.23?
+
+## Practical takeaway
+
+If fundamentals explain why Go concurrency is possible, this section explains how most production Go code actually expresses that concurrency day to day.

--- a/docs/stdlib/net-http-server-transport.md
+++ b/docs/stdlib/net-http-server-transport.md
@@ -1,0 +1,231 @@
+---
+title: net/http Server and Transport Internals
+description: Learn how Go's standard HTTP server and client transport model map onto goroutines, deadlines, and connection reuse.
+---
+
+# net/http Server and Transport Internals
+
+`net/http` is where many Go services spend most of their concurrency budget.
+
+It works because the runtime makes blocking network I/O cheap enough to express in direct style, while the package itself manages connection ownership, keep-alive reuse, and request lifetimes.
+
+## Why this package matters
+
+If you operate a Go service, you almost certainly depend on:
+
+- one goroutine tree per inbound request,
+- one transport pool per outbound dependency,
+- request-scoped context cancellation,
+- connection reuse instead of one TCP dial per request.
+
+Misunderstand any of those boundaries and the system becomes slower, leakier, or less predictable under load.
+
+## End-to-end mental model
+
+```mermaid
+flowchart LR
+    A["Listener accept loop"] --> B["Server connection goroutine"]
+    B --> C["Request context"]
+    C --> D["Handler tree"]
+    D --> E["Outbound http.Client"]
+    E --> F["Transport"]
+    F --> G["Idle pool / persistConn"]
+    G --> H["readLoop / writeLoop"]
+```
+
+On the server side, `net/http` turns sockets into request handlers.
+
+On the client side, `Transport` turns requests into pooled, reusable connections.
+
+Those are different halves of the same lifecycle problem.
+
+## Production sketch
+
+```go
+srv := &http.Server{
+	Addr:              ":8080",
+	Handler:           mux,
+	ReadHeaderTimeout: 2 * time.Second,
+	WriteTimeout:      10 * time.Second,
+	IdleTimeout:       60 * time.Second,
+	BaseContext: func(net.Listener) context.Context {
+		return appCtx
+	},
+}
+
+transport := &http.Transport{
+	MaxIdleConns:        256,
+	MaxIdleConnsPerHost: 64,
+	MaxConnsPerHost:     128,
+	IdleConnTimeout:     90 * time.Second,
+	ResponseHeaderTimeout: 2 * time.Second,
+}
+
+client := &http.Client{
+	Transport: transport,
+	Timeout:   3 * time.Second,
+}
+```
+
+This sketch is not interesting because it uses many fields. It is interesting because it makes lifetime and budget decisions explicit.
+
+## Server mental model
+
+The server side is not “one global handler goroutine.”
+
+The package roughly does this:
+
+1. accept a connection,
+2. attach server and connection context,
+3. read a request,
+4. run the handler,
+5. decide whether the connection stays alive,
+6. repeat or close.
+
+For HTTP/1.x, connection ownership is especially visible because one TCP connection is serially reused for multiple requests. For HTTP/2, multiplexing changes the shape, but the same lifetime and deadline questions still matter.
+
+## Simplified internal sketch
+
+```go
+type Server struct {
+	Handler           Handler
+	ReadHeaderTimeout time.Duration
+	WriteTimeout      time.Duration
+	IdleTimeout       time.Duration
+	BaseContext       func(net.Listener) context.Context
+	ConnContext       func(context.Context, net.Conn) context.Context
+}
+
+type Transport struct {
+	idleMu           sync.Mutex
+	idleConn         map[connectMethodKey][]*persistConn
+	reqCanceler      map[*Request]context.CancelCauseFunc
+	connsPerHost     map[connectMethodKey]int
+	connsPerHostWait map[connectMethodKey]wantConnQueue
+}
+
+type persistConn struct {
+	conn net.Conn
+	// one goroutine reads responses
+	// one goroutine writes requests
+}
+```
+
+The exact source has more bookkeeping, but the design pressure is visible already:
+
+- server fields define timeout and ownership boundaries,
+- transport fields define pooling and cancellation boundaries,
+- `persistConn` is the reusable connection object that actual requests flow through.
+
+## Source walk
+
+### Server side
+
+The `Server` type includes:
+
+- `ReadHeaderTimeout`, `ReadTimeout`, `WriteTimeout`, and `IdleTimeout`,
+- `BaseContext` and `ConnContext`,
+- shutdown and active-connection bookkeeping.
+
+These are not cosmetic settings. They are the core operating contract for inbound traffic.
+
+Relevant source entry points:
+
+- [`server.go` `Server`](https://github.com/golang/go/blob/go1.26.0/src/net/http/server.go#L2964)
+- [`server.go` `Serve`](https://github.com/golang/go/blob/go1.26.0/src/net/http/server.go#L3444)
+
+### Client side
+
+`http.Client` is a thin wrapper. The real concurrency behavior mostly lives in `Transport`:
+
+- idle connection maps,
+- per-host connection limits,
+- request cancellation bookkeeping,
+- dialing and handshake timeouts,
+- `persistConn` read and write loops.
+
+Relevant source entry points:
+
+- [`transport.go` `Transport`](https://github.com/golang/go/blob/go1.26.0/src/net/http/transport.go#L97)
+- [`transport.go` `roundTrip`](https://github.com/golang/go/blob/go1.26.0/src/net/http/transport.go#L590)
+- [`transport.go` `persistConn`](https://github.com/golang/go/blob/go1.26.0/src/net/http/transport.go#L2115)
+- [`transport.go` `readLoop`](https://github.com/golang/go/blob/go1.26.0/src/net/http/transport.go#L2291)
+- [`transport.go` `writeLoop`](https://github.com/golang/go/blob/go1.26.0/src/net/http/transport.go#L2649)
+
+## Response body ownership is a concurrency issue
+
+This is one of the most common mistakes:
+
+```go
+resp, err := client.Do(req)
+if err != nil {
+	return err
+}
+defer resp.Body.Close()
+```
+
+Closing the body is not just cleanup politeness.
+
+It is how the transport learns whether the connection can be reused cleanly. Mishandle that and the pool churns connections instead of reusing them.
+
+## Failure patterns
+
+### Using `http.Get` in a hot production path
+
+```go
+resp, err := http.Get(url)
+```
+
+This hides transport configuration, timeout policy, per-host limits, proxy behavior, and connection budget from the reader. That is acceptable for a script, not for a service boundary.
+
+### Forgetting to close the response body
+
+```go
+resp, err := client.Do(req)
+if err != nil {
+	return err
+}
+return decode(resp.Body) // leak: body never closed
+```
+
+This breaks connection reuse and can exhaust file descriptors or sockets.
+
+### Assuming one timeout knob is enough
+
+`Client.Timeout`, transport header timeouts, request context deadlines, and server-side read/write timeouts cover different edges.
+
+You usually need a deliberate combination, not one giant timeout applied everywhere.
+
+### Treating `TimeoutHandler` as complete request control
+
+`TimeoutHandler` is a blunt wrapper. It helps cap response time, but it does not replace handler-local context discipline, outbound deadlines, or shutdown design.
+
+### Creating a new transport per request
+
+That throws away pooling, creates dial churn, and usually makes latency and resource usage worse.
+
+## Production consequences
+
+- Keep one long-lived `Transport` per policy boundary, not per request.
+- Reuse one `http.Client` per transport policy instead of constructing clients ad hoc in hot code.
+- Make timeouts explicit at the server, request, and transport layers.
+- Treat request context cancellation as a first-class signal inside handlers and outbound calls.
+- Review body-closing discipline in code review with the same seriousness as mutex ownership.
+
+## How to test and observe it
+
+- Test client timeouts with `httptest.Server` and deliberate slow handlers.
+- Test server shutdown with `Server.Shutdown` and in-flight requests.
+- Use `httptrace` when you need to confirm reuse, dial timing, or connection setup behavior.
+- Use runtime traces or socket-level metrics if you suspect connection churn rather than handler CPU.
+
+## Official reading
+
+- [Package docs for `net/http`](https://pkg.go.dev/net/http)
+- [Package docs for `net/http/httptrace`](https://pkg.go.dev/net/http/httptrace)
+- [Go 1.26 `net/http` server source](https://github.com/golang/go/blob/go1.26.0/src/net/http/server.go)
+- [Go 1.26 `net/http` transport source](https://github.com/golang/go/blob/go1.26.0/src/net/http/transport.go)
+
+## Practical takeaway
+
+`net/http` is not only a convenient API. It is the main place where Go's runtime, deadlines, and connection reuse policies become visible in production behavior.

--- a/docs/stdlib/time-timers-tickers.md
+++ b/docs/stdlib/time-timers-tickers.md
@@ -1,0 +1,197 @@
+---
+title: time, Timers, and Tickers
+description: Learn how Go models monotonic time, timer channels, ticker loops, and deadline correctness.
+---
+
+# time, Timers, and Tickers
+
+Time bugs are concurrency bugs with better disguises.
+
+Retries, deadlines, shutdown, backoff, request budgets, and idle cleanup all rely on getting time semantics right.
+
+## Why this package matters
+
+`time` is not only formatting and sleeping.
+
+It defines:
+
+- how deadlines are measured,
+- how timers wake work back up,
+- how periodic jobs are scheduled,
+- how wall time and monotonic time interact.
+
+If you get this wrong, cancellation becomes noisy, retry loops drift, and shutdown logic becomes flaky.
+
+## Example scenario
+
+```mermaid
+flowchart LR
+    A["retry loop"] --> B["Timer.Reset(backoff)"]
+    B --> C["runtime timer heap"]
+    C --> D["timer fires"]
+    D --> E["attempt outbound call"]
+    E --> F["success resets backoff"]
+    E --> G["failure increases backoff"]
+```
+
+## Production sketch
+
+```go
+timer := time.NewTimer(0)
+defer timer.Stop()
+
+backoff := 100 * time.Millisecond
+
+for {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		if err := syncOnce(ctx); err != nil {
+			backoff = min(backoff*2, 2*time.Second)
+		} else {
+			backoff = 100 * time.Millisecond
+		}
+		timer.Reset(backoff)
+	}
+}
+```
+
+This is the shape to prefer when the loop owns the timer lifecycle and needs explicit reset behavior.
+
+## Mental model
+
+Three parts matter most:
+
+1. `time.Time` carries wall-clock data and may also carry a monotonic reading.
+2. `Timer` schedules one future event.
+3. `Ticker` schedules repeated events.
+
+The subtle part is that wall-clock time is for telling time, while monotonic time is for measuring elapsed time.
+
+That is why `time.Since(start)` is safer than subtracting timestamps from different serialized processes.
+
+## Simplified internal sketch
+
+```go
+type Time struct {
+	wall uint64
+	ext  int64
+	loc  *Location
+}
+
+type Timer struct {
+	C <-chan time.Time
+}
+
+func After(d time.Duration) <-chan time.Time {
+	return NewTimer(d).C
+}
+
+func retryLoop(ctx context.Context, timer *time.Timer) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-timer.C:
+			// do work, then timer.Reset(nextDelay)
+		}
+	}
+}
+```
+
+The runtime owns the low-level timer machinery. The `time` package wraps it in API shapes that fit regular Go code.
+
+## Source walk
+
+The Go 1.26 source makes several important details explicit:
+
+- `Time` packs wall-clock and optional monotonic data into `wall` and `ext`.
+- `NewTimer` and `AfterFunc` both delegate to runtime timer creation.
+- As of Go 1.23, timer channels have synchronous semantics and the GC can recover unreferenced timers.
+- `Ticker` is a repeating timer and still needs explicit `Stop` when the owner is done.
+
+Good entry points:
+
+- [`time.go` `Time`](https://github.com/golang/go/blob/go1.26.0/src/time/time.go#L140)
+- [`sleep.go` `Timer`](https://github.com/golang/go/blob/go1.26.0/src/time/sleep.go#L89)
+- [`sleep.go` `NewTimer`](https://github.com/golang/go/blob/go1.26.0/src/time/sleep.go#L143)
+- [`sleep.go` `After`](https://github.com/golang/go/blob/go1.26.0/src/time/sleep.go#L202)
+- [`sleep.go` `AfterFunc`](https://github.com/golang/go/blob/go1.26.0/src/time/sleep.go#L210)
+- [`tick.go` `Ticker`](https://github.com/golang/go/blob/go1.26.0/src/time/tick.go#L16)
+
+## What changed in modern Go
+
+The most important timer semantic update in recent Go versions is Go 1.23:
+
+- unreferenced timers can be garbage collected,
+- timer channels behave synchronously,
+- stale timer values after `Stop` or `Reset` are no longer the default hazard they used to be.
+
+That means some older folklore about always draining timer channels after `Stop` needs version-aware interpretation.
+
+## Failure patterns
+
+### Using `time.After` inside a hot loop without ownership
+
+```go
+for {
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(100 * time.Millisecond):
+		poll()
+	}
+}
+```
+
+This is concise, but it creates a fresh timer every iteration. A reusable `Timer` is usually a better fit for hot loops or adaptive backoff.
+
+### Forgetting to stop a ticker
+
+```go
+ticker := time.NewTicker(5 * time.Second)
+go func() {
+	for range ticker.C {
+		refresh()
+	}
+}()
+```
+
+If nothing owns shutdown for that ticker, the goroutine and periodic wakeups can outlive the real feature lifetime.
+
+### Comparing `time.Time` values with `==`
+
+`==` compares more than the instant. Location and monotonic metadata matter too. Use `Equal` when you mean “same instant.”
+
+### Assuming serialized times keep monotonic data
+
+`MarshalJSON`, `Unix`, `Parse`, and similar operations do not preserve the monotonic reading. That is why elapsed-time math should usually stay within one process.
+
+### Resetting timers without clear ownership
+
+If several goroutines stop, drain, or reset the same timer, the real problem is ownership, not API syntax.
+
+## Production consequences
+
+- Prefer monotonic-time APIs such as `Since`, `Until`, and context deadlines for elapsed-time reasoning.
+- Use one owned `Timer` for adaptive retry loops and dynamic backoff.
+- Use `Ticker` only when you truly want fixed cadence rather than “wait after work completes.”
+- Revisit old timer folklore with the Go version in mind.
+
+## How to test and observe it
+
+- Use `testing/synctest` for timeout logic when you want deterministic virtual time.
+- Write table tests around backoff progression instead of relying on real sleeps.
+- Verify ticker shutdown in leak tests.
+- Inspect traces if you suspect timer storms or bursty wakeups.
+
+## Official reading
+
+- [Package docs for `time`](https://pkg.go.dev/time)
+- [Go 1.26 `time` source](https://github.com/golang/go/blob/go1.26.0/src/time)
+- [Go 1.23 release notes](https://go.dev/doc/go1.23)
+
+## Practical takeaway
+
+A precise model of time is what keeps retries, deadlines, and periodic work from turning correct concurrency code into flaky production behavior.


### PR DESCRIPTION
## Summary
- add a new bilingual Standard Library section for `context`, `net/http`, `database/sql`, and `time`
- update VitePress navigation, homepage learning paths, and README to surface the new section
- keep the docs focused on internals, failure patterns, and production operating consequences

## Testing
- `npm run docs:build`
- `go test ./...`

Closes #17