### PR TITLE
Docs: expand open-source production case studies

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ VitePress will print a local preview URL in the terminal, usually `http://localh
 ## Included production topics
 
 - Large-scale Go systems: admission control, goroutine ownership, memory budgets, and shutdown policy
-- Open-source case studies from Kubernetes, etcd/raft, Prometheus, and NATS
+- Open-source case studies from Kubernetes, etcd/raft, Prometheus, NATS, gRPC-Go, CockroachDB, and go-redis
 
 ## Included testing topics
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -124,6 +124,7 @@ features:
 | How to survive overload instead of just failing later | [Backpressure and Load Shedding](/advanced/backpressure-load-shedding) |
 | How to test timeout-heavy code without real sleeps | [Deterministic Tests with synctest](/testing/synctest) |
 | What large Go production systems care about beyond toy patterns | [Large-Scale Go Systems](/production/large-scale-go-systems) |
+| How major Go projects actually build queues, transport loops, stopper lifetimes, and pools | [Open-Source Case Studies](/production/open-source-case-studies) |
 | How Go differs from Rust Tokio's async runtime model | [Go CSP vs Rust Tokio](/extras/go-csp-vs-rust-tokio) |
 
 ## What Makes This Site Different

--- a/docs/ko/index.md
+++ b/docs/ko/index.md
@@ -124,6 +124,7 @@ features:
 | 과부하를 늦게 터뜨리지 않고 초기에 제어하는 법 | [역압력과 로드 셰딩](/ko/advanced/backpressure-load-shedding) |
 | timeout-heavy 코드를 실제 sleep 없이 어떻게 테스트하는지 | [synctest로 결정적 테스트](/ko/testing/synctest) |
 | 토이 패턴을 넘어 대규모 Go 운영에서 무엇이 중요한지 | [대규모 Go 시스템](/ko/production/large-scale-go-systems) |
+| 주요 Go 오픈소스가 queue, transport loop, stopper lifetime, pool을 어떻게 구현하는지 | [오픈소스 사례](/ko/production/open-source-case-studies) |
 | Go와 Rust Tokio의 async runtime 모델이 어떻게 다른지 | [Go CSP vs Rust Tokio](/ko/extras/go-csp-vs-rust-tokio) |
 
 ## 이 사이트가 다른 이유

--- a/docs/ko/production/index.md
+++ b/docs/ko/production/index.md
@@ -14,7 +14,7 @@ description: Go 코드가 실제 대규모 트래픽을 받을 때 중요해지�
 | 주제 | 왜 중요한가 |
 | --- | --- |
 | [대규모 Go 시스템](/ko/production/large-scale-go-systems) | 런타임 지식을 실제 latency, memory, overload, shutdown 규칙으로 바꿉니다 |
-| [오픈소스 사례](/ko/production/open-source-case-studies) | 대표적인 Go 오픈소스가 concurrency를 어떻게 구조화하는지 소스와 함께 봅니다 |
+| [오픈소스 사례](/ko/production/open-source-case-studies) | Kubernetes, etcd, Prometheus, NATS, gRPC-Go, CockroachDB, go-redis가 concurrency policy를 어떻게 코드에 드러내는지 봅니다 |
 
 ## 프로덕션에서 질문이 달라진다
 

--- a/docs/ko/production/open-source-case-studies.md
+++ b/docs/ko/production/open-source-case-studies.md
@@ -7,115 +7,404 @@ description: 대표적인 Go 오픈소스가 실제로 concurrency를 어떻게 
 
 동시성 감각을 빠르게 끌어올리는 가장 좋은 방법 중 하나는 실제 production pressure를 버틴 Go 프로젝트를 읽는 것입니다.
 
-이 문서는 프로젝트 전체를 요약하려는 것이 아니라, 특히 볼 가치가 있는 concurrency 구조를 짚습니다.
+이 문서는 프로젝트 소개 모음이 아니라, 실제로 훔쳐올 만한 concurrency boundary를 읽는 가이드입니다.
+
+## 빠른 지도
+
+| 프로젝트 | 핵심 교훈 | 주 소스 |
+| --- | --- | --- |
+| Kubernetes `client-go` | 재처리 semantics와 drain-aware worker queue | [`util/workqueue/queue.go`](https://github.com/kubernetes/client-go/blob/c826020ed98be668f4b5a8f140e7a4b8621e2a76/util/workqueue/queue.go#L167-L339) |
+| etcd/raft | `Ready`/`Advance`를 correctness boundary로 쓰는 법 | [`node.go`](https://github.com/etcd-io/raft/blob/f39329d54771fb68f39e26c440c8cbd02215f6c5/node.go#L297-L549) |
+| Prometheus | periodic work를 owner loop 하나로 묶는 법 | [`scrape/scrape.go`](https://github.com/prometheus/prometheus/blob/3b44b8b463be9291a5605b935a5fbeda88db1366/scrape/scrape.go#L822-L1308) |
+| NATS Server | `sync.Cond`로 read/write socket ownership을 분리하는 법 | [`server/client.go`](https://github.com/nats-io/nats-server/blob/bae1d6c752e0550901d0a79a76fb2fabe79c1eff/server/client.go#L355-L355), [`writeLoop`](https://github.com/nats-io/nats-server/blob/bae1d6c752e0550901d0a79a76fb2fabe79c1eff/server/client.go#L1274-L1355), [`readLoop`](https://github.com/nats-io/nats-server/blob/bae1d6c752e0550901d0a79a76fb2fabe79c1eff/server/client.go#L1358-L1415) |
+| gRPC-Go | single writer goroutine과 control buffer | [`internal/transport/controlbuf.go`](https://github.com/grpc/grpc-go/blob/b9f7967353473f3b585092ac5d961de3878e1f12/internal/transport/controlbuf.go#L307-L629) |
+| CockroachDB | 서비스 전체의 task ownership과 quiesce contract | [`pkg/util/stop/stopper.go`](https://github.com/cockroachdb/cockroach/blob/41c5df3d4a4cd26e8852677aebb513184e78ccd9/pkg/util/stop/stopper.go#L152-L670) |
+| go-redis | pool admission, wait budget, connection handoff | [`internal/pool/pool.go`](https://github.com/redis/go-redis/blob/6193e530d612d362359a6709b46dc2c159e1455d/internal/pool/pool.go#L306-L1078) |
+
+## 어떻게 읽어야 하나
+
+아래 코드를 읽기 전에 항상 먼저 물어야 할 질문은 이 다섯 가지입니다.
+
+1. lifetime owner는 어디인가
+2. overload boundary는 어디인가
+3. state owner는 누구인가
+4. shutdown contract는 어디에 드러나는가
+5. 어떤 metric이나 trace가 이 설계의 이상 징후를 보여줄 수 있는가
+
+API 이름보다 이 질문이 더 중요합니다.
 
 ## Kubernetes client-go workqueue
 
-소스:
+왜 읽을 가치가 있는가:
 
-- [kubernetes/client-go util/workqueue/queue.go](https://github.com/kubernetes/client-go/blob/master/util/workqueue/queue.go)
+controller 코드는 흔히 “worker goroutine이 queue를 소비한다” 정도로 설명됩니다. 진짜 중요한 건 goroutine 수가 아니라, 처리 중 재변경 신호를 어떻게 잃지 않는가입니다.
 
-볼 포인트:
+주 소스:
 
-- `dirty`와 `processing` 집합
-- `Get`, `Done`, `ShutDown`
-- 중복 work를 dedupe하면서도 requeue semantics를 잃지 않는 방식
+- [`Typed` queue 상태](https://github.com/kubernetes/client-go/blob/c826020ed98be668f4b5a8f140e7a4b8621e2a76/util/workqueue/queue.go#L192-L203)
+- [`Add`](https://github.com/kubernetes/client-go/blob/c826020ed98be668f4b5a8f140e7a4b8621e2a76/util/workqueue/queue.go#L224-L249)
+- [`Get`](https://github.com/kubernetes/client-go/blob/c826020ed98be668f4b5a8f140e7a4b8621e2a76/util/workqueue/queue.go#L264-L283)
+- [`Done`](https://github.com/kubernetes/client-go/blob/c826020ed98be668f4b5a8f140e7a4b8621e2a76/util/workqueue/queue.go#L289-L302)
+- [`ShutDown`, `ShutDownWithDrain`](https://github.com/kubernetes/client-go/blob/c826020ed98be668f4b5a8f140e7a4b8621e2a76/util/workqueue/queue.go#L305-L340)
 
-왜 중요한가:
+핵심 concurrency boundary:
 
-이 queue 설계는 "같은 item이 처리 중일 때 다시 업데이트되면 어떻게 할 것인가"에 대한 production-grade 답입니다. 같은 item이 queue를 무한히 오염시키지 않으면서도 재처리 신호는 보존합니다.
+queue는 queued item, `dirty`, `processing` 세 상태를 같이 소유하면서 재처리 semantics를 책임집니다.
 
 단순화한 형태:
 
 ```go
-if item already processing {
-    mark dirty
-    return
+func Add(item Key) {
+	if shuttingDown {
+		return
+	}
+	if dirty[item] {
+		if !processing[item] {
+			touch(item)
+		}
+		return
+	}
+	dirty[item] = true
+	if processing[item] {
+		return
+	}
+	queue.push(item)
+	signalWorker()
 }
-enqueue(item)
+
+func Done(item Key) {
+	delete(processing, item)
+	if dirty[item] {
+		queue.push(item)
+		signalWorker()
+	}
+}
 ```
+
+왜 이게 중요한가:
+
+worker가 아직 처리 중인 동안 같은 object가 다시 바뀌어도 그 신호가 사라지지 않습니다. `dirty`가 그것을 기억했다가 `Done` 뒤에 다시 큐잉합니다.
+
+실패 패턴:
+
+이걸 보고 “아무 큐나 두 개의 map만 붙이면 된다”고 읽으면 안 됩니다. 교훈은 더 좁습니다. in-flight 중복 업데이트가 가능한 시스템이라면 replay semantics를 queue가 명시적으로 가져야 한다는 점입니다.
 
 핵심 takeaway:
 
-프로덕션 queue는 단순 slice + channel이 아닙니다. 재처리 semantics와 shutdown semantics를 함께 품습니다.
+이건 단순 channel이 아니라 상태 semantics를 가진 queue입니다.
 
-## etcd raft node loop
+## etcd/raft node loop
 
-소스:
+왜 읽을 가치가 있는가:
 
-- [etcd-io/raft node.go](https://github.com/etcd-io/raft/blob/main/node.go)
+Go에서 communication boundary가 correctness boundary가 되는 가장 좋은 예 중 하나입니다.
 
-볼 포인트:
+주 소스:
 
-- `Ready() <-chan Ready`
-- `Advance()`
-- `Tick()`
-- `Step(ctx, msg)`
+- [`node` 메인 루프](https://github.com/etcd-io/raft/blob/f39329d54771fb68f39e26c440c8cbd02215f6c5/node.go#L297-L456)
+- [`Tick`](https://github.com/etcd-io/raft/blob/f39329d54771fb68f39e26c440c8cbd02215f6c5/node.go#L458-L466)
+- [`Step`](https://github.com/etcd-io/raft/blob/f39329d54771fb68f39e26c440c8cbd02215f6c5/node.go#L473-L545)
+- [`Ready`, `Advance`](https://github.com/etcd-io/raft/blob/f39329d54771fb68f39e26c440c8cbd02215f6c5/node.go#L547-L553)
 
-왜 중요한가:
+핵심 concurrency boundary:
 
-Raft core와 storage / transport를 channel 기반 경계로 분리합니다. core는 "다음에 persist/send 해야 할 것"을 내보내고, 바깥 계층이 durability를 보장한 뒤 `Advance`로 진행시킵니다.
+Raft core는 `Ready`를 통해 “지금 persist/send/apply 해야 하는 작업 묶음”을 내보내고, 바깥 계층은 실제로 그 경계를 만족한 뒤 `Advance`를 호출합니다.
 
 단순화한 형태:
 
 ```go
 for {
-    select {
-    case rd := <-node.Ready():
-        persist(rd)
-        send(rd.Messages)
-        node.Advance()
-    }
+	select {
+	case rd := <-node.Ready():
+		persist(rd.HardState, rd.Entries, rd.Snapshot)
+		send(rd.Messages)
+		apply(rd.CommittedEntries)
+		node.Advance()
+	}
 }
 ```
 
+왜 이게 중요한가:
+
+알고리즘 코어는 디스크 durability나 네트워크 전송을 직접 소유하지 않습니다. 대신 다음 진행에 필요한 correctness unit을 선언하고 바깥이 확인해주길 기다립니다.
+
+실패 패턴:
+
+이걸 그냥 “채널 기반 루프 하나” 정도로 읽으면 핵심을 놓칩니다. durability boundary를 만족하기 전에 `Advance`를 호출하면 설계 자체를 깨뜨립니다.
+
 핵심 takeaway:
 
-communication boundary가 곧 correctness boundary가 되는 아주 좋은 예입니다.
+좋은 channel API는 데이터를 전달할 뿐 아니라, 상태 머신이 언제 앞으로 나가도 되는지도 정의합니다.
 
 ## Prometheus scrape loop
 
-소스:
+왜 읽을 가치가 있는가:
 
-- [prometheus/prometheus scrape/scrape.go](https://github.com/prometheus/prometheus/blob/main/scrape/scrape.go)
+Prometheus는 periodic work를 timer 조각들로 흩뿌리지 않고, 시간과 종료를 하나의 owner loop에 모읍니다.
 
-볼 포인트:
+주 소스:
 
-- `newScrapeLoop`
-- `(*scrapeLoop).run`
-- ticker-driven scheduling, cancellation, staleness handling이 한 lifecycle loop 안에 모여 있는 구조
+- [`scrapeLoop` 상태](https://github.com/prometheus/prometheus/blob/3b44b8b463be9291a5605b935a5fbeda88db1366/scrape/scrape.go#L822-L910)
+- [`newScrapeLoop`](https://github.com/prometheus/prometheus/blob/3b44b8b463be9291a5605b935a5fbeda88db1366/scrape/scrape.go#L1154-L1232)
+- [`run`](https://github.com/prometheus/prometheus/blob/3b44b8b463be9291a5605b935a5fbeda88db1366/scrape/scrape.go#L1234-L1308)
 
-왜 중요한가:
+핵심 concurrency boundary:
 
-Prometheus는 단순히 "N초마다 goroutine 하나 돌린다"가 아닙니다. scrape loop가 시간, 에러 처리, append flow, shutdown semantics를 하나의 owner loop에서 책임집니다.
+하나의 loop가 startup offset, ticker cadence, cancellation, staleness marker, append flow를 모두 소유합니다.
+
+단순화한 형태:
+
+```go
+func run() {
+	waitInitialOffset()
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-parentCtx.Done():
+			return
+		case <-loopCtx.Done():
+			break
+		default:
+		}
+
+		last = scrapeAndReport(last, nowRounded())
+
+		select {
+		case <-parentCtx.Done():
+			return
+		case <-loopCtx.Done():
+			break
+		case <-ticker.C:
+		}
+	}
+
+	endOfRunStaleness(last)
+}
+```
+
+왜 이게 중요한가:
+
+주기 작업은 시간이 곧 state입니다. Prometheus는 그 시간을 owner loop 하나에 붙여서 shutdown과 append semantics를 같이 관리합니다. 소스에서 shutdown용 context와 append용 context를 분리하는 점도 눈여겨볼 만합니다.
+
+실패 패턴:
+
+helper 함수 곳곳에 `time.After`와 ticker를 흩뿌리는 식으로 periodic 시스템을 만들면 lifecycle 경계가 흐려집니다.
 
 핵심 takeaway:
 
-주기 작업은 helper 곳곳에 timer를 뿌리는 것보다, explicit owner loop 하나에 lifecycle을 모으는 편이 대규모 운영에서 훨씬 낫습니다.
+주기 작업이라면 time ownership을 하나의 loop에 모으는 편이 강합니다.
 
-## NATS server client read/write loops
+## NATS Server client read/write loops
 
-소스:
+왜 읽을 가치가 있는가:
 
-- [nats-io/nats-server server/client.go](https://github.com/nats-io/nats-server/blob/main/server/client.go)
+Go에서 channels만이 정답이 아니라는 점을 아주 분명하게 보여줍니다.
 
-볼 포인트:
+주 소스:
 
-- `readLoop`
-- `writeLoop`
-- outbound flush를 위한 `sync.Cond` signaling
+- [`sync.Cond`가 붙은 outbound 상태](https://github.com/nats-io/nats-server/blob/bae1d6c752e0550901d0a79a76fb2fabe79c1eff/server/client.go#L355-L355)
+- [`writeLoop`](https://github.com/nats-io/nats-server/blob/bae1d6c752e0550901d0a79a76fb2fabe79c1eff/server/client.go#L1274-L1355)
+- [`readLoop`](https://github.com/nats-io/nats-server/blob/bae1d6c752e0550901d0a79a76fb2fabe79c1eff/server/client.go#L1358-L1415)
+- [`flushSignal`](https://github.com/nats-io/nats-server/blob/bae1d6c752e0550901d0a79a76fb2fabe79c1eff/server/client.go#L1996-L2003)
 
-왜 중요한가:
+핵심 concurrency boundary:
 
-NATS는 socket read와 write를 분리하고, busy waiting 대신 명시적 signaling을 사용합니다. 모든 것을 channel로만 밀어붙이지 않고, condition variable과 소유권이 더 잘 맞는 경우를 보여줍니다.
+socket read와 write는 ownership이 다릅니다. write side는 buffered outbound state를 소유하고, 필요할 때 `sync.Cond`로 깨워집니다.
+
+단순화한 형태:
+
+```go
+func writeLoop() {
+	for {
+		lock()
+		for open && shouldSleep() {
+			cond.Wait()
+		}
+		if closed {
+			flushAndClose()
+			unlock()
+			return
+		}
+		flushOutbound()
+		unlock()
+	}
+}
+
+func flushSignal() {
+	cond.Signal()
+}
+```
+
+왜 이게 중요한가:
+
+writer loop가 socket write path를 단독 소유하므로, 여러 goroutine이 직접 connection에 write하는 혼란을 피할 수 있습니다.
+
+실패 패턴:
+
+`go readLoop`, `go writeLoop` 모양만 복사하면 안 됩니다. 진짜 교훈은 `single-owner socket writing + explicit wake-up semantics`입니다.
 
 핵심 takeaway:
 
-프로덕션 Go에서는 channel만이 정답이 아닙니다. `sync.Cond`와 명확한 owner loop가 더 적합한 경우가 분명히 있습니다.
+hot socket path에서는 `sync.Cond`와 명확한 owner가 channel보다 더 정확한 모델일 수 있습니다.
 
-## 실패 패턴
+## gRPC-Go transport control buffer
 
-프로덕션 Go 코드를 잘못 읽으면 goroutine만 복사하고 그 주변 경계는 빠뜨리기 쉽습니다.
+왜 읽을 가치가 있는가:
+
+여러 RPC stream이 하나의 HTTP/2 connection을 공유할 때, 왜 single writer가 필요한지 아주 잘 보여줍니다.
+
+주 소스:
+
+- [`controlBuffer`](https://github.com/grpc/grpc-go/blob/b9f7967353473f3b585092ac5d961de3878e1f12/internal/transport/controlbuf.go#L307-L511)
+- [`loopyWriter`](https://github.com/grpc/grpc-go/blob/b9f7967353473f3b585092ac5d961de3878e1f12/internal/transport/controlbuf.go#L513-L584)
+- [`loopyWriter.run`](https://github.com/grpc/grpc-go/blob/b9f7967353473f3b585092ac5d961de3878e1f12/internal/transport/controlbuf.go#L586-L629)
+
+핵심 concurrency boundary:
+
+frame emission은 하나의 writer goroutine이 소유하고, 다른 goroutine은 control item과 data를 control buffer에 enqueue합니다.
+
+단순화한 형태:
+
+```go
+func transportWriter() {
+	for {
+		item := controlBuffer.get(block=true)
+		handleControl(item)
+		processOneActiveStream()
+
+		for controlBuffer.hasMore() || activeStreamsNotEmpty() {
+			handleMoreItems()
+			processOneActiveStream()
+		}
+
+		flushWire()
+	}
+}
+```
+
+왜 이게 중요한가:
+
+control buffer가 transport mutation을 serialize하고, loopy writer는 flow-control quota 아래에서 active stream을 round-robin으로 처리합니다. 즉 하나의 connection 위에 여러 논리 stream을 안전하게 multiplex합니다.
+
+실패 패턴:
+
+stream goroutine이 shared `net.Conn`에 직접 HTTP/2 frame을 쓰게 두면 안 됩니다. single-writer boundary는 구현 디테일이 아니라 설계 핵심입니다.
+
+핵심 takeaway:
+
+multiplexed transport는 대개 command queue + writer owner 구조가 맞습니다.
+
+## CockroachDB stopper
+
+왜 읽을 가치가 있는가:
+
+CockroachDB는 goroutine lifetime을 서비스 차원의 경계로 다룹니다. background task가 “언젠가 끝나겠지”에 맡겨져 있지 않습니다.
+
+주 소스:
+
+- [`Stopper` 상태](https://github.com/cockroachdb/cockroach/blob/41c5df3d4a4cd26e8852677aebb513184e78ccd9/pkg/util/stop/stopper.go#L152-L214)
+- [`WithCancelOnQuiesce`](https://github.com/cockroachdb/cockroach/blob/41c5df3d4a4cd26e8852677aebb513184e78ccd9/pkg/util/stop/stopper.go#L272-L289)
+- [`RunAsyncTask`, `RunAsyncTaskEx`](https://github.com/cockroachdb/cockroach/blob/41c5df3d4a4cd26e8852677aebb513184e78ccd9/pkg/util/stop/stopper.go#L358-L446)
+- [`Stop`, `Quiesce`](https://github.com/cockroachdb/cockroach/blob/41c5df3d4a4cd26e8852677aebb513184e78ccd9/pkg/util/stop/stopper.go#L562-L655)
+
+핵심 concurrency boundary:
+
+stopper가 task admission, task counting, quiesce signal, shutdown wait를 중앙에서 소유합니다.
+
+단순화한 형태:
+
+```go
+func RunAsyncTask(ctx, opts, f) error {
+	handle, err := GetHandle(ctx, opts)
+	if err != nil {
+		return err
+	}
+	go func() {
+		defer handle.Release()
+		f(handleCtx)
+	}()
+	return nil
+}
+
+func Stop(ctx) {
+	markStopping()
+	close(quiescer)
+	cancelQuiesceContexts()
+	waitUntilNumTasksIsZero()
+	runClosersInReverseOrder()
+}
+```
+
+왜 이게 중요한가:
+
+background work에 admission control, observability, coordinated shutdown path를 붙이면 서비스 전체의 lifetime이 예측 가능해집니다.
+
+실패 패턴:
+
+이걸 “조금 더 좋은 wait group”으로 읽으면 안 됩니다. 핵심은 quiescing 상태에서 새 작업을 거부하고, 기존 task에 shutdown-tied cancellation을 준다는 점입니다.
+
+핵심 takeaway:
+
+큰 서비스는 goroutine lifetime을 중앙에서 소유하는 장치가 필요합니다.
+
+## go-redis connection pool
+
+왜 읽을 가치가 있는가:
+
+이건 서버가 아니라 라이브러리지만, admission control과 handoff를 아주 깔끔하게 보여주는 예입니다.
+
+주 소스:
+
+- [`ConnPool` 상태](https://github.com/redis/go-redis/blob/6193e530d612d362359a6709b46dc2c159e1455d/internal/pool/pool.go#L306-L339)
+- [`Get`](https://github.com/redis/go-redis/blob/6193e530d612d362359a6709b46dc2c159e1455d/internal/pool/pool.go#L701-L819)
+- [`queuedNewConn`](https://github.com/redis/go-redis/blob/6193e530d612d362359a6709b46dc2c159e1455d/internal/pool/pool.go#L821-L897)
+- [`waitTurn`](https://github.com/redis/go-redis/blob/6193e530d612d362359a6709b46dc2c159e1455d/internal/pool/pool.go#L954-L978)
+- [`Put`](https://github.com/redis/go-redis/blob/6193e530d612d362359a6709b46dc2c159e1455d/internal/pool/pool.go#L1049-L1078)
+
+핵심 concurrency boundary:
+
+caller는 무제한으로 dial하지 않습니다. 먼저 pool에서 permission을 얻고, 그 다음 idle connection을 재사용하거나 new dial 경로로 들어갑니다.
+
+단순화한 형태:
+
+```go
+func Get(ctx) (*Conn, error) {
+	if err := waitTurn(ctx); err != nil {
+		return nil, err
+	}
+
+	if cn := popHealthyIdle(); cn != nil {
+		return cn, nil
+	}
+
+	return queuedNewConn(ctx)
+}
+
+func waitTurn(ctx) error {
+	if semaphore.TryAcquire() {
+		return nil
+	}
+	return semaphore.Acquire(ctx, poolTimeout)
+}
+```
+
+왜 이게 중요한가:
+
+pool은 명시적인 admission boundary를 가집니다. saturation 시 caller는 기다리거나 fail하지, 무한 dial을 새로 만들지 않습니다.
+
+실패 패턴:
+
+pool을 두면서도 timeout 이후 caller가 각자 직접 connection을 열 수 있게 두면 실제로는 아무 것도 bounded하지 않은 것입니다.
+
+핵심 takeaway:
+
+진짜 pool은 idle connection cache가 아니라 admission controller입니다.
+
+## 공통적인 오해
+
+프로덕션 Go 코드를 잘못 읽으면 goroutine만 복사하고 그 경계는 빠뜨리기 쉽습니다.
 
 ```go
 for _, msg := range batch {
@@ -123,20 +412,10 @@ for _, msg := range batch {
 }
 ```
 
-위에서 본 시스템들이 실제로 강한 이유는 queue, owner loop, signaling edge, lifecycle rule을 같이 갖고 있기 때문입니다. goroutine의 존재 자체보다 그 경계가 더 중요합니다.
-
-## 어떻게 읽어야 하나
-
-오픈소스 Go 코드를 읽을 때는 이렇게 물어보면 좋습니다.
-
-1. lifetime owner는 어디인가
-2. overload boundary는 어디인가
-3. state owner는 누구인가
-4. shutdown contract는 어디에 드러나는가
-5. 어떤 metric / trace가 실패를 드러내는가
+위 시스템들이 강한 이유는 goroutine 수가 아니라, queue state, ownership loop, admission control, flow control, shutdown policy가 같이 있기 때문입니다.
 
 ## Practical takeaway
 
 오픈소스 Go 코드는 API보다 경계를 읽을 때 가장 많이 배울 수 있습니다.
 
-좋은 프로젝트일수록 queue design, lifecycle loop, signaling edge, shutdown path 안에 concurrency policy가 잘 드러납니다.
+좋은 프로젝트일수록 queue design, lifecycle loop, signaling edge, backpressure, shutdown path 안에 concurrency policy가 드러납니다.

--- a/docs/production/index.md
+++ b/docs/production/index.md
@@ -14,7 +14,7 @@ This section is about what changes when the code is no longer a neat example and
 | Topic | Why it matters |
 | --- | --- |
 | [Large-Scale Go Systems](/production/large-scale-go-systems) | Turns runtime knowledge into operating rules for latency, memory, shutdown, and overload |
-| [Open-Source Case Studies](/production/open-source-case-studies) | Shows how major Go projects structure concurrency in real source code |
+| [Open-Source Case Studies](/production/open-source-case-studies) | Shows how Kubernetes, etcd, Prometheus, NATS, gRPC-Go, CockroachDB, and go-redis make concurrency policy visible in real source code |
 
 ## The production shift
 

--- a/docs/production/open-source-case-studies.md
+++ b/docs/production/open-source-case-studies.md
@@ -5,117 +5,406 @@ description: Learn how major Go open-source projects structure concurrency in pr
 
 # Open-Source Case Studies
 
-The fastest way to deepen your concurrency taste is to read real Go systems that survived production pressure.
+The fastest way to sharpen your concurrency taste is to read real Go systems that survived production pressure.
 
-This page does not try to summarize whole projects. It focuses on concurrency structures worth studying.
+This page is not a project summary catalog. It is a source-reading guide focused on the concurrency boundaries that are actually worth stealing.
+
+## Quick map
+
+| Project | Main lesson | Primary source |
+| --- | --- | --- |
+| Kubernetes `client-go` | Requeue semantics and drain-aware worker queues | [`util/workqueue/queue.go`](https://github.com/kubernetes/client-go/blob/c826020ed98be668f4b5a8f140e7a4b8621e2a76/util/workqueue/queue.go#L167-L339) |
+| etcd/raft | `Ready`/`Advance` as a correctness boundary | [`node.go`](https://github.com/etcd-io/raft/blob/f39329d54771fb68f39e26c440c8cbd02215f6c5/node.go#L297-L549) |
+| Prometheus | One owner loop for periodic work and shutdown | [`scrape/scrape.go`](https://github.com/prometheus/prometheus/blob/3b44b8b463be9291a5605b935a5fbeda88db1366/scrape/scrape.go#L822-L1308) |
+| NATS Server | Split read/write socket ownership with `sync.Cond` signaling | [`server/client.go`](https://github.com/nats-io/nats-server/blob/bae1d6c752e0550901d0a79a76fb2fabe79c1eff/server/client.go#L355-L355), [`writeLoop`](https://github.com/nats-io/nats-server/blob/bae1d6c752e0550901d0a79a76fb2fabe79c1eff/server/client.go#L1274-L1355), [`readLoop`](https://github.com/nats-io/nats-server/blob/bae1d6c752e0550901d0a79a76fb2fabe79c1eff/server/client.go#L1358-L1415) |
+| gRPC-Go | Single writer goroutine plus explicit control buffer | [`internal/transport/controlbuf.go`](https://github.com/grpc/grpc-go/blob/b9f7967353473f3b585092ac5d961de3878e1f12/internal/transport/controlbuf.go#L307-L629) |
+| CockroachDB | Service-wide task ownership and quiesce semantics | [`pkg/util/stop/stopper.go`](https://github.com/cockroachdb/cockroach/blob/41c5df3d4a4cd26e8852677aebb513184e78ccd9/pkg/util/stop/stopper.go#L152-L670) |
+| go-redis | Pool admission, wait budgets, and connection handoff | [`internal/pool/pool.go`](https://github.com/redis/go-redis/blob/6193e530d612d362359a6709b46dc2c159e1455d/internal/pool/pool.go#L306-L1078) |
+
+## How to read these systems well
+
+Before reading any source below, ask:
+
+1. where is the lifetime owner,
+2. where is the overload boundary,
+3. where is the state owner,
+4. where is the shutdown contract,
+5. what metric or trace would prove this design is sick.
+
+That lens is more useful than memorizing APIs.
 
 ## Kubernetes client-go workqueue
 
-Source:
+Why it is worth reading:
 
-- [kubernetes/client-go util/workqueue/queue.go](https://github.com/kubernetes/client-go/blob/master/util/workqueue/queue.go)
+Controller code is usually described as “worker goroutines consuming a queue.” The interesting part is not the goroutines. It is how the queue preserves reprocessing signals while preventing duplicate flood.
 
-What to study:
+Primary source:
 
-- `dirty` and `processing` sets,
-- `Get`, `Done`, and `ShutDown`,
-- how duplicate work is deduplicated without losing requeue semantics.
+- [`Typed` queue state](https://github.com/kubernetes/client-go/blob/c826020ed98be668f4b5a8f140e7a4b8621e2a76/util/workqueue/queue.go#L192-L203)
+- [`Add`](https://github.com/kubernetes/client-go/blob/c826020ed98be668f4b5a8f140e7a4b8621e2a76/util/workqueue/queue.go#L224-L249)
+- [`Get`](https://github.com/kubernetes/client-go/blob/c826020ed98be668f4b5a8f140e7a4b8621e2a76/util/workqueue/queue.go#L264-L283)
+- [`Done`](https://github.com/kubernetes/client-go/blob/c826020ed98be668f4b5a8f140e7a4b8621e2a76/util/workqueue/queue.go#L289-L302)
+- [`ShutDown` and `ShutDownWithDrain`](https://github.com/kubernetes/client-go/blob/c826020ed98be668f4b5a8f140e7a4b8621e2a76/util/workqueue/queue.go#L305-L340)
 
-Why it matters:
+Main concurrency boundary:
 
-This queue design is a production answer to a subtle problem: work items can be updated again while they are still being processed. The queue preserves that signal without letting the same item flood the queue endlessly.
+The queue owns requeue semantics with three pieces of state: queued items, `dirty`, and `processing`.
 
 Simplified shape:
 
 ```go
-if item already processing {
-    mark dirty
-    return
+func Add(item Key) {
+	if shuttingDown {
+		return
+	}
+	if dirty[item] {
+		if !processing[item] {
+			touch(item)
+		}
+		return
+	}
+	dirty[item] = true
+	if processing[item] {
+		return
+	}
+	queue.push(item)
+	signalWorker()
 }
-enqueue(item)
+
+func Done(item Key) {
+	delete(processing, item)
+	if dirty[item] {
+		queue.push(item)
+		signalWorker()
+	}
+}
 ```
+
+Why this works:
+
+If an object changes again while a worker is still processing it, the second change is not lost. It is remembered in `dirty` and replayed after `Done`.
+
+Failure pattern to avoid:
+
+Do not cargo-cult this into “I should always have a queue plus two maps.” The lesson is narrower: if updates can arrive while work is in flight, your queue must encode replay semantics explicitly.
 
 Takeaway:
 
-Production queues are not just slices plus channels. They encode reprocessing semantics and shutdown semantics.
+This is a queue with state semantics, not a channel with extra bookkeeping.
 
-## etcd raft node loop
+## etcd/raft node loop
 
-Source:
+Why it is worth reading:
 
-- [etcd-io/raft node.go](https://github.com/etcd-io/raft/blob/main/node.go)
+This is one of the clearest examples in Go of communication boundaries doubling as correctness boundaries.
 
-What to study:
+Primary source:
 
-- `Ready() <-chan Ready`
-- `Advance()`
-- `Tick()`
-- `Step(ctx, msg)`
+- [`node` loop and select`](https://github.com/etcd-io/raft/blob/f39329d54771fb68f39e26c440c8cbd02215f6c5/node.go#L297-L456)
+- [`Tick`](https://github.com/etcd-io/raft/blob/f39329d54771fb68f39e26c440c8cbd02215f6c5/node.go#L458-L466)
+- [`Step`](https://github.com/etcd-io/raft/blob/f39329d54771fb68f39e26c440c8cbd02215f6c5/node.go#L473-L545)
+- [`Ready` and `Advance`](https://github.com/etcd-io/raft/blob/f39329d54771fb68f39e26c440c8cbd02215f6c5/node.go#L547-L553)
 
-Why it matters:
+Main concurrency boundary:
 
-The Raft core is separated from storage and transport through channel-driven boundaries. The core says "here is what must be persisted and sent next," while the application side decides when that work is durable and can be advanced.
+The Raft core emits `Ready` values that the outer system must persist and send before calling `Advance`.
 
 Simplified shape:
 
 ```go
 for {
-    select {
-    case rd := <-node.Ready():
-        persist(rd)
-        send(rd.Messages)
-        node.Advance()
-    }
+	select {
+	case rd := <-node.Ready():
+		persist(rd.HardState, rd.Entries, rd.Snapshot)
+		send(rd.Messages)
+		apply(rd.CommittedEntries)
+		node.Advance()
+	}
 }
 ```
 
+Why this works:
+
+The algorithm core does not own disk durability or transport delivery. It declares the next required unit of work and waits for the embedding system to confirm progress.
+
+Failure pattern to avoid:
+
+Never read this as “just another goroutine with channels.” Calling `Advance` before the durability boundary is actually satisfied breaks the design.
+
 Takeaway:
 
-This is a strong example of communication-first design where the concurrency boundary also becomes a correctness boundary.
+The best channel APIs do not just move data. They codify when a state machine is allowed to move forward.
 
 ## Prometheus scrape loop
 
-Source:
+Why it is worth reading:
 
-- [prometheus/prometheus scrape/scrape.go](https://github.com/prometheus/prometheus/blob/main/scrape/scrape.go)
+Prometheus shows how periodic work becomes robust when one loop owns time, cancellation, staleness markers, and append flow together.
 
-What to study:
+Primary source:
 
-- `newScrapeLoop`
-- `(*scrapeLoop).run`
-- how ticker-driven scheduling, cancellation, and staleness handling live together.
+- [`scrapeLoop` state](https://github.com/prometheus/prometheus/blob/3b44b8b463be9291a5605b935a5fbeda88db1366/scrape/scrape.go#L822-L910)
+- [`newScrapeLoop`](https://github.com/prometheus/prometheus/blob/3b44b8b463be9291a5605b935a5fbeda88db1366/scrape/scrape.go#L1154-L1232)
+- [`run`](https://github.com/prometheus/prometheus/blob/3b44b8b463be9291a5605b935a5fbeda88db1366/scrape/scrape.go#L1234-L1308)
 
-Why it matters:
+Main concurrency boundary:
 
-Prometheus is not just "run a goroutine every N seconds." The scrape loop owns time, error handling, sample append flow, and shutdown behavior in one lifecycle-aware loop.
+One loop owns the target lifecycle. It offsets startup, manages ticker cadence, handles shutdown, and only then appends results.
+
+Simplified shape:
+
+```go
+func run() {
+	waitInitialOffset()
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-parentCtx.Done():
+			return
+		case <-loopCtx.Done():
+			break
+		default:
+		}
+
+		last = scrapeAndReport(last, nowRounded())
+
+		select {
+		case <-parentCtx.Done():
+			return
+		case <-loopCtx.Done():
+			break
+		case <-ticker.C:
+		}
+	}
+
+	endOfRunStaleness(last)
+}
+```
+
+Why this works:
+
+The loop makes “periodic work” a lifecycle-owned component, not a loose collection of timers. The source even separates shutdown-sensitive context from append context because those lifetimes are not identical.
+
+Failure pattern to avoid:
+
+Do not scatter `time.After` or ad hoc tickers across helper functions and call it a scheduler. Periodic systems need one owner loop with one shutdown contract.
 
 Takeaway:
 
-Periodic work at scale should usually have one explicit owner loop rather than ad hoc timers scattered across helpers.
+If work is periodic, give time ownership to a single loop.
 
-## NATS server client read/write loops
+## NATS Server client read/write loops
 
-Source:
+Why it is worth reading:
 
-- [nats-io/nats-server server/client.go](https://github.com/nats-io/nats-server/blob/main/server/client.go)
+NATS is an excellent reminder that channels are not the only clean concurrency tool in Go.
 
-What to study:
+Primary source:
 
-- `readLoop`
-- `writeLoop`
-- `sync.Cond` signaling around outbound flush behavior
+- [`sync.Cond` on the outbound state](https://github.com/nats-io/nats-server/blob/bae1d6c752e0550901d0a79a76fb2fabe79c1eff/server/client.go#L355-L355)
+- [`writeLoop`](https://github.com/nats-io/nats-server/blob/bae1d6c752e0550901d0a79a76fb2fabe79c1eff/server/client.go#L1274-L1355)
+- [`readLoop`](https://github.com/nats-io/nats-server/blob/bae1d6c752e0550901d0a79a76fb2fabe79c1eff/server/client.go#L1358-L1415)
+- [`flushSignal`](https://github.com/nats-io/nats-server/blob/bae1d6c752e0550901d0a79a76fb2fabe79c1eff/server/client.go#L1996-L2003)
 
-Why it matters:
+Main concurrency boundary:
 
-NATS separates socket reading from socket writing and uses explicit signaling instead of busy waiting. This is a good example of where channels are not the only correct Go tool; condition variables and carefully owned loops can be exactly right.
+Socket reads and writes have different ownership. The write side waits on a condition variable and flushes buffered outbound state when signaled.
+
+Simplified shape:
+
+```go
+func writeLoop() {
+	for {
+		lock()
+		for open && shouldSleep() {
+			cond.Wait()
+		}
+		if closed {
+			flushAndClose()
+			unlock()
+			return
+		}
+		flushOutbound()
+		unlock()
+	}
+}
+
+func flushSignal() {
+	cond.Signal()
+}
+```
+
+Why this works:
+
+The writer loop owns the socket write path. Other goroutines mutate shared outbound state and signal the writer. That avoids multiple goroutines racing to write directly to the connection.
+
+Failure pattern to avoid:
+
+Do not copy only the `go readLoop` / `go writeLoop` shape. The real lesson is single-owner socket writing plus explicit wake-up semantics.
 
 Takeaway:
 
-Do not force every production concurrency design into channels if a condition variable plus clear ownership gives a tighter fit.
+A `sync.Cond` plus a clear owner can be more exact than channel-heavy designs for hot socket paths.
 
-## Failure pattern
+## gRPC-Go transport control buffer
 
-A common misread of production Go code is to copy the goroutines and forget the boundaries around them:
+Why it is worth reading:
+
+gRPC-Go has to multiplex many RPC streams over one HTTP/2 connection without letting every stream goroutine write frames directly to the socket.
+
+Primary source:
+
+- [`controlBuffer`](https://github.com/grpc/grpc-go/blob/b9f7967353473f3b585092ac5d961de3878e1f12/internal/transport/controlbuf.go#L307-L511)
+- [`loopyWriter`](https://github.com/grpc/grpc-go/blob/b9f7967353473f3b585092ac5d961de3878e1f12/internal/transport/controlbuf.go#L513-L584)
+- [`loopyWriter.run`](https://github.com/grpc/grpc-go/blob/b9f7967353473f3b585092ac5d961de3878e1f12/internal/transport/controlbuf.go#L586-L629)
+
+Main concurrency boundary:
+
+One writer goroutine owns frame emission. Other goroutines enqueue control items and data into the control buffer.
+
+Simplified shape:
+
+```go
+func transportWriter() {
+	for {
+		item := controlBuffer.get(block=true)
+		handleControl(item)
+		processOneActiveStream()
+
+		for controlBuffer.hasMore() || activeStreamsNotEmpty() {
+			handleMoreItems()
+			processOneActiveStream()
+		}
+
+		flushWire()
+	}
+}
+```
+
+Why this works:
+
+The control buffer serializes transport mutations, and the loopy writer round-robins active streams under flow-control limits. That is how many logical streams share one connection without frame corruption or fairness collapse.
+
+Failure pattern to avoid:
+
+Do not let per-stream goroutines write HTTP/2 frames directly to a shared `net.Conn`. The single-writer boundary is not an implementation detail. It is the design.
+
+Takeaway:
+
+Multiplexed transports usually want a command queue plus one writer owner.
+
+## CockroachDB stopper
+
+Why it is worth reading:
+
+CockroachDB makes goroutine lifetime a first-class service boundary instead of hoping background tasks stop eventually.
+
+Primary source:
+
+- [`Stopper` state](https://github.com/cockroachdb/cockroach/blob/41c5df3d4a4cd26e8852677aebb513184e78ccd9/pkg/util/stop/stopper.go#L152-L214)
+- [`WithCancelOnQuiesce`](https://github.com/cockroachdb/cockroach/blob/41c5df3d4a4cd26e8852677aebb513184e78ccd9/pkg/util/stop/stopper.go#L272-L289)
+- [`RunAsyncTask` and `RunAsyncTaskEx`](https://github.com/cockroachdb/cockroach/blob/41c5df3d4a4cd26e8852677aebb513184e78ccd9/pkg/util/stop/stopper.go#L358-L446)
+- [`Stop` and `Quiesce`](https://github.com/cockroachdb/cockroach/blob/41c5df3d4a4cd26e8852677aebb513184e78ccd9/pkg/util/stop/stopper.go#L562-L655)
+
+Main concurrency boundary:
+
+The stopper owns task admission, task counting, quiesce signaling, and shutdown waiting.
+
+Simplified shape:
+
+```go
+func RunAsyncTask(ctx, opts, f) error {
+	handle, err := GetHandle(ctx, opts)
+	if err != nil {
+		return err
+	}
+	go func() {
+		defer handle.Release()
+		f(handleCtx)
+	}()
+	return nil
+}
+
+func Stop(ctx) {
+	markStopping()
+	close(quiescer)
+	cancelQuiesceContexts()
+	waitUntilNumTasksIsZero()
+	runClosersInReverseOrder()
+}
+```
+
+Why this works:
+
+Background work is not free-floating. It has admission control, observability, and a coordinated shutdown path.
+
+Failure pattern to avoid:
+
+Do not reduce this pattern to “a fancy wait group.” The important design move is refusing new work while quiescing and giving tasks cancellation that is tied to system shutdown.
+
+Takeaway:
+
+Large services need a first-class owner for goroutine lifetime, not just `context.Background()` and hope.
+
+## go-redis connection pool
+
+Why it is worth reading:
+
+Even though this is a library, it is a clean study in admission control and handoff under load.
+
+Primary source:
+
+- [`ConnPool` state](https://github.com/redis/go-redis/blob/6193e530d612d362359a6709b46dc2c159e1455d/internal/pool/pool.go#L306-L339)
+- [`Get`](https://github.com/redis/go-redis/blob/6193e530d612d362359a6709b46dc2c159e1455d/internal/pool/pool.go#L701-L819)
+- [`queuedNewConn`](https://github.com/redis/go-redis/blob/6193e530d612d362359a6709b46dc2c159e1455d/internal/pool/pool.go#L821-L897)
+- [`waitTurn`](https://github.com/redis/go-redis/blob/6193e530d612d362359a6709b46dc2c159e1455d/internal/pool/pool.go#L954-L978)
+- [`Put`](https://github.com/redis/go-redis/blob/6193e530d612d362359a6709b46dc2c159e1455d/internal/pool/pool.go#L1049-L1078)
+
+Main concurrency boundary:
+
+Callers do not dial unboundedly. They first acquire permission from the pool, then either reuse an idle connection or join the path that dials new ones.
+
+Simplified shape:
+
+```go
+func Get(ctx) (*Conn, error) {
+	if err := waitTurn(ctx); err != nil {
+		return nil, err
+	}
+
+	if cn := popHealthyIdle(); cn != nil {
+		return cn, nil
+	}
+
+	return queuedNewConn(ctx)
+}
+
+func waitTurn(ctx) error {
+	if semaphore.TryAcquire() {
+		return nil
+	}
+	return semaphore.Acquire(ctx, poolTimeout)
+}
+```
+
+Why this works:
+
+The pool has an explicit admission boundary. Once saturated, callers wait or fail according to budget instead of spawning unlimited dials.
+
+Failure pattern to avoid:
+
+Do not copy a pool and leave dialing outside the same admission boundary. If every caller can still open its own connection on timeout, you have not actually bounded anything.
+
+Takeaway:
+
+Real pools are admission controllers, not just idle-connection caches.
+
+## Common misread
+
+A common misread of production Go code is to copy the goroutines and forget the boundary around them:
 
 ```go
 for _, msg := range batch {
@@ -123,20 +412,10 @@ for _, msg := range batch {
 }
 ```
 
-The systems above work because they add queues, ownership loops, signaling edges, and lifecycle rules around concurrency. Those boundaries matter more than the raw presence of goroutines.
-
-## How to read these systems well
-
-When you study production Go code, ask:
-
-1. where is the lifetime owner,
-2. where is the overload boundary,
-3. where is the state owner,
-4. where is the shutdown contract,
-5. what metrics or traces would expose failure here.
+The systems above work because they wrap concurrency in queue state, ownership loops, admission control, flow control, and shutdown policy.
 
 ## Practical takeaway
 
 Reading open-source Go code is most useful when you read it for boundaries, not just APIs.
 
-The best projects make concurrency policy visible in queue design, lifecycle loops, signaling edges, and shutdown paths.
+The strongest projects make concurrency policy visible in queue design, lifecycle loops, signaling edges, backpressure, and shutdown paths.


### PR DESCRIPTION
## Summary
- expand the production case studies into a source-reading guide with concrete concurrency boundaries
- add deeper coverage for the existing Kubernetes, etcd/raft, Prometheus, and NATS sections
- add new case studies for gRPC-Go, CockroachDB, and go-redis, plus landing-page and README updates

## Validation
- `go test ./...`
- `npm run docs:build`

Closes #23
