### PR TITLE
Docs: expand standard library operations and I/O coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ VitePress will print a local preview URL in the terminal, usually `http://localh
 - `net/http`: server timeout boundaries, request lifetimes, transport pooling, `persistConn`, and response-body ownership
 - `database/sql`: pool internals, waiters, cleaner lifecycle, `DB.Stats`, and cancellation boundaries
 - `time`: monotonic time, timer/ticker ownership, Go 1.23 timer semantics, and retry-loop design
+- `sync` + `sync/atomic`: `RWMutex`, `WaitGroup`, `Once`, `sync.Map`, `sync.Cond`, and read-mostly snapshot publication
+- `os/signal` + `runtime/metrics` + `net/http/pprof`: process shutdown, signal-aware cancellation, runtime telemetry, and incident-time profiling
+- `io` + `bufio` + `bytes`: interface-driven streaming, buffering, `io.Copy` fast paths, scanner limits, and byte-slice aliasing
+- `encoding/json`: stream decoding, strictness knobs, number handling, compatibility traps, and NDJSON-friendly encoding
 
 ## Included advanced topics
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -43,6 +43,10 @@ const enSidebar = [
       { text: "net/http Server and Transport", link: "/stdlib/net-http-server-transport" },
       { text: "database/sql Pool Internals", link: "/stdlib/database-sql-pool" },
       { text: "time, Timers, and Tickers", link: "/stdlib/time-timers-tickers" },
+      { text: "sync and atomic Primitives", link: "/stdlib/sync-and-atomic" },
+      { text: "Process Signals and Runtime Observability", link: "/stdlib/process-signals-and-observability" },
+      { text: "io, bufio, and bytes", link: "/stdlib/io-bufio-bytes" },
+      { text: "encoding/json in Production", link: "/stdlib/encoding-json" },
     ],
   },
   {
@@ -140,6 +144,10 @@ const koSidebar = [
       { text: "net/http 서버와 Transport 내부", link: "/ko/stdlib/net-http-server-transport" },
       { text: "database/sql 풀 내부", link: "/ko/stdlib/database-sql-pool" },
       { text: "time, Timers, Tickers", link: "/ko/stdlib/time-timers-tickers" },
+      { text: "sync와 atomic 프리미티브", link: "/ko/stdlib/sync-and-atomic" },
+      { text: "프로세스 신호와 런타임 관측", link: "/ko/stdlib/process-signals-and-observability" },
+      { text: "io, bufio, bytes", link: "/ko/stdlib/io-bufio-bytes" },
+      { text: "프로덕션에서의 encoding/json", link: "/ko/stdlib/encoding-json" },
     ],
   },
   {

--- a/docs/index.md
+++ b/docs/index.md
@@ -108,9 +108,12 @@ features:
 | Why a local value still ends up on the heap | [Compiler and Toolchain](/internals/compiler-and-toolchain) |
 | Why one allocation pattern hurts GC more than another | [Allocator and Hybrid Write Barrier](/internals/allocator-and-write-barrier) |
 | How request-scoped cancellation actually propagates | [context Package Internals](/stdlib/context-internals) |
+| When channels are the wrong tool for shared state | [sync and atomic Primitives](/stdlib/sync-and-atomic) |
 | How Go's HTTP server and client transport really own connections | [net/http Server and Transport](/stdlib/net-http-server-transport) |
 | Why `sql.DB` is a pool instead of a connection | [database/sql Pool Internals](/stdlib/database-sql-pool) |
 | Why `time.After` is not always the right loop primitive | [time, Timers, and Tickers](/stdlib/time-timers-tickers) |
+| How to stream bytes and JSON without hidden buffering mistakes | [io, bufio, and bytes](/stdlib/io-bufio-bytes) |
+| How process shutdown and runtime observability fit into Go services | [Process Signals and Runtime Observability](/stdlib/process-signals-and-observability) |
 | Why channels synchronize memory visibility | [Channels, Select, and the Memory Model](/fundamentals/channels-memory-model) |
 | How to cap parallelism across many independent tasks | [Worker Pool](/patterns/worker-pool) |
 | How to structure one request with several sibling tasks | [Structured Concurrency](/advanced/structured-concurrency) |

--- a/docs/ko/index.md
+++ b/docs/ko/index.md
@@ -108,9 +108,12 @@ features:
 | 지역 값이 왜 여전히 힙으로 가는지 | [컴파일러와 툴체인](/ko/internals/compiler-and-toolchain) |
 | 어떤 allocation 패턴이 왜 GC를 더 힘들게 하는지 | [할당기와 하이브리드 write barrier](/ko/internals/allocator-and-write-barrier) |
 | request-scoped cancellation이 실제로 어떻게 전파되는지 | [context 패키지 내부](/ko/stdlib/context-internals) |
+| channel이 shared state에 맞지 않을 때 무엇을 써야 하는지 | [sync와 atomic 프리미티브](/ko/stdlib/sync-and-atomic) |
 | Go HTTP 서버와 클라이언트 transport가 connection을 어떻게 소유하는지 | [net/http 서버와 Transport 내부](/ko/stdlib/net-http-server-transport) |
 | 왜 `sql.DB`는 connection이 아니라 pool인지 | [database/sql 풀 내부](/ko/stdlib/database-sql-pool) |
 | 왜 `time.After`가 항상 좋은 loop primitive는 아닌지 | [time, Timers, Tickers](/ko/stdlib/time-timers-tickers) |
+| byte stream과 JSON을 hidden buffering mistake 없이 다루는 법 | [io, bufio, bytes](/ko/stdlib/io-bufio-bytes) |
+| 프로세스 shutdown과 runtime observability를 Go 서비스에 어떻게 붙이는지 | [프로세스 신호와 런타임 관측](/ko/stdlib/process-signals-and-observability) |
 | 채널이 왜 메모리 가시성 경계를 만드는지 | [Channels, Select, 그리고 Memory Model](/ko/fundamentals/channels-memory-model) |
 | 많은 독립 작업의 병렬 수를 어떻게 제한하는지 | [워커 풀](/ko/patterns/worker-pool) |
 | 하나의 요청 안에서 여러 sibling task를 어떻게 관리하는지 | [구조화된 동시성](/ko/advanced/structured-concurrency) |

--- a/docs/ko/stdlib/encoding-json.md
+++ b/docs/ko/stdlib/encoding-json.md
@@ -1,0 +1,186 @@
+---
+title: 프로덕션에서의 encoding/json
+description: Marshal, Unmarshal, Decoder, Encoder가 실제 Go 서비스에서 어떻게 동작하는지와 stream boundary, compatibility trap을 설명합니다.
+---
+
+# 프로덕션에서의 encoding/json
+
+`encoding/json`은 편하고, 널리 쓰이고, 잘못 쓰기 쉽습니다.
+
+진짜 비용은 CPU만이 아닙니다. 사람들이 조용히 가정하는 다음도 문제입니다.
+
+- strictness
+- duplicate key
+- number handling
+- buffered stream boundary
+- schema drift
+
+## 왜 이 패키지가 중요한가
+
+엄청난 양의 Go 프로덕션 코드가 서비스 경계에서 JSON을 읽고 씁니다.
+
+즉, 이 패키지는 종종:
+
+- request decoding,
+- response encoding,
+- NDJSON streaming,
+- audit/event log,
+- config snapshot,
+- 오래된/새로운 client 간 compatibility
+
+를 책임집니다.
+
+## 예제 시나리오
+
+`examples/ndjsonstream` 패키지는 `json.Decoder`, `json.Encoder`를 써서 NDJSON shipment event를 메모리에 전부 올리지 않고 filtering합니다.
+
+```mermaid
+flowchart LR
+    A["bufio.Reader"] --> B["json.Decoder"]
+    B --> C["ShipmentEvent struct"]
+    C --> D["filter / validate"]
+    D --> E["json.Encoder"]
+    E --> F["bufio.Writer"]
+```
+
+## 실전 코드 스케치
+
+```go
+decoder := json.NewDecoder(req.Body)
+decoder.DisallowUnknownFields()
+decoder.UseNumber()
+
+var payload CreateOrderRequest
+if err := decoder.Decode(&payload); err != nil {
+	return err
+}
+
+encoder := json.NewEncoder(w)
+encoder.SetEscapeHTML(false)
+return encoder.Encode(response)
+```
+
+작은 코드지만, 각 줄이 계약을 바꿉니다.
+
+- `DisallowUnknownFields`는 무시되던 drift를 명시적 실패로 바꾸고,
+- `UseNumber`는 interface-heavy path에서 숫자를 float로 조용히 바꾸지 않게 하며,
+- `SetEscapeHTML(false)`는 출력 가독성과 escaping behavior를 바꿉니다.
+
+## Mental model
+
+이 패키지에는 크게 두 모드가 있습니다.
+
+| API | 가장 잘 맞는 용도 |
+| --- | --- |
+| `Marshal` / `Unmarshal` | 이미 메모리에 있는 whole value encode/decode |
+| `Encoder` / `Decoder` | stream-oriented I/O boundary |
+
+중요한 caveat 두 가지:
+
+1. `Decoder`는 자체 buffering을 하며 현재 value보다 더 읽을 수 있습니다.
+2. 이 패키지는 “엄격한 JSON schema parser”와는 다른 compatibility behavior를 의도적으로 유지합니다.
+
+## 단순화한 내부 코드 예시
+
+streaming decoder는 대략 이런 모양입니다.
+
+```go
+type Decoder struct {
+	r     io.Reader
+	buf   []byte
+	scanp int
+	scan  scanner
+}
+
+func (dec *Decoder) Decode(v any) error {
+	n := dec.readValue()
+	state := dec.buf[dec.scanp : dec.scanp+n]
+	return unmarshalInto(v, state)
+}
+```
+
+핵심은 decoder가 하나의 완전한 JSON value를 내부 buffer에서 찾은 다음, 그 버퍼 조각을 대상으로 unmarshal한다는 점입니다. 그래서 `Buffered()`가 있고, 밑단 reader가 정확히 “value 하나씩만 읽힌다”고 가정하면 안 됩니다.
+
+## 꼭 알아야 할 compatibility behavior
+
+패키지 문서가 직접 강조하는 부분입니다.
+
+- duplicate object key는 허용되며, 나중 값이 이전 값을 replace하거나 merge합니다. 목적지 타입에 따라 달라집니다.
+- struct field match는 case-insensitive입니다.
+- plain `Unmarshal`이나 기본 `Decoder`에서는 unknown key를 무시합니다. `DisallowUnknownFields`를 켜야 거부합니다.
+- 문자열 안의 invalid UTF-8은 replacement character로 바뀝니다.
+- 큰 정수는 float 대상에 decode되면 정밀도를 잃을 수 있습니다.
+
+이건 incidental bug가 아니라 compatibility surface입니다.
+
+## Stream decoding에서 중요한 점
+
+`Encoder.Encode`는 trailing newline을 붙입니다. log나 NDJSON 스타일 출력에는 오히려 유리합니다.
+
+`Decoder.Token`, `Decoder.More`는 array/object를 token 단위로 걸을 수 있게 해줘서, whole-struct decode보다 더 세밀한 streaming control이 필요할 때 유용합니다.
+
+`json.RawMessage`는 envelope은 지금 검증하되 nested payload는 나중에 parse하고 싶을 때 좋습니다.
+
+## 런타임/소스 코드 워크
+
+Go 1.26 기본 구현에서 읽을 만한 지점:
+
+- [`encoding/json/stream.go` `Decoder`](https://github.com/golang/go/blob/go1.26.0/src/encoding/json/stream.go#L16)
+- [`encoding/json/stream.go` `NewDecoder`](https://github.com/golang/go/blob/go1.26.0/src/encoding/json/stream.go#L33)
+- [`encoding/json/stream.go` `Decode`](https://github.com/golang/go/blob/go1.26.0/src/encoding/json/stream.go#L51)
+- [`encoding/json/stream.go` `Encode`](https://github.com/golang/go/blob/go1.26.0/src/encoding/json/stream.go#L204)
+- [`encoding/json/decode.go`](https://github.com/golang/go/blob/go1.26.0/src/encoding/json/decode.go)
+- [`encoding/json/encode.go`](https://github.com/golang/go/blob/go1.26.0/src/encoding/json/encode.go)
+
+트리 안에는 `jsonv2` experiment 파일도 있지만, build tag를 켜지 않은 기본 동작은 여전히 classic implementation입니다.
+
+## 실패 패턴
+
+### `map[string]any`를 공짜 추상화처럼 사용
+
+```go
+var payload map[string]any
+if err := json.Unmarshal(body, &payload); err != nil {
+	return err
+}
+```
+
+유연하긴 하지만 type check, number coercion, field validation을 뒤쪽 코드로 미뤄버립니다.
+
+### unknown field가 기본으로 거부된다고 가정
+
+plain `Unmarshal`이나 기본 `Decoder`는 그렇지 않습니다.
+
+### duplicate key가 에러라고 가정
+
+아닙니다. interoperability나 security가 duplicate-key rejection에 의존한다면 기본 `encoding/json`보다 더 강한 validation이 필요합니다.
+
+### 큰 NDJSON record를 `Scanner`로 처리
+
+JSON layer 자체는 요구하지 않았던 token-size limit를 숨겨 넣는 흔한 방법입니다.
+
+### `Decoder`가 read-ahead 하지 않는다고 생각
+
+하나의 underlying stream 위에 여러 protocol이 공존한다면, 이 특성이 중요해집니다.
+
+## 프로덕션에서의 의미
+
+- 서비스 경계에서는 typed struct를 우선합니다.
+- stream 처리에는 `Decoder`를 쓰고, strict schema가 중요하면 `DisallowUnknownFields`를 켭니다.
+- generic decoding에서 숫자 의미를 보존해야 하면 `UseNumber`를 씁니다.
+- `RawMessage`는 delayed decoding에 쓰고, 영구적인 “나중에 타입 붙이자” 탈출구로 두지 않습니다.
+- JSON이 신뢰 경계를 넘는다면 compatibility behavior를 설계 문서 수준에서 검토해야 합니다.
+
+## 예제와 테스트
+
+- 예제: `examples/ndjsonstream`
+- 예제는 `Decoder`, `Encoder`, buffered I/O, strict field handling을 함께 보여줍니다.
+
+## 공식 자료
+
+- [`encoding/json` 패키지 문서](https://pkg.go.dev/encoding/json)
+- [JSON and Go](https://go.dev/blog/json)
+
+## Practical takeaway
+
+`encoding/json`은 대체로 프로덕션에 충분합니다. 위험한 건 패키지 존재가 아니라, strictness, number handling, stream boundary를 명시하지 않은 채 쓰는 것입니다.

--- a/docs/ko/stdlib/index.md
+++ b/docs/ko/stdlib/index.md
@@ -33,14 +33,33 @@ description: 실전 Go 서비스의 동시성, 수명 관리, I/O, 시간을 결
     <h3><a href="/ko/stdlib/time-timers-tickers">time</a></h3>
     <p>monotonic time, timers, tickers, `Stop`/`Reset`, retry loop를 안전하게 다루는 mental model을 잡습니다.</p>
   </div>
+  <div class="path-card">
+    <h3><a href="/ko/stdlib/sync-and-atomic">sync와 atomic</a></h3>
+    <p>`RWMutex`, `WaitGroup`, `Once`, `sync.Map`, `sync.Cond`, `atomic.Pointer` 중 무엇이 어떤 invariant에 맞는지 설명합니다.</p>
+  </div>
+  <div class="path-card">
+    <h3><a href="/ko/stdlib/process-signals-and-observability">신호와 관측</a></h3>
+    <p>OS signal, graceful process shutdown, runtime metrics, pprof 기반 incident investigation을 연결합니다.</p>
+  </div>
+  <div class="path-card">
+    <h3><a href="/ko/stdlib/io-bufio-bytes">io, bufio, bytes</a></h3>
+    <p>streaming interface, buffering, `io.Copy` fast path, scanner limit, byte-slice aliasing을 설명합니다.</p>
+  </div>
+  <div class="path-card">
+    <h3><a href="/ko/stdlib/encoding-json">encoding/json</a></h3>
+    <p>JSON 서비스 경계에서 strictness, stream decoding, number handling, compatibility trap을 정리합니다.</p>
+  </div>
 </div>
 
 ## 추천 읽기 순서
 
 1. 먼저 [context](/ko/stdlib/context-internals)를 읽습니다. lifetime ownership이 이 섹션의 나머지 주제 전부에 영향을 주기 때문입니다.
 2. 다음으로 [time, timers, tickers](/ko/stdlib/time-timers-tickers)를 읽습니다. deadline과 retry는 시간 모델이 정확해야 안전합니다.
-3. 그 다음 [net/http 서버와 transport 내부](/ko/stdlib/net-http-server-transport)를 읽습니다. 여기서 context와 timer가 실제 네트워크 I/O와 만납니다.
-4. 마지막으로 [database/sql pool 내부](/ko/stdlib/database-sql-pool)를 읽습니다. 여기서는 cancellation, waiting, resource limit이 운영 문제로 드러납니다.
+3. 그 다음 [sync와 atomic 프리미티브](/ko/stdlib/sync-and-atomic)를 읽고, 특정 상태 경계에 channels, mutex, map, atomic snapshot 중 무엇이 맞는지 판단합니다.
+4. 그 다음 [net/http 서버와 transport 내부](/ko/stdlib/net-http-server-transport)를 읽습니다. 여기서 context와 timer가 실제 네트워크 I/O와 만납니다.
+5. 이어서 [database/sql pool 내부](/ko/stdlib/database-sql-pool)를 읽습니다. 여기서는 cancellation, waiting, resource limit이 운영 문제로 드러납니다.
+6. streaming API나 로그 경계를 다룰 때는 [io, bufio, bytes](/ko/stdlib/io-bufio-bytes)와 [프로덕션에서의 encoding/json](/ko/stdlib/encoding-json)을 같이 읽습니다.
+7. 마지막으로 [프로세스 신호와 런타임 관측](/ko/stdlib/process-signals-and-observability)을 읽어 서비스 운영 관점으로 연결합니다.
 
 ## 읽고 나면 답할 수 있어야 하는 질문
 
@@ -48,6 +67,10 @@ description: 실전 Go 서비스의 동시성, 수명 관리, I/O, 시간을 결
 - 왜 `http.Client`는 response body 처리를 잘못하면 reuse가 무너지는가?
 - 왜 `sql.DB`는 per-request 객체가 아니라 long-lived shared handle인가?
 - 왜 `time.Time`은 wall-clock과 monotonic reading을 같이 들고 있는가?
+- 언제 plain mutex가 `sync.Map`나 atomics보다 더 깔끔한가?
+- 왜 `signal.NotifyContext`가 raw signal channel보다 더 좋은 shutdown entry point가 되는가?
+- 왜 `io.Copy`가 hand-written loop보다 빠를 수 있는가?
+- 왜 `encoding/json`은 strict schema 시스템이라면 거부할 동작을 조용히 허용하는가?
 - 왜 Go 1.23의 timer channel semantics 변화가 중요한가?
 
 ## Practical takeaway

--- a/docs/ko/stdlib/io-bufio-bytes.md
+++ b/docs/ko/stdlib/io-bufio-bytes.md
@@ -1,0 +1,212 @@
+---
+title: io, bufio, bytes
+description: Go의 핵심 I/O 인터페이스, buffering 도구, 바이트 컨테이너가 처리량과 메모리, 스트리밍 동작에 어떤 영향을 주는지 설명합니다.
+---
+
+# io, bufio, bytes
+
+Go의 I/O 스택이 강력한 이유는 interface-driven이기 때문이지, 복잡함을 숨기기 때문이 아닙니다.
+
+같은 `io.Reader` 모양이:
+
+- socket,
+- file,
+- decompressor,
+- bytes buffer,
+- goroutine 사이의 pipe
+
+를 모두 표현할 수 있습니다.
+
+이 유연함은 fast path와 ownership rule을 이해할 때만 진짜 힘이 됩니다.
+
+## 왜 이 패키지들이 중요한가
+
+프로덕션에서 I/O 동작은:
+
+- 실제로 stream하는지 아니면 전부 메모리에 올리는지,
+- write가 coalesce되는지 잘게 쪼개지는지,
+- mutable byte storage에 alias를 오래 들고 있는지,
+- 무심코 쓴 helper가 memory bomb가 되는지
+
+를 결정합니다.
+
+## 예제 시나리오
+
+`examples/ndjsonstream` 패키지는 `bufio`, `io`, `bytes`, `encoding/json`을 써서 NDJSON을 읽고 다시 내보냅니다.
+
+```mermaid
+flowchart LR
+    A["network/file reader"] --> B["bufio.Reader"]
+    B --> C["json.Decoder"]
+    C --> D["filter stage"]
+    D --> E["json.Encoder"]
+    E --> F["bufio.Writer"]
+    F --> G["bytes.Buffer / socket / file"]
+```
+
+## 실전 코드 스케치
+
+```go
+reader := bufio.NewReaderSize(src, 16*1024)
+writer := bufio.NewWriterSize(dst, 16*1024)
+defer writer.Flush()
+
+limited := io.LimitReader(reader, 1<<20)
+written, err := io.Copy(writer, limited)
+```
+
+핵심은 함수 이름이 아니라, 각 함수가 resource boundary를 어떻게 바꾸는지입니다.
+
+- `bufio`는 buffering behavior를 바꾸고,
+- `LimitReader`는 노출 범위를 제한하고,
+- `io.Copy`는 가능하면 더 빠른 복사 경로를 선택합니다.
+
+## Mental model
+
+핵심 규칙은 이렇습니다.
+
+- `io`는 동작을 인터페이스 뒤에 숨기고,
+- `bufio`는 buffer와 token helper를 얹고,
+- `bytes`는 in-memory byte container를 명시적 aliasing 규칙과 함께 제공합니다.
+
+즉:
+
+- 어떤 인터페이스를 구현했느냐에 따라 fast path가 열리고,
+- buffering은 syscall 패턴을 바꾸지만 ownership 자체를 바꾸지는 않으며,
+- `bytes.Buffer.Bytes()`가 돌려준 slice는 이후 mutation 전까지 live storage를 가리킵니다.
+
+## 단순화한 내부 코드 예시
+
+`io.Copy`는 interface-driven optimization의 대표적인 예입니다.
+
+```go
+func Copy(dst Writer, src Reader) (int64, error) {
+	if wt, ok := src.(WriterTo); ok {
+		return wt.WriteTo(dst)
+	}
+	if rf, ok := dst.(ReaderFrom); ok {
+		return rf.ReadFrom(src)
+	}
+	return copyWithTemporaryBuffer(dst, src)
+}
+```
+
+`bufio.Scanner`는 convenience와 제한된 안전 범위를 동시에 보여주는 예입니다.
+
+```go
+type Scanner struct {
+	r            io.Reader
+	buf          []byte
+	maxTokenSize int
+}
+```
+
+token이 limit을 넘으면 scanning은 실패합니다. 우연이 아니라 의도된 설계입니다.
+
+## 각 패키지가 특히 잘하는 일
+
+### `io`
+
+`io`는 composable streaming behavior가 필요할 때 씁니다.
+
+- `LimitReader`로 입력 제한
+- `TeeReader`로 logging/hashing 복제
+- `MultiWriter`, `MultiReader`로 흐름 조합
+- `Pipe`로 goroutine 사이 직접 byte stream 연결
+
+단, 구체 타입이 명시적으로 보장하지 않는 한 `Reader`나 `Writer`가 concurrent use에 안전하다고 가정하면 안 됩니다.
+
+### `bufio`
+
+`bufio.Reader`, `bufio.Writer`는 밑단의 reader/writer가 너무 많은 작은 호출로 손해를 볼 때 씁니다.
+
+`Scanner`는 token size가 bounded하고 convenience가 그 tradeoff를 정당화할 때만 쓰는 게 맞습니다. 다음이 필요하면:
+
+- unbounded line,
+- partial token control,
+- exact unread handling이 있는 sequential scan
+
+보통 `bufio.Reader`가 더 낫습니다.
+
+### `bytes`
+
+`bytes.Buffer`는 mutable byte accumulation과 `ReadFrom`/`WriteTo` 같은 streaming helper에 잘 맞습니다.
+
+`bytes.Reader`는 read-only in-memory `io.Reader`/`io.ReaderAt`/`io.Seeker`가 필요할 때 적합합니다.
+
+aliasing discipline도 중요합니다. `Bytes()`는 durable copy가 아니라 live storage view입니다.
+
+## 런타임/소스 코드 워크
+
+읽을 만한 진입점:
+
+- [`io/io.go` `Copy`](https://github.com/golang/go/blob/go1.26.0/src/io/io.go#L387)
+- [`io/pipe.go` `Pipe`](https://github.com/golang/go/blob/go1.26.0/src/io/pipe.go#L195)
+- [`bufio/scan.go` `Scanner`](https://github.com/golang/go/blob/go1.26.0/src/bufio/scan.go#L29)
+- [`bufio/scan.go` `Scan`](https://github.com/golang/go/blob/go1.26.0/src/bufio/scan.go#L139)
+- [`bytes/buffer.go` `Buffer`](https://github.com/golang/go/blob/go1.26.0/src/bytes/buffer.go#L20)
+- [`bytes/buffer.go` `ReadFrom`](https://github.com/golang/go/blob/go1.26.0/src/bytes/buffer.go#L224)
+
+특히 기억할 만한 디테일:
+
+- `io.Copy`는 staging buffer로 가기 전에 `WriterTo`, `ReaderFrom`을 먼저 시도합니다.
+- `Scanner`는 oversize token에서 unrecoverable하게 멈추고, 마지막 정상 token보다 더 많이 소비했을 수도 있습니다.
+- `bytes.Buffer`는 가능하면 기존 capacity를 재사용하고, unread bytes를 앞으로 당긴 뒤에야 allocation을 시도합니다.
+
+## 실패 패턴
+
+### interface 기반 I/O가 자동으로 concurrent-safe하다고 가정
+
+```go
+go func() { _, _ = reader.Read(bufA) }()
+go func() { _, _ = reader.Read(bufB) }()
+```
+
+이게 안전한지는 `io.Reader` 인터페이스가 아니라 concrete type이 결정합니다.
+
+### buffered writer를 flush하지 않음
+
+```go
+writer := bufio.NewWriter(dst)
+_, _ = writer.Write(payload)
+return nil // bug: 바이트가 아직 메모리에 남아 있을 수 있음
+```
+
+### unbounded token에 `Scanner` 사용
+
+`Scanner`의 기본 `MaxScanTokenSize`는 64 KiB입니다. 많은 로그에는 좋지만, arbitrarily large line이나 document에는 나쁜 기본값일 수 있습니다.
+
+### `Buffer.Bytes()`를 이후 write와 함께 오래 들고 있음
+
+```go
+view := buf.Bytes()
+buf.WriteString("more") // view가 가리키는 내용이 바뀔 수 있음
+```
+
+안정적인 바이트가 필요하면 복사해야 합니다.
+
+### unbounded input에 `io.ReadAll` 사용
+
+이건 이름만 예쁠 뿐, 메모리 문제를 뒤로 미루는 경우가 많습니다.
+
+## 프로덕션에서의 의미
+
+- hand-written copy loop보다 먼저 `io.Copy`와 fast path를 활용합니다.
+- network/file boundary에서는 작은 read/write가 문제일 때 `bufio.Reader`/`Writer`를 먼저 고려합니다.
+- `Scanner`는 token size 계약이 명확할 때만 씁니다.
+- `bytes.Buffer`는 owned mutable object로 다루고, 데이터 수명이 길어지면 복사합니다.
+
+## 예제와 테스트
+
+- 예제: `examples/ndjsonstream`
+- 테스트는 NDJSON streaming output, strict filtering, `io.LimitReader` 기반 bounded preview copy를 검증합니다.
+
+## 공식 자료
+
+- [`io` 패키지 문서](https://pkg.go.dev/io)
+- [`bufio` 패키지 문서](https://pkg.go.dev/bufio)
+- [`bytes` 패키지 문서](https://pkg.go.dev/bytes)
+
+## Practical takeaway
+
+좋은 Go I/O 코드는 교묘한 loop보다도, 명확한 ownership, bounded input, 그리고 표준 인터페이스가 제공하는 fast path를 올바르게 활용하는 데서 나옵니다.

--- a/docs/ko/stdlib/process-signals-and-observability.md
+++ b/docs/ko/stdlib/process-signals-and-observability.md
@@ -1,0 +1,211 @@
+---
+title: 프로세스 신호와 런타임 관측
+description: os/signal, signal.NotifyContext, runtime/metrics, net/http/pprof가 Go 프로세스 수명과 운영 관측에 어떤 역할을 하는지 설명합니다.
+---
+
+# 프로세스 신호와 런타임 관측
+
+프로덕션 Go 서비스는 마지막 goroutine에서 끝나지 않습니다.
+
+다음도 같이 필요합니다.
+
+- 프로세스 shutdown boundary
+- signal-aware cancellation
+- 값싼 runtime metrics
+- 안전한 profiling hook
+
+이때 `os/signal`, `runtime/metrics`, `net/http/pprof`가 들어옵니다.
+
+## 왜 이 패키지들이 중요한가
+
+서비스가:
+
+- `SIGTERM`에서 예측 가능하게 종료되지 못하고,
+- 사용자가 느끼기 전에 runtime pressure를 보여주지 못하고,
+- latency나 memory가 무너질 때 profile을 제공하지 못한다면,
+
+애플리케이션 레이어의 동시성 correctness는 절반짜리일 뿐입니다.
+
+## 예제 시나리오
+
+```mermaid
+flowchart LR
+    A["SIGTERM / Ctrl-C"] --> B["signal.NotifyContext"]
+    B --> C["root service context canceled"]
+    C --> D["HTTP server shutdown"]
+    C --> E["worker drain"]
+    F["runtime/metrics sampling"] --> G["operability dashboard"]
+    H["internal pprof mux"] --> I["heap / mutex / block / trace inspection"]
+```
+
+## 실전 코드 스케치
+
+```go
+rootCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+defer stop()
+
+go func() {
+	internalMux := http.NewServeMux()
+	internalMux.HandleFunc("/debug/pprof/", pprof.Index)
+	internalMux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	internalMux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	internalMux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	internalMux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+	_ = http.ListenAndServe("127.0.0.1:6060", internalMux)
+}()
+
+samples := []metrics.Sample{
+	{Name: "/sched/goroutines:goroutines"},
+	{Name: "/sync/mutex/wait/total:seconds"},
+	{Name: "/memory/classes/heap/objects:bytes"},
+}
+metrics.Read(samples)
+```
+
+핵심은 이 기능들이 random handler 안의 부가 기능이 아니라, 서비스 skeleton의 일부여야 한다는 점입니다.
+
+## Mental model
+
+이 패키지들은 서로 다른 층을 담당합니다.
+
+| 패키지 | 주 역할 |
+| --- | --- |
+| `os/signal` | 프로세스 signal을 Go 이벤트로 번역 |
+| `signal.NotifyContext` | signal 도착을 cancellation flow로 투영 |
+| `runtime/metrics` | 안정적인 runtime counter/histogram 노출 |
+| `net/http/pprof` | 자세한 runtime profile을 HTTP로 노출 |
+
+즉, 이 조합은 하나의 프로세스가:
+
+- “이제 멈춰야 한다”
+- “런타임이 지금 이런 압력을 받고 있다”
+- “시간과 메모리가 어디로 가는지 증거는 여기 있다”
+
+를 말할 수 있게 해줍니다.
+
+## 단순화한 내부 코드 예시
+
+```go
+ctx, stop := signal.NotifyContext(parent, os.Interrupt, syscall.SIGTERM)
+defer stop()
+
+samples := []metrics.Sample{
+	{Name: "/sched/goroutines:goroutines"},
+	{Name: "/sched/latencies:seconds"},
+}
+metrics.Read(samples)
+
+internalMux := http.NewServeMux()
+internalMux.Handle("/debug/pprof/", http.HandlerFunc(pprof.Index))
+```
+
+중요한 점은 이 패키지들이 bridge 역할을 한다는 것입니다.
+
+- signal은 context cancellation로,
+- runtime counter는 sampled telemetry로,
+- runtime 내부 상태는 inspectable profile로 바뀝니다.
+
+## Signals: 비즈니스 로직이 아니라 process lifetime
+
+`signal.NotifyContext`는 graceful shutdown의 진입점으로 가장 좋은 경우가 많습니다.
+
+이 함수를 쓰면 나머지 프로그램을 signal channel 중심이 아니라 context 중심으로 유지할 수 있습니다.
+
+중요한 디테일 두 가지:
+
+1. 반환된 `stop()`을 호출해서 리소스를 해제하고 적절할 때 기본 signal handling을 복원해야 합니다.
+2. 모든 signal이 같은 방식으로 동작하지 않습니다. `SIGKILL`, `SIGSTOP`은 잡을 수 없고, `SIGPIPE`는 stdout/stderr와 일반 socket에서 동작이 다릅니다.
+
+## `runtime/metrics`: 안정적인 runtime telemetry
+
+`runtime/metrics`는 runtime counter와 histogram의 안정적인 표면입니다.
+
+metric 집합은 진화할 수 있지만, `metrics.All()`로 discovery가 가능하고 지원되는 key의 의미는 안정적으로 유지됩니다. 그래서 불안정한 runtime 내부를 scraping하는 것보다 훨씬 나은 기반입니다.
+
+특히 자주 볼 만한 key:
+
+- `/sched/goroutines:goroutines`
+- `/sched/latencies:seconds`
+- `/sync/mutex/wait/total:seconds`
+- `/gc/heap/goal:bytes`
+- `/memory/classes/heap/objects:bytes`
+
+ongoing visibility에는 metrics를, incident investigation에는 profile을 씁니다.
+
+## `net/http/pprof`: 깊은 조사 도구이지 public API가 아님
+
+`net/http/pprof`는 다음을 노출하는 표준 방식입니다.
+
+- heap profile
+- CPU profile
+- goroutine dump
+- mutex / block profile
+- execution trace
+
+Go 1.22부터 handler는 `GET`를 요구합니다. 오래된 tooling이나 wrapper가 있다면 이 차이를 알아야 합니다.
+
+이 패키지는 보통:
+
+- loopback 전용 listener,
+- 내부 전용 포트,
+- 또는 인증/네트워크 보호 뒤의 admin path
+
+에만 두는 게 맞습니다.
+
+public application mux에 아무 생각 없이 붙이면 안 됩니다.
+
+## 런타임/패키지 소스 워크
+
+읽을 만한 시작점:
+
+- [`os/signal` 패키지 문서](https://pkg.go.dev/os/signal)
+- [`signal.go` 소스](https://github.com/golang/go/blob/go1.26.0/src/os/signal/signal.go)
+- [`runtime/metrics` 패키지 문서](https://pkg.go.dev/runtime/metrics)
+- [`sample.go` 소스](https://github.com/golang/go/blob/go1.26.0/src/runtime/metrics/sample.go)
+- [`net/http/pprof` 패키지 문서](https://pkg.go.dev/net/http/pprof)
+- [`pprof.go` 소스](https://github.com/golang/go/blob/go1.26.0/src/net/http/pprof/pprof.go)
+
+이 영역은 로컬 구현만 보는 것보다 패키지 문서를 같이 읽는 게 중요합니다. OS 동작과 metric key semantics가 구현 디테일만큼 중요하기 때문입니다.
+
+## 실패 패턴
+
+### `NotifyContext`의 `stop` 함수를 호출하지 않음
+
+```go
+ctx, stop := signal.NotifyContext(parent, os.Interrupt, syscall.SIGTERM)
+_ = stop // bug: signal forwarding 리소스를 불필요하게 오래 잡고 있음
+```
+
+### signal을 portable business event처럼 다룸
+
+signal 동작은 플랫폼과 signal 종류에 따라 다릅니다. process-control 레이어에만 남겨두는 게 맞습니다.
+
+### runtime metrics를 discovery 없이 하드코딩
+
+모든 runtime version이 같은 key를 낼 거라고 믿으면 brittle합니다. generic tooling이라면 `metrics.All()`을 써야 합니다.
+
+### public listener에 pprof 노출
+
+이건 스타일 문제가 아니라 운영/보안 버그입니다.
+
+### pprof를 상시 application telemetry처럼 사용
+
+profile은 조사 도구이지 값싼 상시 메트릭이 아닙니다. 계속 볼 신호는 먼저 metrics로 가져가야 합니다.
+
+## 프로덕션에서의 의미
+
+- OS shutdown을 Go shutdown으로 연결하는 가장 깔끔한 bridge는 대개 `signal.NotifyContext`입니다.
+- runtime metrics는 goroutine pressure, scheduler delay, lock waiting, GC shape를 보여주므로 dashboard와 alerting에 들어가야 합니다.
+- `pprof`는 incident 때 쉽게 켤 수 있어야 하지만 public internet에서는 어렵게 닿아야 합니다.
+- graceful shutdown 설계는 signal handler가 있다는 이유만으로 믿지 말고 테스트해야 합니다.
+
+## 사이트 내 다른 섹션과의 연결
+
+- 애플리케이션 쪽 drain pattern은 [Graceful Shutdown](/ko/patterns/graceful-shutdown)에서 봅니다.
+- metrics가 이상 신호를 보여준 뒤 block/mutex/trace를 파고드는 흐름은 [트레이싱과 경합 관측](/ko/testing/tracing-and-profiling)에서 이어집니다.
+- 서비스 운영 규칙은 [대규모 Go 시스템](/ko/production/large-scale-go-systems)과 연결됩니다.
+
+## Practical takeaway
+
+signal은 Go 프로세스가 언제 멈춰야 하는지 정의하고, runtime metrics와 profile은 그 프로세스가 살아 있는 동안 무엇을 하고 있는지 설명합니다. 프로덕션 엔지니어링에는 둘 다 필요합니다.

--- a/docs/ko/stdlib/sync-and-atomic.md
+++ b/docs/ko/stdlib/sync-and-atomic.md
@@ -1,0 +1,284 @@
+---
+title: sync와 atomic 프리미티브
+description: RWMutex, WaitGroup, Once, sync.Map, sync.Cond, sync/atomic을 프로덕션 Go 코드에서 언제 써야 하는지 설명합니다.
+---
+
+# sync와 atomic 프리미티브
+
+Go는 channels-only 언어가 아닙니다.
+
+대규모 프로덕션 코드베이스는 명시적인 shared-state coordination이 필요하고, 표준 라이브러리는 그 목적에 맞는 여러 도구를 제공합니다. 중요한 건 API를 외우는 게 아니라, 어떤 primitive가 어떤 invariant를 보호하는지 이해하는 것입니다.
+
+## 왜 이 패키지 묶음이 중요한가
+
+코드가 다음 중 하나를 가지는 순간:
+
+- read-mostly shared state,
+- one-time initialization,
+- 반드시 drain되어야 하는 task group,
+- 여러 goroutine이 기다리는 어떤 조건,
+- hot counter나 pointer snapshot
+
+이미 synchronization design을 하고 있는 겁니다.
+
+모든 걸 channel로 억지로 밀어 넣는다고 안전해지는 게 아니라, 오히려 선택이 덜 명확해질 수 있습니다.
+
+## 예제 시나리오
+
+`examples/configsnapshot` 패키지는 read-mostly feature config store를 모델링합니다. 한 goroutine이 전체 snapshot을 새로 읽어 publish하고, 많은 goroutine이 동시에 읽습니다.
+
+```mermaid
+flowchart LR
+    A["Config loader"] --> B["Reload mutex"]
+    B --> C["atomic.Pointer snapshot publish"]
+    C --> D1["Request reader 1"]
+    C --> D2["Request reader 2"]
+    C --> D3["Request reader N"]
+    E["sync.Once bootstrap"] --> B
+```
+
+이 문제는 다음 조합에 잘 맞습니다.
+
+- bootstrap에는 `sync.Once`
+- 느린 reload 작업 주위에는 작은 mutex
+- 값 읽기에는 `atomic.Pointer`
+
+## 실전 코드 스케치
+
+```go
+type Store struct {
+	bootstrapOnce sync.Once
+	reloadMu      sync.Mutex
+	current       atomic.Pointer[Snapshot]
+}
+
+func (s *Store) Bootstrap(ctx context.Context) error {
+	var err error
+	s.bootstrapOnce.Do(func() {
+		err = s.Reload(ctx)
+	})
+	return err
+}
+
+func (s *Store) Reload(ctx context.Context) error {
+	s.reloadMu.Lock()
+	defer s.reloadMu.Unlock()
+
+	next, err := loadSnapshot(ctx)
+	if err != nil {
+		return err
+	}
+	s.current.Store(&next)
+	return nil
+}
+```
+
+핵심은 각 primitive가 아주 좁은 concern 하나씩만 맡는다는 점입니다.
+
+## Mental model
+
+실제 invariant에 맞는 가장 좁은 primitive를 고르면 됩니다.
+
+| Primitive | 가장 잘 맞는 용도 |
+| --- | --- |
+| `RWMutex` | coherent한 multi-field invariant를 가진 shared object, read-heavy access |
+| `WaitGroup` | bounded task set이 끝날 때까지 기다리는 owner |
+| `Once` | 정확히 한 번만 해야 하는 초기화 |
+| `sync.Map` | write-once 또는 disjoint-key 패턴에 특화된 concurrent map |
+| `sync.Cond` | lock으로 보호된 조건에 대한 wait/signal |
+| `sync/atomic` | flag, counter, pointer snapshot 같은 작은 독립 상태 |
+
+여러 필드가 함께 일관되게 바뀌어야 한다면 atomic은 너무 작고, `sync.Map`은 너무 약하게 타입화되어 있는 경우가 많습니다. 이럴 때는 mutex가 더 명확합니다.
+
+## 단순화한 내부 코드 예시
+
+```go
+type Once struct {
+	done atomic.Bool
+	mu   sync.Mutex
+}
+
+type WaitGroup struct {
+	state atomic.Uint64 // counter + waiter count
+	sema  uint32
+}
+
+type RWMutex struct {
+	w           Mutex
+	writerSem   uint32
+	readerSem   uint32
+	readerCount atomic.Int32
+	readerWait  atomic.Int32
+}
+
+type Map struct {
+	internal concurrentHashTrie
+}
+```
+
+공통 패턴은 이렇습니다.
+
+- hot path에는 atomic,
+- 완전한 coordination이 필요하면 mutex나 semaphore,
+- `first use after copy 금지`를 강하게 전제.
+
+## 주요 primitive가 실제로 하는 일
+
+### `RWMutex`
+
+`RWMutex`는 “읽기 병렬성이 공짜”라는 뜻이 아닙니다.
+
+다음 경우에 가장 잘 맞습니다.
+
+- read가 write보다 훨씬 많고,
+- read critical section이 짧고,
+- 정말로 하나의 coherent object를 보호해야 할 때.
+
+write가 잦거나, 호출자가 `RLock`에서 `Lock`으로 upgrade를 시도하기 시작하면 오히려 더 느리고 이해하기 어려워집니다. Go 구현은 writer가 기다리기 시작하면 새 reader를 막아서 writer가 결국 진행할 수 있게 합니다.
+
+### `WaitGroup`
+
+`WaitGroup`은 counting semaphore이지, general lifecycle manager가 아닙니다.
+
+Go 1.26 문서는 가능하면 직접 `Add`/`Done` 쌍보다 `WaitGroup.Go`를 선호하라고 설명합니다. misuse는 여전히 같습니다.
+
+- `Add`와 `Wait`의 경합
+- 이전 `Wait`가 끝나기 전에 같은 `WaitGroup` 재사용
+- `Done`을 호출하지 않는 task leak
+
+### `Once`
+
+`Once`는 반드시 한 번만 해야 하는 initialization에 쓰는 도구입니다.
+
+retry wrapper가 아닙니다. 함수가 실패하거나 panic해도 `Once`는 그 호출을 소비한 것으로 봅니다.
+
+immutable bootstrap에는 좋고, “성공할 때까지 재시도”에는 맞지 않습니다.
+
+### `sync.Map`
+
+`sync.Map`은 특화된 자료구조입니다. 패키지 문서도 이 점을 직접 말합니다.
+
+Go 1.26 기준 구현은 단순 `map + lock`이 아니라 `internal/sync.HashTrieMap` 기반입니다. 특히 다음 경우를 최적화합니다.
+
+- write once, read many
+- disjoint key set에 대한 concurrent read/write
+
+타입 안정성이나 compound invariant가 중요한 일반 도메인 저장소의 기본값으로 쓰기엔 맞지 않습니다.
+
+### `sync.Cond`
+
+`Cond`는 queue도 아니고 mailbox도 아닙니다.
+
+lock으로 보호된 어떤 조건에 대한 rendezvous입니다. `Wait`는 항상 loop 안에서 호출해야 합니다. wakeup이 왔다고 해서 lock을 다시 잡았을 때 그 조건이 여전히 참이라는 뜻은 아니기 때문입니다.
+
+### `sync/atomic`
+
+Go의 atomic 연산은 sequentially consistent입니다. 꽤 강한 보장입니다.
+
+하지만 그게 모든 shared-state 문제에 적합하다는 뜻은 아닙니다. atomic은 하나의 값이 독립적으로 의미를 가질 때 가장 좋습니다.
+
+- readiness flag
+- request counter
+- immutable snapshot에 대한 pointer
+
+여러 필드가 함께 바뀌어야 하는 순간부터는 reasoning이 급격히 어려워집니다.
+
+## 런타임/소스 코드 워크
+
+Go 1.26에서 읽을 만한 진입점:
+
+- [`sync/once.go`](https://github.com/golang/go/blob/go1.26.0/src/sync/once.go)
+- [`sync/waitgroup.go`](https://github.com/golang/go/blob/go1.26.0/src/sync/waitgroup.go)
+- [`sync/rwmutex.go`](https://github.com/golang/go/blob/go1.26.0/src/sync/rwmutex.go)
+- [`sync/cond.go`](https://github.com/golang/go/blob/go1.26.0/src/sync/cond.go)
+- [`sync/map.go`](https://github.com/golang/go/blob/go1.26.0/src/sync/map.go)
+- [`sync/atomic/type.go`](https://github.com/golang/go/blob/go1.26.0/src/sync/atomic/type.go)
+
+특히 볼 만한 디테일:
+
+- `Once`는 hot-path layout을 위해 `done`을 앞에 두고, slow path에서는 mutex를 써서 다른 호출자가 initialization 종료까지 기다리게 만듭니다.
+- `WaitGroup`은 task count와 waiter count를 하나의 atomic word에 패킹하고 runtime semaphore로 waiters를 깨웁니다.
+- `RWMutex`는 reader count를 atomic으로 추적하고, fast path가 실패하면 runtime semaphore로 reader/writer를 block합니다.
+- `Cond.Wait`는 runtime notify list에 waiter를 등록하고 unlock 후 sleep, 그 다음 re-lock 합니다.
+- `sync.Map.Range`는 일관된 snapshot이 아님을 문서가 명확히 말합니다.
+
+## 실패 패턴
+
+### write-heavy state에 `RWMutex` 사용
+
+```go
+rw.RLock()
+defer rw.RUnlock()
+```
+
+write가 잦다면 `RWMutex`는 plain mutex보다 더 느리고 이해하기 어려울 수 있습니다.
+
+### `Wait`가 시작된 뒤 `Add` 호출
+
+```go
+go func() {
+	wg.Add(1) // misuse
+	defer wg.Done()
+	work()
+}()
+wg.Wait()
+```
+
+이건 `WaitGroup`이 정확히 막아야 하는 misuse입니다.
+
+### retry 가능한 초기화에 `Once` 사용
+
+```go
+once.Do(func() {
+	err = connect()
+})
+```
+
+`connect()`가 한 번 실패하면 같은 `Once`로는 다시 시도되지 않습니다.
+
+### `sync.Map`을 typed domain store의 기본값으로 사용
+
+`sync.Map`은 개별 연산의 concurrency safety를 줄 뿐, 도메인 invariant를 더 쉽게 지켜주지는 않습니다.
+
+### loop 없이 `Cond.Wait` 사용
+
+```go
+cond.L.Lock()
+cond.Wait()
+useSharedState() // bug: 조건이 여전히 참이라는 보장이 없음
+cond.L.Unlock()
+```
+
+lock이 조건을 보호합니다. signal은 다시 확인하라는 의미일 뿐입니다.
+
+### compound invariant를 atomic 여러 개로 표현
+
+```go
+atomic.StoreInt64(&state.balance, nextBalance)
+atomic.StoreInt64(&state.version, nextVersion)
+```
+
+reader가 두 필드를 함께 일관되게 봐야 한다면, separate atomic store는 coherent multi-field transaction이 아닙니다.
+
+## 프로덕션에서의 의미
+
+- 왜 다른 primitive가 더 나은지 명확히 설명할 수 있을 때까지는 plain mutex를 기본값으로 둡니다.
+- read-mostly immutable snapshot에는 `atomic.Pointer`가 종종 가장 깔끔하고 빠릅니다.
+- `sync.Map`은 특화된 경우에만 씁니다.
+- `WaitGroup`은 local join 도구이지 long-lived service controller가 아닙니다.
+- correctness에 중요한 조건이라면 lock과 `Cond`를 state owner 근처에 둡니다.
+
+## 예제와 테스트
+
+- 예제: `examples/configsnapshot`
+- 테스트는 one-time bootstrap, whole snapshot의 atomic publication, 실패 시 last known-good snapshot 유지까지 검증합니다.
+
+## 공식 자료
+
+- [`sync` 패키지 문서](https://pkg.go.dev/sync)
+- [`sync/atomic` 패키지 문서](https://pkg.go.dev/sync/atomic)
+- [Go memory model](https://go.dev/ref/mem)
+
+## Practical takeaway
+
+강한 Go 코드베이스는 “channel 순수주의”로 가지 않습니다. 실제 invariant에 맞는 가장 작은 synchronization primitive를 고르고, 거기서 멈춥니다.

--- a/docs/stdlib/encoding-json.md
+++ b/docs/stdlib/encoding-json.md
@@ -1,0 +1,184 @@
+---
+title: encoding/json in Production
+description: Learn how Marshal, Unmarshal, Decoder, and Encoder behave in real Go services, including stream boundaries and compatibility traps.
+---
+
+# encoding/json in Production
+
+`encoding/json` is convenient, ubiquitous, and easy to misuse.
+
+Its real cost is not only CPU time. It is also the semantic assumptions people quietly make about:
+
+- strictness,
+- duplicate keys,
+- number handling,
+- buffered stream boundaries,
+- schema drift.
+
+## Why this package matters
+
+A huge amount of Go production code reads or writes JSON at service boundaries.
+
+That means the package is often responsible for:
+
+- request decoding,
+- response encoding,
+- NDJSON streaming,
+- audit or event logs,
+- config snapshots,
+- compatibility between old and new clients.
+
+## Example scenario
+
+The `examples/ndjsonstream` package uses `json.Decoder` and `json.Encoder` to filter newline-delimited shipment events without buffering the whole stream in memory.
+
+```mermaid
+flowchart LR
+    A["bufio.Reader"] --> B["json.Decoder"]
+    B --> C["ShipmentEvent struct"]
+    C --> D["filter / validate"]
+    D --> E["json.Encoder"]
+    E --> F["bufio.Writer"]
+```
+
+## Production sketch
+
+```go
+decoder := json.NewDecoder(req.Body)
+decoder.DisallowUnknownFields()
+decoder.UseNumber()
+
+var payload CreateOrderRequest
+if err := decoder.Decode(&payload); err != nil {
+	return err
+}
+
+encoder := json.NewEncoder(w)
+encoder.SetEscapeHTML(false)
+return encoder.Encode(response)
+```
+
+This is small code, but every line changes the contract:
+
+- `DisallowUnknownFields` turns ignored drift into explicit failure,
+- `UseNumber` avoids silent float conversion in interface-heavy paths,
+- `SetEscapeHTML(false)` changes output readability and escaping behavior.
+
+## Mental model
+
+The package has two main modes:
+
+| API | Best fit |
+| --- | --- |
+| `Marshal` / `Unmarshal` | whole-value encode/decode already in memory |
+| `Encoder` / `Decoder` | stream-oriented I/O boundaries |
+
+Two important caveats:
+
+1. `Decoder` introduces its own buffering and may read past the current value.
+2. The package intentionally preserves some compatibility behaviors that are not “strict JSON schema” behavior.
+
+## Simplified internal sketch
+
+The streaming decoder roughly works like this:
+
+```go
+type Decoder struct {
+	r     io.Reader
+	buf   []byte
+	scanp int
+	scan  scanner
+}
+
+func (dec *Decoder) Decode(v any) error {
+	n := dec.readValue()
+	state := dec.buf[dec.scanp : dec.scanp+n]
+	return unmarshalInto(v, state)
+}
+```
+
+The key idea is that the decoder scans until it has one complete JSON value, then unmarshals that value from its internal buffer. That is why `Buffered()` exists and why you should not assume exact one-value-per-read behavior from the underlying reader.
+
+## Compatibility behaviors you need to know
+
+The package docs call these out because they matter in real systems:
+
+- duplicate object keys are accepted, with later values replacing or merging into earlier ones depending on destination type,
+- struct field matching is case-insensitive,
+- unknown object keys are ignored unless `DisallowUnknownFields` is enabled on a `Decoder`,
+- invalid UTF-8 in strings is replaced,
+- large integers lose precision when decoded into floating-point destinations.
+
+These behaviors are part of the compatibility surface, not just incidental implementation choices.
+
+## Stream decoding details
+
+`Encoder.Encode` appends a trailing newline. That is useful for logs and NDJSON-style output.
+
+`Decoder.Token` and `Decoder.More` let you walk arrays or objects token by token, which is useful when you need streaming control rather than whole-struct decode.
+
+`json.RawMessage` is useful when one layer should validate an envelope but delay parsing of a nested payload.
+
+## Runtime source walk
+
+Useful entry points in the default Go 1.26 implementation:
+
+- [`encoding/json/stream.go` `Decoder`](https://github.com/golang/go/blob/go1.26.0/src/encoding/json/stream.go#L16)
+- [`encoding/json/stream.go` `NewDecoder`](https://github.com/golang/go/blob/go1.26.0/src/encoding/json/stream.go#L33)
+- [`encoding/json/stream.go` `Decode`](https://github.com/golang/go/blob/go1.26.0/src/encoding/json/stream.go#L51)
+- [`encoding/json/stream.go` `Encode`](https://github.com/golang/go/blob/go1.26.0/src/encoding/json/stream.go#L204)
+- [`encoding/json/decode.go`](https://github.com/golang/go/blob/go1.26.0/src/encoding/json/decode.go)
+- [`encoding/json/encode.go`](https://github.com/golang/go/blob/go1.26.0/src/encoding/json/encode.go)
+
+One detail worth noticing in the tree is that Go 1.26 also contains `jsonv2` experiment files behind build tags. The default package behavior is still the classic implementation unless that experiment is enabled.
+
+## Failure patterns
+
+### Treating `map[string]any` as a free abstraction
+
+```go
+var payload map[string]any
+if err := json.Unmarshal(body, &payload); err != nil {
+	return err
+}
+```
+
+This is flexible, but it pushes type checks, number coercion, and field validation into later code.
+
+### Assuming unknown fields are rejected by default
+
+They are not when you use plain `Unmarshal` or a default `Decoder`.
+
+### Assuming duplicate keys are an error
+
+They are not. If interoperability or security depends on strict duplicate-key rejection, you need stronger validation than default `encoding/json`.
+
+### Using `Scanner` instead of `Decoder` for large NDJSON records
+
+This often creates a hidden token-size limit that the JSON layer itself did not require.
+
+### Forgetting that `Decoder` may read ahead
+
+If several protocols share one underlying stream, read-ahead behavior matters.
+
+## Production consequences
+
+- Prefer typed structs at service boundaries.
+- Use `Decoder` for streaming and enable `DisallowUnknownFields` where schema strictness matters.
+- Use `UseNumber` when generic decoding must preserve numeric intent.
+- Keep `RawMessage` for delayed decoding, not as a permanent “we will type this later” escape hatch.
+- Review compatibility assumptions when JSON crosses trust boundaries.
+
+## Example and tests
+
+- Example: `examples/ndjsonstream`
+- The example shows stream filtering with `Decoder`, `Encoder`, buffered I/O, and strict field handling.
+
+## Official reading
+
+- [Package docs for `encoding/json`](https://pkg.go.dev/encoding/json)
+- [JSON and Go](https://go.dev/blog/json)
+
+## Practical takeaway
+
+`encoding/json` is usually good enough for production. The danger is not that it exists. The danger is using it without being explicit about strictness, numbers, and stream boundaries.

--- a/docs/stdlib/index.md
+++ b/docs/stdlib/index.md
@@ -33,14 +33,33 @@ This section focuses on the packages that quietly define how real systems behave
     <h3><a href="/stdlib/time-timers-tickers">time</a></h3>
     <p>Build a correct model for monotonic time, timers, tickers, `Stop`/`Reset`, and retry loops that do not quietly rot.</p>
   </div>
+  <div class="path-card">
+    <h3><a href="/stdlib/sync-and-atomic">sync and atomic</a></h3>
+    <p>Choose between `RWMutex`, `WaitGroup`, `Once`, `sync.Map`, `sync.Cond`, and `atomic.Pointer` based on the invariant you need to protect.</p>
+  </div>
+  <div class="path-card">
+    <h3><a href="/stdlib/process-signals-and-observability">signals and observability</a></h3>
+    <p>Connect OS signals, graceful process shutdown, runtime metrics, and pprof-based incident investigation.</p>
+  </div>
+  <div class="path-card">
+    <h3><a href="/stdlib/io-bufio-bytes">io, bufio, and bytes</a></h3>
+    <p>Understand streaming interfaces, buffering, `io.Copy` fast paths, scanner limits, and byte-slice aliasing.</p>
+  </div>
+  <div class="path-card">
+    <h3><a href="/stdlib/encoding-json">encoding/json</a></h3>
+    <p>Handle strictness, stream decoding, number handling, and compatibility traps at JSON service boundaries.</p>
+  </div>
 </div>
 
 ## Suggested reading order
 
 1. Start with [context](/stdlib/context-internals), because lifetime ownership affects every other package in this section.
 2. Continue with [time, timers, and tickers](/stdlib/time-timers-tickers), because deadlines and retries depend on correct clock and timer usage.
-3. Read [net/http server and transport internals](/stdlib/net-http-server-transport), where context and timers meet real network I/O.
-4. Finish with [database/sql pool internals](/stdlib/database-sql-pool), where cancellation, waiting, and resource limits become operating concerns.
+3. Read [sync and atomic primitives](/stdlib/sync-and-atomic) before deciding whether channels, mutexes, maps, or atomic snapshots are the right fit for a given state boundary.
+4. Read [net/http server and transport internals](/stdlib/net-http-server-transport), where context and timers meet real network I/O.
+5. Continue with [database/sql pool internals](/stdlib/database-sql-pool), where cancellation, waiting, and resource limits become operating concerns.
+6. Read [io, bufio, and bytes](/stdlib/io-bufio-bytes) and [encoding/json in production](/stdlib/encoding-json) together when you are working at streaming API or log boundaries.
+7. Finish with [process signals and runtime observability](/stdlib/process-signals-and-observability) so package-level design connects to service-level operations.
 
 ## What you should be able to answer afterward
 
@@ -48,6 +67,10 @@ This section focuses on the packages that quietly define how real systems behave
 - Why can `http.Client` reuse collapse if you mishandle response bodies?
 - Why is `sql.DB` a long-lived shared handle instead of a per-request object?
 - Why does `time.Time` carry both wall-clock and monotonic readings?
+- When is a plain mutex cleaner than `sync.Map` or atomics?
+- Why is `signal.NotifyContext` usually a better shutdown entry point than raw signal channels?
+- Why can `io.Copy` outperform your hand-written loop?
+- Why does `encoding/json` silently accept behaviors that a strict schema system would reject?
 - Why did timer channel semantics change materially in Go 1.23?
 
 ## Practical takeaway

--- a/docs/stdlib/io-bufio-bytes.md
+++ b/docs/stdlib/io-bufio-bytes.md
@@ -1,0 +1,208 @@
+---
+title: io, bufio, and bytes
+description: Learn how Go's core I/O interfaces, buffering tools, and byte containers shape throughput, memory, and streaming behavior.
+---
+
+# io, bufio, and bytes
+
+Go's I/O stack is powerful because it is interface-driven, not because it hides complexity.
+
+The same `io.Reader` shape can represent:
+
+- a socket,
+- a file,
+- a decompressor,
+- a bytes buffer,
+- a pipe between goroutines.
+
+That flexibility is useful only if you understand the fast paths and the ownership rules underneath it.
+
+## Why these packages matter
+
+In production, I/O behavior determines:
+
+- whether you stream or accidentally buffer everything,
+- whether writes are coalesced or fragmented,
+- whether you hold aliases into mutable byte storage,
+- whether one innocent helper quietly becomes a memory bomb.
+
+## Example scenario
+
+The `examples/ndjsonstream` package ingests and re-emits newline-delimited JSON using `bufio`, `io`, `bytes`, and `encoding/json`.
+
+```mermaid
+flowchart LR
+    A["network/file reader"] --> B["bufio.Reader"]
+    B --> C["json.Decoder"]
+    C --> D["filter stage"]
+    D --> E["json.Encoder"]
+    E --> F["bufio.Writer"]
+    F --> G["bytes.Buffer / socket / file"]
+```
+
+## Production sketch
+
+```go
+reader := bufio.NewReaderSize(src, 16*1024)
+writer := bufio.NewWriterSize(dst, 16*1024)
+defer writer.Flush()
+
+limited := io.LimitReader(reader, 1<<20)
+written, err := io.Copy(writer, limited)
+```
+
+The point is not that these functions exist. It is that each one changes the resource boundary:
+
+- `bufio` changes buffering behavior,
+- `LimitReader` caps exposure,
+- `io.Copy` may choose an optimized copy path for you.
+
+## Mental model
+
+The core rules:
+
+- `io` packages behavior behind interfaces,
+- `bufio` adds buffers and token helpers,
+- `bytes` gives in-memory byte containers with explicit aliasing behavior.
+
+That means:
+
+- interface satisfaction can unlock fast paths,
+- buffering changes syscall patterns but not ownership,
+- slices returned by `bytes.Buffer.Bytes()` alias live storage until the next mutation.
+
+## Simplified internal sketch
+
+`io.Copy` is a good example of interface-driven optimization:
+
+```go
+func Copy(dst Writer, src Reader) (int64, error) {
+	if wt, ok := src.(WriterTo); ok {
+		return wt.WriteTo(dst)
+	}
+	if rf, ok := dst.(ReaderFrom); ok {
+		return rf.ReadFrom(src)
+	}
+	return copyWithTemporaryBuffer(dst, src)
+}
+```
+
+`bufio.Scanner` is a good example of convenience with a deliberately limited safety envelope:
+
+```go
+type Scanner struct {
+	r            io.Reader
+	buf          []byte
+	maxTokenSize int
+}
+```
+
+If the token grows beyond the configured limit, scanning fails. That is a design choice, not an accident.
+
+## What these packages are really good at
+
+### `io`
+
+Use `io` when you want composable streaming behavior:
+
+- `LimitReader` to cap input,
+- `TeeReader` to duplicate a stream into logging or hashing,
+- `MultiWriter` or `MultiReader` to compose flows,
+- `Pipe` when one goroutine should stream bytes directly into another.
+
+Do not assume `Reader` or `Writer` implementations are safe for concurrent use unless the concrete type documents that explicitly.
+
+### `bufio`
+
+Use `bufio.Reader` and `bufio.Writer` when the underlying reader or writer would otherwise suffer from many tiny calls.
+
+Use `Scanner` only when token size is bounded and the convenience is worth the tradeoff. If you need:
+
+- unbounded lines,
+- partial token control,
+- sequential scans with exact unread handling,
+
+use `bufio.Reader` instead.
+
+### `bytes`
+
+Use `bytes.Buffer` for mutable byte accumulation and streaming helpers such as `ReadFrom` and `WriteTo`.
+
+Use `bytes.Reader` when you want a read-only in-memory `io.Reader`/`io.ReaderAt`/`io.Seeker`.
+
+Be disciplined with aliasing. `Bytes()` is a window into the buffer's live storage, not a durable copy.
+
+## Runtime source walk
+
+Useful entry points:
+
+- [`io/io.go` `Copy`](https://github.com/golang/go/blob/go1.26.0/src/io/io.go#L387)
+- [`io/pipe.go` `Pipe`](https://github.com/golang/go/blob/go1.26.0/src/io/pipe.go#L195)
+- [`bufio/scan.go` `Scanner`](https://github.com/golang/go/blob/go1.26.0/src/bufio/scan.go#L29)
+- [`bufio/scan.go` `Scan`](https://github.com/golang/go/blob/go1.26.0/src/bufio/scan.go#L139)
+- [`bytes/buffer.go` `Buffer`](https://github.com/golang/go/blob/go1.26.0/src/bytes/buffer.go#L20)
+- [`bytes/buffer.go` `ReadFrom`](https://github.com/golang/go/blob/go1.26.0/src/bytes/buffer.go#L224)
+
+Details worth remembering:
+
+- `io.Copy` prefers `WriterTo` and `ReaderFrom` before falling back to a staging buffer.
+- `Scanner` stops unrecoverably on oversized tokens and may advance farther than you expect before the last good token.
+- `bytes.Buffer` tries hard to reuse existing capacity and slide unread bytes down before allocating.
+
+## Failure patterns
+
+### Assuming interface-based I/O is automatically concurrency-safe
+
+```go
+go func() { _, _ = reader.Read(bufA) }()
+go func() { _, _ = reader.Read(bufB) }()
+```
+
+Whether this is safe depends on the concrete type, not the `io.Reader` interface.
+
+### Forgetting to flush a buffered writer
+
+```go
+writer := bufio.NewWriter(dst)
+_, _ = writer.Write(payload)
+return nil // bug: bytes may still be sitting in memory
+```
+
+### Using `Scanner` for unbounded tokens
+
+`Scanner` has a default `MaxScanTokenSize` of 64 KiB. That is ideal for many logs and terrible for arbitrarily large lines or documents.
+
+### Holding `Buffer.Bytes()` across later writes
+
+```go
+view := buf.Bytes()
+buf.WriteString("more") // view may now describe changed contents
+```
+
+If you need stable bytes, copy them.
+
+### Calling `io.ReadAll` on unbounded input
+
+That is often just deferred memory trouble with a nicer function name.
+
+## Production consequences
+
+- Let `io.Copy` and its fast paths work for you before hand-writing copy loops.
+- Reach for `bufio.Reader`/`Writer` at network and file boundaries where tiny reads or writes would otherwise dominate.
+- Use `Scanner` only when the token size contract is clear.
+- Treat `bytes.Buffer` as an owned mutable object. Copy when data must outlive later mutations.
+
+## Example and tests
+
+- Example: `examples/ndjsonstream`
+- The tests verify streaming NDJSON output, strict filtering, and bounded preview copying via `io.LimitReader`.
+
+## Official reading
+
+- [Package docs for `io`](https://pkg.go.dev/io)
+- [Package docs for `bufio`](https://pkg.go.dev/bufio)
+- [Package docs for `bytes`](https://pkg.go.dev/bytes)
+
+## Practical takeaway
+
+Good Go I/O code is less about clever loops and more about clear ownership, bounded input, and letting the standard interfaces choose the right fast path.

--- a/docs/stdlib/process-signals-and-observability.md
+++ b/docs/stdlib/process-signals-and-observability.md
@@ -1,0 +1,207 @@
+---
+title: Process Signals and Runtime Observability
+description: Learn how os/signal, signal.NotifyContext, runtime/metrics, and net/http/pprof shape process lifecycle and production observability in Go.
+---
+
+# Process Signals and Runtime Observability
+
+Production Go services do not end at the last goroutine you wrote.
+
+They also need:
+
+- process shutdown boundaries,
+- signal-aware cancellation,
+- cheap runtime metrics,
+- safe profiling hooks.
+
+That is where `os/signal`, `runtime/metrics`, and `net/http/pprof` come in.
+
+## Why these packages matter
+
+If a service cannot:
+
+- shut down predictably on `SIGTERM`,
+- expose runtime pressure before users feel it,
+- provide profiles when latency or memory goes bad,
+
+then concurrency correctness in the application layer is only half the job.
+
+## Example scenario
+
+```mermaid
+flowchart LR
+    A["SIGTERM / Ctrl-C"] --> B["signal.NotifyContext"]
+    B --> C["root service context canceled"]
+    C --> D["HTTP server shutdown"]
+    C --> E["worker drain"]
+    F["runtime/metrics sampling"] --> G["operability dashboard"]
+    H["internal pprof mux"] --> I["heap / mutex / block / trace inspection"]
+```
+
+## Production sketch
+
+```go
+rootCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+defer stop()
+
+go func() {
+	internalMux := http.NewServeMux()
+	internalMux.HandleFunc("/debug/pprof/", pprof.Index)
+	internalMux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	internalMux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	internalMux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	internalMux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+	_ = http.ListenAndServe("127.0.0.1:6060", internalMux)
+}()
+
+samples := []metrics.Sample{
+	{Name: "/sched/goroutines:goroutines"},
+	{Name: "/sync/mutex/wait/total:seconds"},
+	{Name: "/memory/classes/heap/objects:bytes"},
+}
+metrics.Read(samples)
+```
+
+The theme is simple: shutdown and observability belong in the service skeleton, not as afterthoughts inside random handlers.
+
+## Mental model
+
+These packages serve different layers:
+
+| Package | Main job |
+| --- | --- |
+| `os/signal` | translate process signals into Go-visible events |
+| `signal.NotifyContext` | project signal arrival into cancellation flow |
+| `runtime/metrics` | expose stable runtime counters and histograms |
+| `net/http/pprof` | expose detailed runtime profiles over HTTP |
+
+Together they let one process say:
+
+- “it is time to stop,”
+- “here is what the runtime is experiencing,”
+- “here is the evidence for where time or memory is going.”
+
+## Simplified internal sketch
+
+```go
+ctx, stop := signal.NotifyContext(parent, os.Interrupt, syscall.SIGTERM)
+defer stop()
+
+samples := []metrics.Sample{
+	{Name: "/sched/goroutines:goroutines"},
+	{Name: "/sched/latencies:seconds"},
+}
+metrics.Read(samples)
+
+internalMux := http.NewServeMux()
+internalMux.Handle("/debug/pprof/", http.HandlerFunc(pprof.Index))
+```
+
+The important point is that these packages are bridges:
+
+- signals become context cancellation,
+- runtime counters become sampled telemetry,
+- internal runtime state becomes inspectable profiles.
+
+## Signals: process lifetime, not business logic
+
+`signal.NotifyContext` is usually the best entry point for graceful shutdown.
+
+It lets you keep the rest of the program context-driven instead of sprinkling signal channels everywhere.
+
+Two details matter:
+
+1. You should still call the returned `stop()` function to release resources and restore default handling when appropriate.
+2. Not all signals behave the same. `SIGKILL` and `SIGSTOP` cannot be caught, and `SIGPIPE` has special behavior that differs between stdout/stderr and ordinary sockets.
+
+## `runtime/metrics`: stable runtime telemetry
+
+`runtime/metrics` is the stable surface for runtime counters and histograms.
+
+The metric set can evolve, but the package gives you discovery via `metrics.All()` and stable key semantics for supported metrics. This makes it a better foundation for runtime telemetry than scraping unstable internals.
+
+Especially useful keys include:
+
+- `/sched/goroutines:goroutines`
+- `/sched/latencies:seconds`
+- `/sync/mutex/wait/total:seconds`
+- `/gc/heap/goal:bytes`
+- `/memory/classes/heap/objects:bytes`
+
+Use metrics when you want cheap ongoing visibility. Use profiles when you need investigation depth.
+
+## `net/http/pprof`: deep inspection, not public API
+
+`net/http/pprof` is the standard way to expose:
+
+- heap profiles,
+- CPU profiles,
+- goroutine dumps,
+- mutex and block profiles,
+- execution traces.
+
+As of Go 1.22, the handlers require `GET`. That matters if you have old tooling or custom wrappers.
+
+This package should usually live on:
+
+- a loopback-only listener,
+- an internal-only port,
+- or a protected admin path behind authentication and network controls.
+
+It should not be casually mounted on the public application mux.
+
+## Runtime source and package walk
+
+Useful starting points:
+
+- [`os/signal` package docs](https://pkg.go.dev/os/signal)
+- [`signal.go` source](https://github.com/golang/go/blob/go1.26.0/src/os/signal/signal.go)
+- [`runtime/metrics` package docs](https://pkg.go.dev/runtime/metrics)
+- [`sample.go` source](https://github.com/golang/go/blob/go1.26.0/src/runtime/metrics/sample.go)
+- [`net/http/pprof` package docs](https://pkg.go.dev/net/http/pprof)
+- [`pprof.go` source](https://github.com/golang/go/blob/go1.26.0/src/net/http/pprof/pprof.go)
+
+The package docs are particularly important here because OS behavior and supported metric keys matter as much as the local implementation.
+
+## Failure patterns
+
+### Forgetting to call the `stop` function from `NotifyContext`
+
+```go
+ctx, stop := signal.NotifyContext(parent, os.Interrupt, syscall.SIGTERM)
+_ = stop // bug: leaves signal forwarding resources attached longer than needed
+```
+
+### Treating signals as portable business events
+
+Signal behavior varies by platform and by signal type. Keep them at the process-control layer.
+
+### Hard-coding runtime metrics without discovery discipline
+
+Blindly assuming every runtime version exposes the same keys is brittle. Use `metrics.All()` when building generic tooling.
+
+### Exposing pprof on the public listener
+
+That is an operational and security bug, not just a style issue.
+
+### Using pprof as always-on application telemetry
+
+Profiles are for investigation, not for cheap every-request measurement. For ongoing signals, start with normal metrics.
+
+## Production consequences
+
+- `signal.NotifyContext` usually gives the cleanest bridge from OS shutdown to Go shutdown.
+- Runtime metrics should feed dashboards and alerting because they expose goroutine pressure, scheduler delay, lock waiting, and GC shape.
+- `pprof` should be easy to turn to during incidents but hard to reach from the public internet.
+- Graceful shutdown design should be exercised in tests, not assumed because a signal handler exists.
+
+## Where this connects to the rest of the site
+
+- Use [Graceful Shutdown](/patterns/graceful-shutdown) for the application-side drain pattern.
+- Use [Tracing and Contention Observability](/testing/tracing-and-profiling) for block, mutex, and trace workflows after metrics tell you something is wrong.
+- Use [Large-Scale Go Systems](/production/large-scale-go-systems) for service-level operating rules.
+
+## Practical takeaway
+
+Signals define when a Go process should stop. Runtime metrics and profiles explain what that process is doing while it is alive. Good production engineering needs both.

--- a/docs/stdlib/sync-and-atomic.md
+++ b/docs/stdlib/sync-and-atomic.md
@@ -1,0 +1,284 @@
+---
+title: sync and atomic Primitives
+description: Learn when RWMutex, WaitGroup, Once, sync.Map, sync.Cond, and sync/atomic are the right tools in production Go code.
+---
+
+# sync and atomic Primitives
+
+Go is not a channels-only language.
+
+Large production codebases often need explicit shared-state coordination, and the standard library gives several tools for that job. The important part is not memorizing APIs. It is understanding which primitive protects which kind of invariant.
+
+## Why this package family matters
+
+The moment your code has:
+
+- read-mostly shared state,
+- one-time initialization,
+- a task group that must drain cleanly,
+- a condition that many goroutines wait on,
+- a hot counter or pointer snapshot,
+
+you are already making synchronization design choices.
+
+Pretending everything should be a channel usually makes those choices less explicit, not safer.
+
+## Example scenario
+
+The `examples/configsnapshot` package models a read-mostly feature-config store. One goroutine refreshes a full snapshot, while many goroutines read it concurrently.
+
+```mermaid
+flowchart LR
+    A["Config loader"] --> B["Reload mutex"]
+    B --> C["atomic.Pointer snapshot publish"]
+    C --> D1["Request reader 1"]
+    C --> D2["Request reader 2"]
+    C --> D3["Request reader N"]
+    E["sync.Once bootstrap"] --> B
+```
+
+This is a good fit for:
+
+- `sync.Once` for bootstrap,
+- a small mutex around slow reload work,
+- `atomic.Pointer` for cheap, read-mostly snapshot access.
+
+## Production sketch
+
+```go
+type Store struct {
+	bootstrapOnce sync.Once
+	reloadMu      sync.Mutex
+	current       atomic.Pointer[Snapshot]
+}
+
+func (s *Store) Bootstrap(ctx context.Context) error {
+	var err error
+	s.bootstrapOnce.Do(func() {
+		err = s.Reload(ctx)
+	})
+	return err
+}
+
+func (s *Store) Reload(ctx context.Context) error {
+	s.reloadMu.Lock()
+	defer s.reloadMu.Unlock()
+
+	next, err := loadSnapshot(ctx)
+	if err != nil {
+		return err
+	}
+	s.current.Store(&next)
+	return nil
+}
+```
+
+The key is that each primitive owns one narrow concern. None of them is being asked to protect the whole feature by itself.
+
+## Mental model
+
+Use the narrowest primitive that matches the invariant:
+
+| Primitive | Best fit |
+| --- | --- |
+| `RWMutex` | one shared object with coherent multi-field invariants and read-heavy access |
+| `WaitGroup` | one owner waiting for a bounded set of tasks to finish |
+| `Once` | exactly-once initialization |
+| `sync.Map` | specialized concurrent map with write-once or disjoint-key patterns |
+| `sync.Cond` | wait/signal around a condition guarded by a lock |
+| `sync/atomic` | one small piece of independently valid state such as a flag, counter, or pointer |
+
+If you need to protect many related fields with compound invariants, atomics are usually too small and `sync.Map` is usually too weakly typed. A mutex often wins on clarity.
+
+## Simplified internal sketch
+
+```go
+type Once struct {
+	done atomic.Bool
+	mu   sync.Mutex
+}
+
+type WaitGroup struct {
+	state atomic.Uint64 // counter + waiter count
+	sema  uint32
+}
+
+type RWMutex struct {
+	w           Mutex
+	writerSem   uint32
+	readerSem   uint32
+	readerCount atomic.Int32
+	readerWait  atomic.Int32
+}
+
+type Map struct {
+	internal concurrentHashTrie
+}
+```
+
+The common pattern is:
+
+- atomics for the hot path,
+- a mutex or semaphore when full coordination is required,
+- explicit “must not be copied after first use” semantics.
+
+## What the major primitives are really doing
+
+### `RWMutex`
+
+`RWMutex` is not “free read concurrency.”
+
+It works best when:
+
+- reads are much more frequent than writes,
+- read critical sections are short,
+- you truly need one coherent protected object.
+
+It is a bad fit when writes are common or when callers start trying to upgrade from `RLock` to `Lock`. Go's implementation blocks new readers once a writer is pending so the writer can eventually make progress.
+
+### `WaitGroup`
+
+`WaitGroup` is a counting semaphore, not a general lifecycle manager.
+
+In Go 1.26 the docs explicitly recommend preferring `WaitGroup.Go` over hand-written `Add`/`Done` pairs where possible. The misuse cases are still the same:
+
+- `Add` racing with `Wait`,
+- reusing the same `WaitGroup` before the previous wait completes,
+- leaking tasks that never call `Done`.
+
+### `Once`
+
+`Once` is for initialization that must happen exactly once.
+
+It is not a retry wrapper. If the function fails or panics, `Once` still considers the call consumed.
+
+That makes it excellent for immutable bootstrap and a poor fit for “try until healthy.”
+
+### `sync.Map`
+
+`sync.Map` is specialized. The package docs say this directly.
+
+As of Go 1.26, the implementation uses `internal/sync.HashTrieMap`, not a plain map plus one lock. It is optimized for cases like:
+
+- write once, read many,
+- disjoint key sets written concurrently.
+
+It is not a good default replacement for `map[K]V` plus a mutex when your logic depends on type safety or compound invariants.
+
+### `sync.Cond`
+
+`Cond` is not a queue. It is not a mailbox.
+
+It is a rendezvous around a condition guarded by a lock. `Wait` must always be done in a loop because wakeup does not mean the condition is still true by the time the waiter reacquires the lock.
+
+### `sync/atomic`
+
+Atomic operations in Go are sequentially consistent. That is a strong guarantee.
+
+It does not mean they are a good fit for every shared-state problem. Atomics are ideal when one value is independently meaningful:
+
+- a readiness flag,
+- a request counter,
+- a pointer to an immutable snapshot.
+
+They become hard to reason about when several fields must change together.
+
+## Runtime source walk
+
+Useful entry points in the Go 1.26 source:
+
+- [`sync/once.go`](https://github.com/golang/go/blob/go1.26.0/src/sync/once.go)
+- [`sync/waitgroup.go`](https://github.com/golang/go/blob/go1.26.0/src/sync/waitgroup.go)
+- [`sync/rwmutex.go`](https://github.com/golang/go/blob/go1.26.0/src/sync/rwmutex.go)
+- [`sync/cond.go`](https://github.com/golang/go/blob/go1.26.0/src/sync/cond.go)
+- [`sync/map.go`](https://github.com/golang/go/blob/go1.26.0/src/sync/map.go)
+- [`sync/atomic/type.go`](https://github.com/golang/go/blob/go1.26.0/src/sync/atomic/type.go)
+
+Details worth noticing:
+
+- `Once` keeps `done` first for hot-path layout and uses a mutex on the slow path so other callers wait for initialization to finish.
+- `WaitGroup` packs task count and waiter count into one atomic word and releases waiters with a runtime semaphore.
+- `RWMutex` tracks reader count atomically and uses runtime semaphores to block readers or writers when the fast path fails.
+- `Cond.Wait` adds the waiter to a runtime notify list, unlocks, sleeps, then re-locks.
+- `sync.Map.Range` is explicitly not a consistent snapshot.
+
+## Failure patterns
+
+### Using `RWMutex` for write-heavy state
+
+```go
+rw.RLock()
+defer rw.RUnlock()
+```
+
+If writes are frequent, an `RWMutex` can be slower and harder to reason about than a plain mutex.
+
+### Calling `Add` after `Wait` has already begun
+
+```go
+go func() {
+	wg.Add(1) // misuse
+	defer wg.Done()
+	work()
+}()
+wg.Wait()
+```
+
+This is exactly the misuse `WaitGroup` is designed to reject.
+
+### Treating `Once` as retryable initialization
+
+```go
+once.Do(func() {
+	err = connect()
+})
+```
+
+If `connect()` fails once, future callers will not retry through the same `Once`.
+
+### Using `sync.Map` as a drop-in typed domain store
+
+`sync.Map` gives you concurrency safety for individual operations. It does not make your domain invariants easier to maintain.
+
+### Waiting on `Cond` without a loop
+
+```go
+cond.L.Lock()
+cond.Wait()
+useSharedState() // bug: condition may no longer hold
+cond.L.Unlock()
+```
+
+The lock guards the condition. The signal only tells you to check again.
+
+### Using atomics for compound invariants
+
+```go
+atomic.StoreInt64(&state.balance, nextBalance)
+atomic.StoreInt64(&state.version, nextVersion)
+```
+
+If readers need both fields to change together, separate atomics do not give you a coherent multi-field transaction.
+
+## Production consequences
+
+- Prefer a plain mutex until you can clearly explain why another primitive is a better fit.
+- Use `atomic.Pointer` for read-mostly immutable snapshots. It is often the cleanest high-throughput option.
+- Keep `sync.Map` for the narrow cases it is optimized for, not as a default style.
+- Treat `WaitGroup` as a local joining tool, not as a long-lived service controller.
+- If a condition is central to correctness, keep the lock and `Cond` near the state owner.
+
+## Example and tests
+
+- Example: `examples/configsnapshot`
+- The tests verify one-time bootstrap, atomic publication of whole snapshots, and failure paths that keep the last known-good snapshot active.
+
+## Official reading
+
+- [Package docs for `sync`](https://pkg.go.dev/sync)
+- [Package docs for `sync/atomic`](https://pkg.go.dev/sync/atomic)
+- [Go memory model](https://go.dev/ref/mem)
+
+## Practical takeaway
+
+The strongest Go codebases are not “channel-pure.” They pick the smallest synchronization primitive that matches the real invariant and then stop there.

--- a/examples/configsnapshot/configsnapshot.go
+++ b/examples/configsnapshot/configsnapshot.go
@@ -1,0 +1,96 @@
+package configsnapshot
+
+import (
+	"context"
+	"errors"
+	"maps"
+	"sync"
+	"sync/atomic"
+)
+
+var ErrNilLoader = errors.New("loader must not be nil")
+
+type Snapshot struct {
+	Version      int
+	FeatureFlags map[string]bool
+	RegionBudget map[string]int
+}
+
+type Loader func(context.Context) (Snapshot, error)
+
+type Store struct {
+	loader Loader
+
+	bootstrapOnce sync.Once
+	bootstrapErr  error
+
+	reloadMu sync.Mutex
+	current  atomic.Pointer[Snapshot]
+}
+
+func NewStore(loader Loader) (*Store, error) {
+	if loader == nil {
+		return nil, ErrNilLoader
+	}
+
+	return &Store{loader: loader}, nil
+}
+
+func (s *Store) Bootstrap(ctx context.Context) error {
+	s.bootstrapOnce.Do(func() {
+		s.bootstrapErr = s.Reload(ctx)
+	})
+
+	return s.bootstrapErr
+}
+
+func (s *Store) Reload(ctx context.Context) error {
+	s.reloadMu.Lock()
+	defer s.reloadMu.Unlock()
+
+	next, err := s.loader(ctx)
+	if err != nil {
+		return err
+	}
+
+	cloned := cloneSnapshot(next)
+	s.current.Store(&cloned)
+
+	return nil
+}
+
+func (s *Store) Current() (Snapshot, bool) {
+	ptr := s.current.Load()
+	if ptr == nil {
+		return Snapshot{}, false
+	}
+
+	return cloneSnapshot(*ptr), true
+}
+
+func (s *Store) Enabled(flag string) bool {
+	ptr := s.current.Load()
+	if ptr == nil {
+		return false
+	}
+
+	return ptr.FeatureFlags[flag]
+}
+
+func (s *Store) RegionBudgetFor(region string) (int, bool) {
+	ptr := s.current.Load()
+	if ptr == nil {
+		return 0, false
+	}
+
+	budget, ok := ptr.RegionBudget[region]
+	return budget, ok
+}
+
+func cloneSnapshot(in Snapshot) Snapshot {
+	return Snapshot{
+		Version:      in.Version,
+		FeatureFlags: maps.Clone(in.FeatureFlags),
+		RegionBudget: maps.Clone(in.RegionBudget),
+	}
+}

--- a/examples/configsnapshot/configsnapshot_test.go
+++ b/examples/configsnapshot/configsnapshot_test.go
@@ -1,0 +1,144 @@
+package configsnapshot
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestBootstrapRunsLoaderOnlyOnce(t *testing.T) {
+	var calls atomic.Int32
+
+	store, err := NewStore(func(_ context.Context) (Snapshot, error) {
+		calls.Add(1)
+		time.Sleep(10 * time.Millisecond)
+
+		return Snapshot{
+			Version: 1,
+			FeatureFlags: map[string]bool{
+				"beta-search": true,
+			},
+			RegionBudget: map[string]int{
+				"eu-west-1": 24,
+			},
+		}, nil
+	})
+	if err != nil {
+		t.Fatalf("NewStore returned error: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 8)
+
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs <- store.Bootstrap(context.Background())
+		}()
+	}
+
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("Bootstrap returned error: %v", err)
+		}
+	}
+
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("loader calls = %d, want 1", got)
+	}
+
+	if !store.Enabled("beta-search") {
+		t.Fatalf("expected published snapshot to enable beta-search")
+	}
+}
+
+func TestReloadFailureKeepsLastGoodSnapshot(t *testing.T) {
+	var calls atomic.Int32
+
+	store, err := NewStore(func(_ context.Context) (Snapshot, error) {
+		switch calls.Add(1) {
+		case 1:
+			return Snapshot{
+				Version: 1,
+				FeatureFlags: map[string]bool{
+					"beta-search": true,
+				},
+				RegionBudget: map[string]int{
+					"us-east-1": 10,
+				},
+			}, nil
+		default:
+			return Snapshot{}, errors.New("config backend unavailable")
+		}
+	})
+	if err != nil {
+		t.Fatalf("NewStore returned error: %v", err)
+	}
+
+	if err := store.Bootstrap(context.Background()); err != nil {
+		t.Fatalf("Bootstrap returned error: %v", err)
+	}
+
+	if err := store.Reload(context.Background()); err == nil {
+		t.Fatalf("Reload error = nil, want backend error")
+	}
+
+	snapshot, ok := store.Current()
+	if !ok {
+		t.Fatalf("Current returned no snapshot after successful bootstrap")
+	}
+	if snapshot.Version != 1 {
+		t.Fatalf("snapshot version = %d, want 1", snapshot.Version)
+	}
+	if !snapshot.FeatureFlags["beta-search"] {
+		t.Fatalf("expected previous snapshot to remain active after reload failure")
+	}
+}
+
+func TestCurrentReturnsIsolatedCopy(t *testing.T) {
+	store, err := NewStore(func(_ context.Context) (Snapshot, error) {
+		return Snapshot{
+			Version: 2,
+			FeatureFlags: map[string]bool{
+				"beta-search": true,
+			},
+			RegionBudget: map[string]int{
+				"ap-south-1": 15,
+			},
+		}, nil
+	})
+	if err != nil {
+		t.Fatalf("NewStore returned error: %v", err)
+	}
+
+	if err := store.Bootstrap(context.Background()); err != nil {
+		t.Fatalf("Bootstrap returned error: %v", err)
+	}
+
+	snapshot, ok := store.Current()
+	if !ok {
+		t.Fatalf("Current returned no snapshot")
+	}
+
+	snapshot.FeatureFlags["beta-search"] = false
+	snapshot.RegionBudget["ap-south-1"] = 1
+
+	if !store.Enabled("beta-search") {
+		t.Fatalf("mutating returned snapshot should not alter stored snapshot")
+	}
+
+	budget, ok := store.RegionBudgetFor("ap-south-1")
+	if !ok {
+		t.Fatalf("expected stored region budget to exist")
+	}
+	if budget != 15 {
+		t.Fatalf("stored budget = %d, want 15", budget)
+	}
+}

--- a/examples/ndjsonstream/ndjsonstream.go
+++ b/examples/ndjsonstream/ndjsonstream.go
@@ -1,0 +1,85 @@
+package ndjsonstream
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+)
+
+const defaultBufferSize = 16 * 1024
+
+var ErrInvalidPreviewLimit = errors.New("preview limit must be at least 1")
+
+type ShipmentEvent struct {
+	OrderID     string `json:"order_id"`
+	Stage       string `json:"stage"`
+	Carrier     string `json:"carrier"`
+	WeightGrams int    `json:"weight_grams"`
+}
+
+func EncodeStream(ctx context.Context, w io.Writer, events <-chan ShipmentEvent) error {
+	buffered := bufio.NewWriterSize(w, defaultBufferSize)
+	encoder := json.NewEncoder(buffered)
+	encoder.SetEscapeHTML(false)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case event, ok := <-events:
+			if !ok {
+				return buffered.Flush()
+			}
+			if err := encoder.Encode(event); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func FilterStage(r io.Reader, stage string) ([]byte, error) {
+	decoder := json.NewDecoder(bufio.NewReaderSize(r, defaultBufferSize))
+	decoder.DisallowUnknownFields()
+
+	var out bytes.Buffer
+	buffered := bufio.NewWriterSize(&out, defaultBufferSize)
+	encoder := json.NewEncoder(buffered)
+	encoder.SetEscapeHTML(false)
+
+	for {
+		var event ShipmentEvent
+
+		err := decoder.Decode(&event)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		if event.Stage != stage {
+			continue
+		}
+
+		if err := encoder.Encode(event); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := buffered.Flush(); err != nil {
+		return nil, err
+	}
+
+	return bytes.Clone(out.Bytes()), nil
+}
+
+func CopyPreview(dst io.Writer, src io.Reader, limit int64) (int64, error) {
+	if limit < 1 {
+		return 0, ErrInvalidPreviewLimit
+	}
+
+	return io.Copy(dst, io.LimitReader(src, limit))
+}

--- a/examples/ndjsonstream/ndjsonstream_test.go
+++ b/examples/ndjsonstream/ndjsonstream_test.go
@@ -1,0 +1,103 @@
+package ndjsonstream
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"testing"
+)
+
+func TestEncodeStreamWritesNDJSON(t *testing.T) {
+	events := make(chan ShipmentEvent, 2)
+	events <- ShipmentEvent{OrderID: "ord-1", Stage: "packed", Carrier: "dhl", WeightGrams: 1800}
+	events <- ShipmentEvent{OrderID: "ord-2", Stage: "shipped", Carrier: "ups", WeightGrams: 2100}
+	close(events)
+
+	var out bytes.Buffer
+	if err := EncodeStream(context.Background(), &out, events); err != nil {
+		t.Fatalf("EncodeStream returned error: %v", err)
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(out.Bytes()))
+
+	var decoded []ShipmentEvent
+	for {
+		var event ShipmentEvent
+		err := decoder.Decode(&event)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Decode returned error: %v", err)
+		}
+		decoded = append(decoded, event)
+	}
+
+	if len(decoded) != 2 {
+		t.Fatalf("decoded %d events, want 2", len(decoded))
+	}
+	if decoded[0].OrderID != "ord-1" || decoded[1].OrderID != "ord-2" {
+		t.Fatalf("decoded events out of order: %#v", decoded)
+	}
+}
+
+func TestFilterStageKeepsOnlyMatchingRecords(t *testing.T) {
+	input := bytes.NewBufferString(
+		`{"order_id":"ord-1","stage":"packed","carrier":"dhl","weight_grams":1800}` + "\n" +
+			`{"order_id":"ord-2","stage":"shipped","carrier":"ups","weight_grams":2100}` + "\n" +
+			`{"order_id":"ord-3","stage":"packed","carrier":"fedex","weight_grams":1600}` + "\n",
+	)
+
+	filtered, err := FilterStage(input, "packed")
+	if err != nil {
+		t.Fatalf("FilterStage returned error: %v", err)
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(filtered))
+
+	var decoded []ShipmentEvent
+	for {
+		var event ShipmentEvent
+		err := decoder.Decode(&event)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Decode returned error: %v", err)
+		}
+		decoded = append(decoded, event)
+	}
+
+	if len(decoded) != 2 {
+		t.Fatalf("decoded %d events, want 2", len(decoded))
+	}
+	if decoded[0].OrderID != "ord-1" || decoded[1].OrderID != "ord-3" {
+		t.Fatalf("unexpected filtered records: %#v", decoded)
+	}
+}
+
+func TestFilterStageRejectsUnknownFields(t *testing.T) {
+	input := bytes.NewBufferString(`{"order_id":"ord-1","stage":"packed","carrier":"dhl","weight_grams":1800,"unexpected":true}` + "\n")
+
+	if _, err := FilterStage(input, "packed"); err == nil {
+		t.Fatalf("FilterStage error = nil, want unknown-field error")
+	}
+}
+
+func TestCopyPreviewLimitsBytes(t *testing.T) {
+	var out bytes.Buffer
+
+	written, err := CopyPreview(&out, bytes.NewBufferString("tracking:ord-100"), 8)
+	if err != nil {
+		t.Fatalf("CopyPreview returned error: %v", err)
+	}
+
+	if written != 8 {
+		t.Fatalf("written = %d, want 8", written)
+	}
+	if out.String() != "tracking" {
+		t.Fatalf("preview = %q, want %q", out.String(), "tracking")
+	}
+}


### PR DESCRIPTION
## Summary
- expand the bilingual Standard Library section with `sync`/`sync/atomic`, process signals and runtime observability, `io`/`bufio`/`bytes`, and `encoding/json`
- add runnable examples and tests for read-mostly config snapshots and streaming NDJSON I/O
- update the standard-library overview, homepage entry points, sidebar navigation, and README

## Testing
- `go test ./...`
- `npm run docs:build`

Closes #19