### PR TITLE
Docs: add library playbooks and Go-vs-Rust guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,13 @@ VitePress will print a local preview URL in the terminal, usually `http://localh
 - `io` + `bufio` + `bytes`: interface-driven streaming, buffering, `io.Copy` fast paths, scanner limits, and byte-slice aliasing
 - `encoding/json`: stream decoding, strictness knobs, number handling, compatibility traps, and NDJSON-friendly encoding
 
+## Included playbooks
+
+- `net/http`: transport reuse, timeout boundaries, response body ownership, and streaming caveats
+- `grpc-go`: `NewClient`, long-lived channels, RPC deadlines, keepalive caution, and streaming ownership
+- `go-redis`: pooling, protocol selection, RESP2/RESP3 tradeoffs, instrumentation, and timeout policy
+- `Kafka with IBM Sarama`: producer durability, consumer-group session lifecycle, offsets, and rebalance discipline
+
 ## Included advanced topics
 
 - Structured concurrency with `errgroup`
@@ -108,3 +115,4 @@ VitePress will print a local preview URL in the terminal, usually `http://localh
 ## Included extras
 
 - Go CSP vs Rust Tokio comparison
+- Go vs Rust decision guide for when to keep services in Go and when to move a subsystem to Rust

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -53,6 +53,16 @@ const enSidebar = [
     ],
   },
   {
+    text: "Playbooks",
+    items: [
+      { text: "Overview", link: "/playbooks/" },
+      { text: "net/http Production Field Guide", link: "/playbooks/net-http-production-field-guide" },
+      { text: "grpc-go Production Playbook", link: "/playbooks/grpc-go-production-playbook" },
+      { text: "go-redis Production Playbook", link: "/playbooks/go-redis-production-playbook" },
+      { text: "Kafka with IBM Sarama", link: "/playbooks/kafka-with-ibm-sarama" },
+    ],
+  },
+  {
     text: "Patterns",
     items: [
       { text: "Overview", link: "/patterns/" },
@@ -100,6 +110,7 @@ const enSidebar = [
     items: [
       { text: "Overview", link: "/extras/" },
       { text: "Go CSP vs Rust Tokio", link: "/extras/go-csp-vs-rust-tokio" },
+      { text: "Go vs Rust Decision Guide", link: "/extras/go-vs-rust-decision-guide" },
     ],
   },
 ] as const;
@@ -157,6 +168,16 @@ const koSidebar = [
     ],
   },
   {
+    text: "실전 플레이북",
+    items: [
+      { text: "개요", link: "/ko/playbooks/" },
+      { text: "net/http 실전 필드 가이드", link: "/ko/playbooks/net-http-production-field-guide" },
+      { text: "grpc-go 실전 플레이북", link: "/ko/playbooks/grpc-go-production-playbook" },
+      { text: "go-redis 실전 플레이북", link: "/ko/playbooks/go-redis-production-playbook" },
+      { text: "Kafka with IBM Sarama", link: "/ko/playbooks/kafka-with-ibm-sarama" },
+    ],
+  },
+  {
     text: "패턴",
     items: [
       { text: "개요", link: "/ko/patterns/" },
@@ -204,6 +225,7 @@ const koSidebar = [
     items: [
       { text: "개요", link: "/ko/extras/" },
       { text: "Go CSP vs Rust Tokio", link: "/ko/extras/go-csp-vs-rust-tokio" },
+      { text: "Go vs Rust 결정 가이드", link: "/ko/extras/go-vs-rust-decision-guide" },
     ],
   },
 ] as const;
@@ -259,6 +281,7 @@ export default defineConfig({
           { text: "Fundamentals", link: "/fundamentals/" },
           { text: "Internals", link: "/internals/" },
           { text: "Standard Library", link: "/stdlib/" },
+          { text: "Playbooks", link: "/playbooks/" },
           { text: "Patterns", link: "/patterns/" },
           { text: "Advanced", link: "/advanced/" },
           { text: "Production", link: "/production/" },
@@ -296,6 +319,7 @@ export default defineConfig({
           { text: "기초 원리", link: "/ko/fundamentals/" },
           { text: "내부 구조", link: "/ko/internals/" },
           { text: "표준 라이브러리", link: "/ko/stdlib/" },
+          { text: "실전 플레이북", link: "/ko/playbooks/" },
           { text: "패턴", link: "/ko/patterns/" },
           { text: "고급 주제", link: "/ko/advanced/" },
           { text: "프로덕션", link: "/ko/production/" },

--- a/docs/extras/go-vs-rust-decision-guide.md
+++ b/docs/extras/go-vs-rust-decision-guide.md
@@ -1,0 +1,183 @@
+---
+title: Go vs Rust Decision Guide
+description: Learn when Go should remain the default and when a subsystem should move to Rust, with a concrete decision tree and migration model.
+---
+
+# Go vs Rust Decision Guide
+
+This page is not about declaring a winner.
+
+It exists because teams often ask the wrong question:
+
+- bad question: “Is Rust better than Go?”
+- useful question: “What kind of problem am I actually solving, and where does each language pay for itself?”
+
+:::tip Quick takeaway
+Default to Go for service orchestration, APIs, control planes, internal tooling, and most network services. Move a narrow subsystem to Rust when you need tighter memory footprints, lower tail-latency variance, stronger compile-time ownership guarantees, or lower-level control than Go gives you comfortably.
+:::
+
+## Decision tree
+
+```mermaid
+flowchart TD
+    A["Current pain"] --> B{"Is the main problem architecture, ownership, or observability?"}
+    B -- "Yes" --> C["Stay in Go and fix the design first"]
+    B -- "No" --> D{"Do you need tighter memory / lower tail variance / lower-level control?"}
+    D -- "No" --> E["Stay in Go"]
+    D -- "Yes" --> F{"Is the pain concentrated in a narrow hot path or subsystem?"}
+    F -- "Yes" --> G["Keep the service in Go and move the hot path to Rust"]
+    F -- "No" --> H{"Does the team have real Rust ownership, async, and tooling maturity?"}
+    H -- "No" --> I["Stay in Go for now and raise the technical bar first"]
+    H -- "Yes" --> J["A Rust-first subsystem or service may be justified"]
+```
+
+## The default stance
+
+Go should remain the default unless the problem proves otherwise.
+
+That is not conservatism. It is cost accounting.
+
+Go gives you a very favorable default stack for:
+
+- direct-style concurrent services,
+- simple deployment and cross-compilation,
+- runtime-integrated goroutines and netpoll,
+- fast team onboarding,
+- operational simplicity.
+
+Rust gives you a different bargain:
+
+- stronger compile-time ownership guarantees,
+- lower-level control over allocation and layout,
+- no GC-driven latency trade,
+- better fit for some systems and data-plane workloads.
+
+## Keep Go by default when
+
+Go is usually the better default for:
+
+- HTTP and gRPC APIs,
+- control planes,
+- Kubernetes operators and platform services,
+- queue consumers and background workers,
+- internal tooling and CLIs,
+- service glue where most complexity is I/O and coordination rather than raw compute.
+
+If the system is dominated by network waits, business rules, orchestration, and integration work, Go usually wins on total engineering throughput.
+
+## Move a subsystem to Rust when
+
+Rust starts paying for itself when one or more of these are true:
+
+- memory footprint per connection or per object really matters,
+- GC-related tail variance is materially hurting the product,
+- the hot path needs zero-copy or very tight buffer control,
+- the code is a parser, proxy, codec, storage engine, execution engine, or other data-plane component,
+- you need stronger compile-time ownership and aliasing guarantees than code review can reliably enforce in Go,
+- you are building a library or component that must interoperate tightly with C, C++, kernel, or embedded constraints.
+
+The important point is that this is often a subsystem call, not a whole-company call.
+
+## Good reasons that are not actually reasons
+
+Do not move to Rust just because:
+
+- someone on social media says it is faster,
+- a Go service has bad p99s but you have not fixed queueing or backpressure,
+- memory is high but the profile shows obvious waste you have not removed,
+- goroutines leak because shutdown ownership is poor,
+- deadlines, pooling, and retries are currently undisciplined,
+- the team has no operational story for Rust builds, debugging, profiling, or incident response.
+
+Those are often architecture and discipline problems, not language-limit problems.
+
+## Comparative mental model
+
+| Axis | Go advantage | Rust advantage |
+| --- | --- | --- |
+| Team throughput | simpler service code, easier onboarding, fast iteration | more invariants enforced at compile time once the team is fluent |
+| Concurrency ergonomics | goroutines, channels, netpoll, direct style | explicit ownership and async boundaries |
+| Latency profile | very good for most services, with GC trade-offs | better fit when GC variance is unacceptable |
+| Memory control | good enough for many backends | stronger control over layout, borrowing, and allocation |
+| Systems integration | easy deployment and static binaries | stronger fit for low-level libraries, kernels, parsers, and FFI-heavy components |
+| Operational cost | usually lower for common service work | can pay off for narrow high-performance components |
+
+## What the official models emphasize
+
+Rust's official book explicitly frames “fearless concurrency” as making incorrect concurrent code fail to compile earlier. Tokio's runtime docs describe a runtime with an I/O driver, scheduler, and timer, and its fairness guarantee assumes tasks do not block the runtime thread indefinitely.
+
+Go's official guidance emphasizes direct concurrency composition and the CSP-style idea of sharing memory by communicating. That makes Go particularly attractive for service code where communication structure matters more than memory layout tricks.
+
+## Use-case matrix
+
+### Stay in Go
+
+- API gateways and internal APIs
+- control planes and operators
+- job workers and pipeline services
+- most microservices
+- teams optimizing for feature velocity and operability
+
+### Consider Rust for a subsystem
+
+- protocol parsers and codecs
+- high-throughput proxies
+- storage and indexing engines
+- memory-sensitive agents
+- embedded or edge components
+- hot loops where allocation shape dominates cost
+
+### Consider Rust more broadly
+
+- the product is fundamentally a data-plane or systems product,
+- the team already has Rust and async experience,
+- the debugging, CI, packaging, and incident tooling are already in place,
+- the gain is not theoretical but measured.
+
+## Split architecture is often the best answer
+
+A lot of teams should not ask “Go or Rust?” at the service boundary.
+
+They should ask:
+
+- can the control plane stay in Go,
+- can the hot parser / engine / proxy / native module move to Rust,
+- can the boundary between them stay observable and operationally boring?
+
+That gives you:
+
+- Go where coordination dominates,
+- Rust where tight control dominates.
+
+## Migration checklist
+
+Before moving a subsystem to Rust, verify all of these:
+
+1. The bottleneck is measured and real.
+2. The bottleneck survives obvious Go-side fixes.
+3. The target scope is narrow and explicit.
+4. The team can build, profile, test, and debug Rust in production.
+5. The runtime model and shutdown model are understood, not copied from tutorials.
+6. The interface between Go and Rust is simpler than the problem you are trying to solve.
+
+## Where this connects to the rest of the site
+
+- Read [Go CSP vs Rust Tokio](/extras/go-csp-vs-rust-tokio) for a runtime-model comparison.
+- Read [Go Runtime and Scheduler](/fundamentals/go-runtime-scheduler) and [Garbage Collector and Green Tea GC](/fundamentals/garbage-collector) before blaming Go for every latency problem.
+- Read [Backpressure and Load Shedding](/advanced/backpressure-load-shedding) and [Large-Scale Go Systems](/production/large-scale-go-systems) before concluding the language is the bottleneck.
+
+## Official reading
+
+- [Fearless Concurrency in the Rust Book](https://doc.rust-lang.org/book/ch16-00-concurrency.html)
+- [Tokio spawning tutorial](https://tokio.rs/tokio/tutorial/spawning)
+- [Tokio runtime docs](https://docs.rs/tokio/latest/tokio/runtime/)
+- [Effective Go: concurrency](https://go.dev/doc/effective_go#concurrency)
+- [Go concurrency patterns: pipelines](https://go.dev/blog/pipelines)
+
+## Practical takeaway
+
+Rust is not a status upgrade over Go.
+
+It is a different cost structure.
+
+Keep Go as the default for service orchestration. Move a narrow subsystem to Rust when measured constraints demand tighter control than Go gives you comfortably.

--- a/docs/extras/index.md
+++ b/docs/extras/index.md
@@ -17,6 +17,7 @@ This extra section exists for two reasons:
 | Topic | Why it matters |
 | --- | --- |
 | [Go CSP vs Rust Tokio](/extras/go-csp-vs-rust-tokio) | Shows how similar high-level goals lead to very different runtime and language designs |
+| [Go vs Rust Decision Guide](/extras/go-vs-rust-decision-guide) | Turns language comparison into a practical call about when to keep a service in Go and when to move a subsystem to Rust |
 
 ## Practical takeaway
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,9 @@ hero:
       text: Standard Library
       link: /stdlib/
     - theme: alt
+      text: Playbooks
+      link: /playbooks/
+    - theme: alt
       text: Browse Patterns
       link: /patterns/
     - theme: alt
@@ -34,6 +37,8 @@ features:
     details: "The site now covers escape analysis, SSA, allocator internals, generics, interface layout, unsafe, cgo, PGO, and sync.Pool internals."
   - title: Standard library deep dives
     details: "The site now treats `context`, `net`, `crypto/tls`, `net/http`, `database/sql`, `os/exec`, and `time` as first-class learning tracks instead of assuming they are already understood."
+  - title: Production library playbooks
+    details: "The site now documents how to operate `net/http`, `grpc-go`, `go-redis`, and Kafka with IBM Sarama using safe defaults, observability hooks, and failure patterns."
   - title: Practical examples
     details: "Examples use realistic backend domains such as shipping, fraud analysis, inventory coordination, and cache-miss suppression."
   - title: Tested behavior
@@ -74,28 +79,33 @@ features:
     <p><a href="/stdlib/">Open standard library</a></p>
   </div>
   <div class="path-card">
-    <h3>4. Practical Patterns</h3>
+    <h3>4. Playbooks</h3>
+    <p>Move from package internals to operator-facing guidance for `net/http`, `grpc-go`, `go-redis`, and Kafka with IBM Sarama.</p>
+    <p><a href="/playbooks/">Open playbooks</a></p>
+  </div>
+  <div class="path-card">
+    <h3>5. Practical Patterns</h3>
     <p>Move into worker pools, pipelines, fan-out/fan-in, and context cancellation when you are mapping code to real workloads.</p>
     <p><a href="/patterns/">Browse patterns</a></p>
   </div>
   <div class="path-card">
-    <h3>5. Advanced Topics</h3>
+    <h3>6. Advanced Topics</h3>
     <p>Study resource budgeting, structured lifetimes, duplicate suppression, ownership models, and overload behavior.</p>
     <p><a href="/advanced/">Go deeper</a></p>
   </div>
   <div class="path-card">
-    <h3>6. Testing</h3>
+    <h3>7. Testing</h3>
     <p>Learn how to prove cancellation, shutdown, race safety, and timeout behavior instead of relying on lucky sleeps.</p>
     <p><a href="/testing/">Open testing</a></p>
   </div>
   <div class="path-card">
-    <h3>7. Production</h3>
+    <h3>8. Production</h3>
     <p>Study queue budgets, overload policy, goroutine ownership, and open-source concurrency designs from real Go systems.</p>
     <p><a href="/production/">Open production</a></p>
   </div>
   <div class="path-card">
-    <h3>8. Extras</h3>
-    <p>Compare Go's CSP-flavored model with Rust Tokio so your mental model holds across ecosystems.</p>
+    <h3>9. Extras</h3>
+    <p>Compare Go's CSP-flavored model with Rust Tokio and use the Go-vs-Rust decision guide when language choice becomes an engineering question.</p>
     <p><a href="/extras/">Open extras</a></p>
   </div>
 </div>
@@ -112,6 +122,10 @@ features:
 | How to budget connection establishment and represent endpoints without `net.IP` footguns | [net and netip](/stdlib/net-and-netip) |
 | How TLS handshake, verification, and ALPN fit into request lifetime | [crypto/tls in Production](/stdlib/crypto-tls) |
 | How Go's HTTP server and client transport really own connections | [net/http Server and Transport](/stdlib/net-http-server-transport) |
+| How to operate `http.Client` and `Transport` with real timeout and reuse policy | [net/http Production Field Guide](/playbooks/net-http-production-field-guide) |
+| How to use gRPC channels without `Dial` and `WithBlock` footguns | [grpc-go Production Playbook](/playbooks/grpc-go-production-playbook) |
+| How to run Redis clients with explicit pool, protocol, and timeout policy | [go-redis Production Playbook](/playbooks/go-redis-production-playbook) |
+| How Kafka semantics and IBM Sarama config actually fit together | [Kafka with IBM Sarama](/playbooks/kafka-with-ibm-sarama) |
 | Why `sql.DB` is a pool instead of a connection | [database/sql Pool Internals](/stdlib/database-sql-pool) |
 | Why `time.After` is not always the right loop primitive | [time, Timers, and Tickers](/stdlib/time-timers-tickers) |
 | How subprocess cancellation, pipes, and `WaitDelay` actually behave | [os/exec and Subprocess Lifecycle](/stdlib/os-exec-and-subprocesses) |
@@ -126,6 +140,7 @@ features:
 | What large Go production systems care about beyond toy patterns | [Large-Scale Go Systems](/production/large-scale-go-systems) |
 | How major Go projects actually build queues, transport loops, stopper lifetimes, and pools | [Open-Source Case Studies](/production/open-source-case-studies) |
 | How Go differs from Rust Tokio's async runtime model | [Go CSP vs Rust Tokio](/extras/go-csp-vs-rust-tokio) |
+| When Go should stay the default and when a subsystem should move to Rust | [Go vs Rust Decision Guide](/extras/go-vs-rust-decision-guide) |
 
 ## What Makes This Site Different
 
@@ -151,7 +166,8 @@ features:
 3. Work through [Fundamentals Overview](/fundamentals/) before jumping into implementation patterns.
 4. Read [Internals Overview](/internals/) when you want compiler, allocator, and type-system cost models rather than only runtime APIs.
 5. Read [Standard Library Overview](/stdlib/) when you want to understand how real Go services express lifetime, I/O, SQL, and time semantics.
-6. Pick the practical pattern that matches your workload in [Patterns Overview](/patterns/).
-7. Read [Testing Overview](/testing/) before treating any concurrent component as production-ready.
-8. Read [Production Overview](/production/) for operating rules and open-source case studies.
-9. Finish with [Advanced Overview](/advanced/) and [Extras Overview](/extras/) for deeper design and ecosystem comparison.
+6. Read [Playbooks Overview](/playbooks/) when you want safe defaults and operator-facing rules for libraries you actually deploy.
+7. Pick the practical pattern that matches your workload in [Patterns Overview](/patterns/).
+8. Read [Testing Overview](/testing/) before treating any concurrent component as production-ready.
+9. Read [Production Overview](/production/) for operating rules and open-source case studies.
+10. Finish with [Advanced Overview](/advanced/) and [Extras Overview](/extras/) for deeper design and ecosystem comparison.

--- a/docs/ko/extras/go-vs-rust-decision-guide.md
+++ b/docs/ko/extras/go-vs-rust-decision-guide.md
@@ -1,0 +1,183 @@
+---
+title: Go vs Rust 결정 가이드
+description: 언제 Go를 기본값으로 유지하고, 언제 특정 서브시스템을 Rust로 옮길지 결정 트리와 멘탈모델로 설명합니다.
+---
+
+# Go vs Rust 결정 가이드
+
+이 문서는 누가 더 낫다고 선언하려는 문서가 아닙니다.
+
+왜냐하면 팀이 보통 잘못된 질문부터 하기 때문입니다.
+
+- 나쁜 질문: “Rust가 Go보다 낫나?”
+- 좋은 질문: “내가 푸는 문제가 정확히 무엇이고, 각 언어가 어디서 비용을 정당화하는가?”
+
+:::tip Quick takeaway
+기본값은 Go로 두는 편이 맞습니다. 서비스 orchestration, API, control plane, 내부 도구, 대부분의 네트워크 서비스에서는 특히 그렇습니다. Rust는 더 낮은 메모리 풋프린트, 더 타이트한 tail-latency variance, 더 강한 compile-time ownership 보장, 더 낮은 수준의 제어가 실제로 필요할 때 좁은 서브시스템에 투입하는 편이 맞습니다.
+:::
+
+## 결정 트리
+
+```mermaid
+flowchart TD
+    A["현재 고통"] --> B{"주된 문제가 architecture, ownership, observability인가?"}
+    B -- "예" --> C["일단 Go에 남아서 설계를 먼저 고친다"]
+    B -- "아니오" --> D{"더 낮은 메모리 / 더 작은 tail variance / 더 낮은 수준의 제어가 필요한가?"}
+    D -- "아니오" --> E["Go에 남는다"]
+    D -- "예" --> F{"문제가 좁은 hot path 또는 subsystem에 집중되어 있는가?"}
+    F -- "예" --> G["서비스는 Go에 두고 hot path만 Rust로 옮긴다"]
+    F -- "아니오" --> H{"팀이 Rust ownership, async, tooling에 실제로 익숙한가?"}
+    H -- "아니오" --> I["지금은 Go에 남고 기술 기준부터 올린다"]
+    H -- "예" --> J["Rust-first subsystem 또는 service가 정당화될 수 있다"]
+```
+
+## 기본 입장
+
+증명이 나오기 전까지는 Go를 기본값으로 유지하는 편이 맞습니다.
+
+이건 보수적 태도가 아니라 비용 계산입니다.
+
+Go는 다음에 유리한 기본 스택을 줍니다.
+
+- direct-style concurrent service code
+- 간단한 배포와 cross-compilation
+- runtime-integrated goroutine과 netpoll
+- 빠른 팀 온보딩
+- 단순한 운영 모델
+
+Rust는 다른 거래를 제시합니다.
+
+- 더 강한 compile-time ownership 보장
+- allocation과 layout에 대한 더 낮은 수준의 제어
+- GC-driven latency trade 없음
+- 일부 systems/data-plane workload에 더 잘 맞음
+
+## 기본값으로 Go에 남는 경우
+
+대개 Go가 더 잘 맞는 경우는 다음입니다.
+
+- HTTP / gRPC API
+- control plane
+- Kubernetes operator와 platform service
+- queue consumer와 background worker
+- 내부 도구와 CLI
+- raw compute보다 I/O와 coordination이 더 중요한 서비스
+
+시스템의 대부분이 network wait, business rule, orchestration, integration work로 채워져 있다면 총 엔지니어링 생산성 면에서 Go가 유리한 경우가 많습니다.
+
+## Rust로 서브시스템을 옮길 만한 경우
+
+Rust가 비용을 정당화하기 시작하는 순간은 대체로 이럴 때입니다.
+
+- connection당 또는 object당 memory footprint가 실제로 중요할 때
+- GC 관련 tail variance가 제품을 실질적으로 해칠 때
+- hot path에서 zero-copy나 매우 세밀한 buffer control이 필요할 때
+- parser, proxy, codec, storage engine, execution engine처럼 data-plane 성격이 강할 때
+- Go 코드 리뷰만으로는 안정적으로 강제하기 어려운 ownership/aliasing 제약이 있을 때
+- C, C++, kernel, embedded constraint와 매우 타이트하게 맞물리는 라이브러리/컴포넌트를 만들 때
+
+중요한 점은, 이 판단이 회사 전체 언어 선택이 아니라 특정 서브시스템 판단인 경우가 많다는 것입니다.
+
+## 사실은 이유가 아닌 것들
+
+다음 이유만으로 Rust로 옮기면 안 됩니다.
+
+- 소셜 미디어에서 Rust가 더 빠르다고 들었기 때문
+- Go 서비스 p99가 나쁜데 queueing이나 backpressure를 먼저 안 고쳤기 때문
+- memory가 높은데 profile이 보여주는 낭비를 아직 제거하지 않았기 때문
+- goroutine leak이 shutdown ownership 문제인데 언어 탓으로 돌리기 때문
+- deadline, pooling, retry가 현재 무질서한데 언어를 바꾸면 해결될 거라고 생각하기 때문
+- 팀에 Rust 빌드/디버깅/프로파일링/운영 경험이 없기 때문
+
+이건 종종 언어 한계가 아니라 architecture와 discipline 문제입니다.
+
+## 비교 mental model
+
+| 축 | Go의 장점 | Rust의 장점 |
+| --- | --- | --- |
+| 팀 생산성 | 서비스 코드를 단순하게 쓰기 좋고 온보딩이 빠름 | 팀이 익숙해진 뒤에는 더 많은 invariant를 컴파일 타임에 강제 |
+| 동시성 ergonomics | goroutine, channel, netpoll, direct style | ownership과 async boundary가 더 명시적 |
+| latency profile | 대부분의 서비스에 충분히 좋고, GC trade가 있음 | GC variance가 허용되지 않을 때 더 유리 |
+| memory control | 많은 백엔드에서 충분함 | layout, borrowing, allocation 제어가 더 강함 |
+| systems integration | 배포와 static binary가 단순함 | low-level library, kernel, parser, FFI-heavy workload에 더 잘 맞음 |
+| 운영 비용 | 일반적인 서비스 작업에서 대체로 낮음 | 좁은 고성능 컴포넌트에서는 비용을 상쇄할 수 있음 |
+
+## 공식 모델이 강조하는 것
+
+Rust 공식 책은 “fearless concurrency”를, 잘못된 concurrent code를 더 이른 시점에 컴파일 에러로 드러내는 방향으로 설명합니다. Tokio runtime 문서는 I/O driver, scheduler, timer를 가진 runtime과 fairness 가정이 task가 runtime thread를 계속 붙잡지 않는다는 전제 위에 있음을 설명합니다.
+
+Go 공식 가이드는 direct concurrency composition과 “sharing memory by communicating” 같은 CSP 계열 사고를 강조합니다. 그래서 memory layout trick보다 communication structure가 더 중요한 서비스 코드에서는 Go가 특히 매력적입니다.
+
+## 유즈케이스 매트릭스
+
+### Go에 남는 편이 좋은 경우
+
+- API gateway와 internal API
+- control plane과 operator
+- job worker와 pipeline service
+- 대부분의 microservice
+- feature velocity와 operability를 더 중시하는 팀
+
+### Rust를 서브시스템에 도입할 만한 경우
+
+- protocol parser와 codec
+- high-throughput proxy
+- storage / indexing engine
+- memory-sensitive agent
+- embedded / edge component
+- allocation shape가 비용을 지배하는 hot loop
+
+### Rust를 더 넓게 검토할 만한 경우
+
+- 제품 자체가 data-plane 또는 systems product일 때
+- 팀이 이미 Rust와 async에 익숙할 때
+- debugging, CI, packaging, incident tooling이 준비돼 있을 때
+- 기대 이득이 이론이 아니라 측정으로 확인됐을 때
+
+## Split architecture가 종종 최선이다
+
+많은 팀은 서비스 경계에서 “Go냐 Rust냐”를 묻기보다 이렇게 물어야 합니다.
+
+- control plane은 Go에 둘 수 있는가
+- hot parser / engine / proxy / native module만 Rust로 옮길 수 있는가
+- 그 경계가 여전히 observable하고 운영하기 지루할 만큼 단순한가
+
+이렇게 하면:
+
+- coordination이 많은 곳은 Go,
+- tight control이 필요한 곳은 Rust
+
+로 나눌 수 있습니다.
+
+## 마이그레이션 체크리스트
+
+Rust로 옮기기 전에 최소한 이것들은 확인해야 합니다.
+
+1. 병목이 측정으로 확인됐다.
+2. 명백한 Go-side fix를 해도 병목이 남아 있다.
+3. 대상 범위가 좁고 명시적이다.
+4. 팀이 Rust를 빌드, 프로파일링, 테스트, 디버깅, 운영할 수 있다.
+5. runtime model과 shutdown model을 튜토리얼 복붙이 아니라 실제로 이해하고 있다.
+6. Go와 Rust 사이 인터페이스가 원래 문제보다 더 복잡하지 않다.
+
+## 이 사이트의 다른 문서와 연결
+
+- runtime model 비교는 [Go CSP vs Rust Tokio](/ko/extras/go-csp-vs-rust-tokio)를 읽습니다.
+- Go를 탓하기 전에 [Go 런타임과 스케줄러](/ko/fundamentals/go-runtime-scheduler), [가비지 컬렉터와 Green Tea GC](/ko/fundamentals/garbage-collector)를 읽습니다.
+- 언어가 아니라 설계가 병목일 수 있으므로 [역압력과 로드 셰딩](/ko/advanced/backpressure-load-shedding), [대규모 Go 시스템](/ko/production/large-scale-go-systems)도 같이 봅니다.
+
+## 공식 자료
+
+- [Rust Book의 Fearless Concurrency](https://doc.rust-lang.org/book/ch16-00-concurrency.html)
+- [Tokio spawning tutorial](https://tokio.rs/tokio/tutorial/spawning)
+- [Tokio runtime docs](https://docs.rs/tokio/latest/tokio/runtime/)
+- [Effective Go: concurrency](https://go.dev/doc/effective_go#concurrency)
+- [Go concurrency patterns: pipelines](https://go.dev/blog/pipelines)
+
+## Practical takeaway
+
+Rust는 Go의 상위호환 상태 업그레이드가 아닙니다.
+
+비용 구조가 다른 도구입니다.
+
+서비스 orchestration의 기본값은 Go로 두고, 측정된 제약이 Go보다 더 타이트한 제어를 요구할 때만 좁은 서브시스템을 Rust로 옮기는 편이 가장 현실적입니다.

--- a/docs/ko/extras/index.md
+++ b/docs/ko/extras/index.md
@@ -17,6 +17,7 @@ description: Go 바깥의 런타임과 비교해 mental model을 넓히는 보�
 | 주제 | 왜 중요한가 |
 | --- | --- |
 | [Go CSP vs Rust Tokio](/ko/extras/go-csp-vs-rust-tokio) | 비슷한 목표를 가진 두 시스템이 왜 전혀 다른 설계를 택했는지 보여줍니다 |
+| [Go vs Rust 결정 가이드](/ko/extras/go-vs-rust-decision-guide) | 서비스를 Go에 두고 특정 서브시스템만 Rust로 옮겨야 하는지 판단 기준을 제공합니다 |
 
 ## Practical takeaway
 

--- a/docs/ko/index.md
+++ b/docs/ko/index.md
@@ -16,6 +16,9 @@ hero:
       text: 표준 라이브러리
       link: /ko/stdlib/
     - theme: alt
+      text: 실전 플레이북
+      link: /ko/playbooks/
+    - theme: alt
       text: 패턴 둘러보기
       link: /ko/patterns/
     - theme: alt
@@ -34,6 +37,8 @@ features:
     details: "Escape analysis, SSA, allocator, generics, interface layout, unsafe, cgo, PGO, sync.Pool 내부까지 추가로 다룹니다."
   - title: 표준 라이브러리까지 깊게
     details: "`context`, `net`, `crypto/tls`, `net/http`, `database/sql`, `os/exec`, `time`를 따로 빼서 실제 서비스 코드가 돌아가는 경계를 자세히 설명합니다."
+  - title: 실전 라이브러리 플레이북
+    details: "`net/http`, `grpc-go`, `go-redis`, Kafka with IBM Sarama를 safe default, observability, failure pattern 중심으로 운영 관점에서 설명합니다."
   - title: 실용 예제 중심
     details: "배송, 부정거래 분석, 재고, 중복 요청 억제처럼 실제 백엔드 문제에 가까운 예제를 사용합니다."
   - title: 테스트로 검증
@@ -74,28 +79,33 @@ features:
     <p><a href="/ko/stdlib/">표준 라이브러리 보기</a></p>
   </div>
   <div class="path-card">
-    <h3>4. 실전 패턴</h3>
+    <h3>4. 실전 플레이북</h3>
+    <p>`net/http`, `grpc-go`, `go-redis`, Kafka with IBM Sarama를 운영할 때 필요한 정책과 실패 패턴을 봅니다.</p>
+    <p><a href="/ko/playbooks/">실전 플레이북 보기</a></p>
+  </div>
+  <div class="path-card">
+    <h3>5. 실전 패턴</h3>
     <p>워커 풀, 파이프라인, 팬아웃/팬인, 컨텍스트 취소를 실제 workload 관점으로 읽습니다.</p>
     <p><a href="/ko/patterns/">패턴 보기</a></p>
   </div>
   <div class="path-card">
-    <h3>5. 고급 주제</h3>
+    <h3>6. 고급 주제</h3>
     <p>자원 예산, 수명 관리, 중복 억제, 소유권 모델, 과부하 제어까지 확장합니다.</p>
     <p><a href="/ko/advanced/">고급 주제 보기</a></p>
   </div>
   <div class="path-card">
-    <h3>6. 테스트</h3>
+    <h3>7. 테스트</h3>
     <p>cancellation, shutdown, race safety, timeout behavior를 lucky sleep 없이 검증하는 법을 익힙니다.</p>
     <p><a href="/ko/testing/">테스트 보기</a></p>
   </div>
   <div class="path-card">
-    <h3>7. 프로덕션</h3>
+    <h3>8. 프로덕션</h3>
     <p>queue budget, overload policy, goroutine ownership, 실제 오픈소스의 concurrency 구조를 같이 봅니다.</p>
     <p><a href="/ko/production/">프로덕션 보기</a></p>
   </div>
   <div class="path-card">
-    <h3>8. 비교 / 확장</h3>
-    <p>Go의 CSP 계열 모델을 Rust Tokio와 비교해 mental model을 더 넓힙니다.</p>
+    <h3>9. 비교 / 확장</h3>
+    <p>Go의 CSP 계열 모델을 Rust Tokio와 비교하고, 언제 Go에 남고 언제 Rust로 옮겨야 하는지도 결정 가이드로 정리합니다.</p>
     <p><a href="/ko/extras/">비교 / 확장 보기</a></p>
   </div>
 </div>
@@ -112,6 +122,10 @@ features:
 | connection establish budget을 어떻게 잡고 `net.IP` footgun 없이 endpoint를 표현하는지 | [net과 netip](/ko/stdlib/net-and-netip) |
 | TLS handshake, verification, ALPN이 request lifetime과 어떻게 연결되는지 | [프로덕션에서의 crypto/tls](/ko/stdlib/crypto-tls) |
 | Go HTTP 서버와 클라이언트 transport가 connection을 어떻게 소유하는지 | [net/http 서버와 Transport 내부](/ko/stdlib/net-http-server-transport) |
+| `http.Client`와 `Transport`를 실제 timeout/reuse 정책으로 어떻게 운영하는지 | [net/http 실전 필드 가이드](/ko/playbooks/net-http-production-field-guide) |
+| `Dial`과 `WithBlock` 함정 없이 gRPC channel을 어떻게 운영하는지 | [grpc-go 실전 플레이북](/ko/playbooks/grpc-go-production-playbook) |
+| Redis client를 pool, protocol, timeout 정책으로 어떻게 다뤄야 하는지 | [go-redis 실전 플레이북](/ko/playbooks/go-redis-production-playbook) |
+| Kafka semantics와 IBM Sarama 설정이 실제로 어떻게 연결되는지 | [Kafka with IBM Sarama](/ko/playbooks/kafka-with-ibm-sarama) |
 | 왜 `sql.DB`는 connection이 아니라 pool인지 | [database/sql 풀 내부](/ko/stdlib/database-sql-pool) |
 | 왜 `time.After`가 항상 좋은 loop primitive는 아닌지 | [time, Timers, Tickers](/ko/stdlib/time-timers-tickers) |
 | subprocess cancellation, pipe, `WaitDelay`가 실제로 어떻게 동작하는지 | [os/exec와 subprocess lifecycle](/ko/stdlib/os-exec-and-subprocesses) |
@@ -126,6 +140,7 @@ features:
 | 토이 패턴을 넘어 대규모 Go 운영에서 무엇이 중요한지 | [대규모 Go 시스템](/ko/production/large-scale-go-systems) |
 | 주요 Go 오픈소스가 queue, transport loop, stopper lifetime, pool을 어떻게 구현하는지 | [오픈소스 사례](/ko/production/open-source-case-studies) |
 | Go와 Rust Tokio의 async runtime 모델이 어떻게 다른지 | [Go CSP vs Rust Tokio](/ko/extras/go-csp-vs-rust-tokio) |
+| 언제 Go를 기본값으로 유지하고 언제 Rust로 좁게 옮겨야 하는지 | [Go vs Rust 결정 가이드](/ko/extras/go-vs-rust-decision-guide) |
 
 ## 이 사이트가 다른 이유
 
@@ -151,7 +166,8 @@ features:
 3. [기초 원리 개요](/ko/fundamentals/)부터 읽습니다.
 4. runtime API 너머의 cost model이 궁금하면 [내부 구조 개요](/ko/internals/)를 읽습니다.
 5. 실제 Go 서비스가 lifetime, I/O, SQL, time을 어떻게 표현하는지 보려면 [표준 라이브러리 개요](/ko/stdlib/)를 읽습니다.
-6. 자기 workload에 맞는 패턴을 [패턴 개요](/ko/patterns/)에서 고릅니다.
-7. concurrent component를 production-ready로 보기 전에 [테스트 개요](/ko/testing/)를 읽습니다.
-8. 운영 규칙과 오픈소스 사례를 보려면 [프로덕션 개요](/ko/production/)를 읽습니다.
-9. 운영 설계와 비교 관점까지 확장할 때 [고급 주제 개요](/ko/advanced/), [비교 / 확장 개요](/ko/extras/)로 넘어갑니다.
+6. 실제로 배포하는 라이브러리의 안전한 기본값이 궁금하면 [실전 플레이북 개요](/ko/playbooks/)를 읽습니다.
+7. 자기 workload에 맞는 패턴을 [패턴 개요](/ko/patterns/)에서 고릅니다.
+8. concurrent component를 production-ready로 보기 전에 [테스트 개요](/ko/testing/)를 읽습니다.
+9. 운영 규칙과 오픈소스 사례를 보려면 [프로덕션 개요](/ko/production/)를 읽습니다.
+10. 운영 설계와 비교 관점까지 확장할 때 [고급 주제 개요](/ko/advanced/), [비교 / 확장 개요](/ko/extras/)로 넘어갑니다.

--- a/docs/ko/playbooks/go-redis-production-playbook.md
+++ b/docs/ko/playbooks/go-redis-production-playbook.md
@@ -1,0 +1,140 @@
+---
+title: go-redis 실전 플레이북
+description: go-redis를 pooling, timeout, protocol, instrumentation 정책 관점에서 운영하는 법을 설명합니다.
+---
+
+# go-redis 실전 플레이북
+
+`go-redis`는 호출은 쉽지만, 잘못 쓰기도 쉽습니다.
+
+겉으로는 가벼운 클라이언트처럼 보이지만 운영 관점에서는 pool owner이자 timeout boundary이고 protocol policy surface입니다.
+
+## Mental model
+
+`go-redis` client는 long-lived resource boundary로 다루는 편이 맞습니다.
+
+- connection pooling 소유
+- dial/read/write/pool wait budget 소유
+- protocol mode와 hook 소유
+- 개별 request보다 오래 살아야 하는 객체
+
+## 안전한 기본 스케치
+
+```go
+rdb := redis.NewClient(&redis.Options{
+	Addr:            "redis:6379",
+	Protocol:        2,
+	DialTimeout:     1 * time.Second,
+	ReadTimeout:     500 * time.Millisecond,
+	WriteTimeout:    500 * time.Millisecond,
+	PoolTimeout:     1 * time.Second,
+	PoolSize:        64,
+	MinIdleConns:    8,
+	ReadBufferSize:  32 * 1024,
+	WriteBufferSize: 32 * 1024,
+	MaxRetries:      2,
+})
+
+if err := errors.Join(
+	redisotel.InstrumentTracing(rdb),
+	redisotel.InstrumentMetrics(rdb),
+); err != nil {
+	return err
+}
+```
+
+이 스케치가 안전한 이유는 주요 정책 레버를 전부 드러내기 때문입니다.
+
+- connection reuse
+- 짧은 network budget
+- bounded pool wait
+- 의도적인 RESP version
+- 처음부터 instrumentation
+
+## 운영 규칙
+
+### client를 재사용한다
+
+request마다 client를 새로 만들면 pooling을 버리고 Redis를 dial-heavy dependency로 바꿔버립니다. policy boundary마다 long-lived client 하나가 맞습니다.
+
+### RESP2/RESP3를 의식적으로 고른다
+
+공식 저장소는 둘 다 지원하지만, 그게 RESP3가 무조건 기본값이라는 뜻은 아닙니다. RediSearch나 query response처럼 RESP3 shape가 아직 불안정한 경로를 쓴다면 RESP2가 더 안전할 수 있습니다.
+
+### pipeline은 batching이지 transaction이 아니다
+
+pipeline은 round trip을 줄여줍니다. transactional isolation을 주지는 않습니다. 서버 측 atomicity가 필요하면 Redis transaction이나 Lua/Functions를 별도로 써야 합니다.
+
+### pool timeout은 network timeout만큼 중요하다
+
+Redis dependency는 서버가 느려서도 실패하지만, 네트워크가 느려서도 실패하고, 내 caller가 pool 뒤에서 오래 대기해서도 실패합니다. 이 세 상태는 운영 의미가 다릅니다.
+
+### buffer tuning은 workload가 증명할 때만 한다
+
+프로젝트는 현재 32KiB read/write buffer를 기본값으로 둡니다. 이건 좋은 시작점입니다. 더 큰 buffer는 large pipeline이나 high-throughput workload가 실제로 요구할 때만 올리는 편이 낫습니다.
+
+## 실패 패턴
+
+### request마다 client 생성
+
+```go
+func get(ctx context.Context, key string) (string, error) {
+	rdb := redis.NewClient(&redis.Options{Addr: "redis:6379"}) // bad
+	return rdb.Get(ctx, key).Result()
+}
+```
+
+### request path에서 `context.Background()` 사용
+
+```go
+val, err := rdb.Get(context.Background(), key).Result() // bad: request budget이 없음
+```
+
+### pipeline을 atomic하게 오해
+
+```go
+pipe := rdb.Pipeline()
+pipe.Incr(ctx, "balance")
+pipe.Set(ctx, "status", "ok", 0)
+_, _ = pipe.Exec(ctx) // bad assumption: batching은 transaction이 아님
+```
+
+### search-heavy 코드에서 blind RESP3 전환
+
+공식 저장소는 일부 RediSearch/query 응답 구조가 RESP3에서 아직 unstable하다고 명시합니다. command set 확인 없이 protocol을 바꾸면 안 됩니다.
+
+### pool 가시성이 없음
+
+`PoolStats`를 한 번도 안 보면 self-inflicted queueing을 remote Redis latency로 착각하게 됩니다.
+
+## 주의해서 써야 할 것
+
+- memory와 buffer impact를 측정하지 않은 큰 pipeline
+- unstable structure가 있는 command family에서의 RESP3
+- non-idempotent workflow에서의 높은 retry count
+- user-facing path에서의 `context.Background()`와 wide-open timeout
+
+## Observability와 테스트
+
+- `PoolStats()`를 주기적으로 수집하고 hits, misses, timeouts, total connections를 봅니다.
+- `redisotel`로 tracing과 metrics를 초기에 붙입니다.
+- Redis command latency와 pool-wait latency를 대시보드에서 분리합니다.
+- 실제 Redis 통합 테스트로 timeout/retry 정책을 확인한 뒤 운영에 태웁니다.
+
+## 언제 잘 맞는가
+
+go-redis는 caching, lightweight state, rate limiting, queue, ephemeral coordination 같은 대부분의 Go+Redis workload에서 기본값으로 맞습니다.
+
+## 언제 다른 도구를 봐야 하나
+
+strict relational guarantee, 대형 analytical scan, 복잡한 multi-step business transaction이 필요하다면 Redis + go-redis는 아무리 사용성이 좋아도 맞는 추상화가 아닐 가능성이 큽니다.
+
+## 공식 자료
+
+- [go-redis 저장소](https://github.com/redis/go-redis)
+- [Go-Redis is now an official Redis client](https://redis.io/blog/go-redis-official-redis-client/)
+- [`github.com/redis/go-redis/v9` 패키지 문서](https://pkg.go.dev/github.com/redis/go-redis/v9)
+
+## Practical takeaway
+
+go-redis는 Redis command helper로 보면 위험하고, pooled network dependency이자 protocol/timeout policy surface로 보면 훨씬 안전해집니다.

--- a/docs/ko/playbooks/grpc-go-production-playbook.md
+++ b/docs/ko/playbooks/grpc-go-production-playbook.md
@@ -1,0 +1,155 @@
+---
+title: grpc-go 실전 플레이북
+description: grpc-go를 long-lived channel, deadline, keepalive discipline, streaming ownership 관점에서 운영하는 법을 설명합니다.
+---
+
+# grpc-go 실전 플레이북
+
+`grpc-go`는 단순히 “바이너리 HTTP”가 아닙니다.
+
+이 라이브러리는 transport, channel, RPC policy가 한꺼번에 들어 있는 스택이라서, connection과 deadline을 대충 다루면 금방 복잡해집니다.
+
+## Mental model
+
+첫 번째 규칙은 단순합니다.
+
+- `ClientConn`은 long-lived channel이고,
+- RPC는 그 채널 위에서 잠깐 흐르는 work입니다.
+
+이 수명을 뒤집으면 비용도 커지고 고장도 잦아집니다.
+
+## 안전한 기본 스케치
+
+```go
+cc, err := grpc.NewClient(
+	"dns:///api.example.com:443",
+	grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
+		MinVersion: tls.VersionTLS12,
+	})),
+	grpc.WithConnectParams(grpc.ConnectParams{
+		MinConnectTimeout: 5 * time.Second,
+		Backoff: backoff.Config{
+			BaseDelay:  200 * time.Millisecond,
+			Multiplier: 1.6,
+			MaxDelay:   3 * time.Second,
+		},
+	}),
+)
+if err != nil {
+	return err
+}
+defer cc.Close()
+
+ctx, cancel := context.WithTimeout(parent, 2*time.Second)
+defer cancel()
+
+resp, err := pb.NewUsersClient(cc).GetUser(ctx, req)
+```
+
+이 스케치는 다음 기본값을 강제합니다.
+
+- deprecated `Dial`이 아니라 `grpc.NewClient`
+- long-lived channel 하나
+- per-RPC deadline
+- 명시적인 transport credential
+- bounded connect backoff
+
+## 운영 규칙
+
+### `grpc.NewClient`를 우선한다
+
+공식 패키지 문서는 이제 `NewClient`를 중심으로 설명합니다. 이 함수는 즉시 I/O를 하지 않고 channel만 만듭니다. 대부분의 경우 이 동작이 맞습니다.
+
+### `Dial`, 특히 `WithBlock`은 기본값으로 쓰지 않는다
+
+`Dial`은 deprecated이고 `WithBlock`은 공식 문서에서도 권장하지 않습니다. dependency가 잠깐 불안정한 것을 서비스 전체 startup outage로 바꾸기 쉽기 때문입니다.
+
+### authority 또는 policy boundary마다 channel 하나
+
+destination과 policy set 단위로 `ClientConn`을 만들고, 그 위에 여러 RPC를 태우는 구조가 맞습니다. 요청마다 channel을 열면 안 됩니다.
+
+### deadline은 startup이 아니라 RPC에 붙인다
+
+channel이 이미 있어도 각 RPC는 deadline이 필요합니다. 그렇지 않으면 queueing, retry, network stall의 lifetime이 무제한이 됩니다.
+
+### streaming은 ownership discipline이 필요하다
+
+stream을 중간에 버릴 거면 context를 cancel해야 하고, 끝까지 읽을 거면 `Recv()`를 `io.EOF`까지 돌려야 합니다. stream을 반쯤 방치하는 것은 HTTP body leak과 비슷한 문제입니다.
+
+### keepalive는 협의된 운영 정책이다
+
+aggressive client keepalive는 harmless한 설정이 아닙니다. 공식 keepalive 가이드는 지원되지 않는 cadence가 서버에서 `GOAWAY` `too_many_pings`를 유발할 수 있다고 명시합니다.
+
+## 실패 패턴
+
+### RPC마다 channel 생성
+
+```go
+func call(ctx context.Context, req *pb.Request) error {
+	cc, err := grpc.NewClient("dns:///api.example.com:443", grpc.WithTransportCredentials(creds))
+	if err != nil {
+		return err
+	}
+	defer cc.Close()
+	_, err = pb.NewAPIClient(cc).Handle(ctx, req)
+	return err
+}
+```
+
+이렇게 하면 connection setup, resolver work, transport warmup을 전부 hot path에 태우게 됩니다.
+
+### RPC에 deadline이 없음
+
+```go
+resp, err := client.GetUser(context.Background(), req) // bad: lifetime 무제한
+```
+
+### startup 정책으로 `WithBlock`
+
+```go
+cc, err := grpc.Dial(target, grpc.WithTransportCredentials(creds), grpc.WithBlock()) // bad default
+```
+
+### 너무 공격적인 keepalive
+
+서비스가 그 cadence를 명시적으로 지원하지 않으면, 오히려 reconnect churn을 만드는 설정이 됩니다.
+
+### cancel 없이 stream 방치
+
+```go
+stream, _ := client.Subscribe(ctx, req)
+return nil // bad: stream context가 transport resource를 계속 소유
+```
+
+## 주의해서 써야 할 것
+
+- `WithBlock`
+- 명시적 retry policy 없이 blanket default로 두는 `WaitForReady`
+- 조용한 channel에 대한 공격적인 keepalive
+- staging에서 이해하지 못한 채 켜는 service-config 기능
+- 서로 다른 trust/credential boundary를 하나의 `ClientConn`에 섞는 것
+
+## Observability와 테스트
+
+- `deadline_exceeded`와 `unavailable` 비율을 분리해서 봅니다.
+- interceptor나 stats handler로 method latency, size, status code를 수집합니다.
+- 실제 네트워크 없이 RPC 레벨 테스트를 하려면 `bufconn`이나 별도 통합 환경을 씁니다.
+- 장애 분석 때는 “gRPC가 느리다”가 아니라 resolver, connect, TLS, handler latency를 분리해서 봐야 합니다.
+
+## 언제 잘 맞는가
+
+typed internal API, streaming, deadline, cross-language protocol compatibility가 필요하면 `grpc-go`는 강한 기본값입니다.
+
+## 언제 다른 도구를 봐야 하나
+
+트래픽이 단순한 HTTP/JSON이고 복잡성 대부분이 브라우저/사람 대상 API에서 나온다면 raw HTTP가 더 운영하기 쉬울 수 있습니다. 반대로 fire-and-forget 이벤트 전달만 필요하다면 RPC 스택 자체가 과한 추상화일 수 있습니다.
+
+## 공식 자료
+
+- [`google.golang.org/grpc` 패키지 문서](https://pkg.go.dev/google.golang.org/grpc)
+- [gRPC keepalive guide](https://grpc.io/docs/guides/keepalive/)
+- [net/http 서버와 Transport 내부](/ko/stdlib/net-http-server-transport)
+
+## Practical takeaway
+
+grpc-go는 “호출마다 connection”이 아니라 “long-lived channel 위에 짧은 RPC budget”이라고 보는 순간 훨씬 다루기 쉬워집니다.

--- a/docs/ko/playbooks/index.md
+++ b/docs/ko/playbooks/index.md
@@ -1,0 +1,63 @@
+---
+title: 실전 플레이북
+description: 실제 프로덕션 동작을 좌우하는 Go 라이브러리와 클라이언트 패키지를 운영 관점에서 설명합니다.
+---
+
+# 실전 플레이북
+
+표준 라이브러리 섹션이 패키지가 어떻게 동작하는지 설명했다면,
+
+이 섹션은 그 패키지와 라이브러리에 실제 트래픽을 어떻게 안전하게 태울지를 설명합니다.
+
+이 섹션의 각 페이지는 공통적으로 다음을 다룹니다.
+
+- config를 만지기 전에 필요한 mental model,
+- 안전한 기본 설정 스케치,
+- 팀을 실제로 아프게 하는 failure pattern,
+- observability와 testing 포인트,
+- 언제 잘 맞고 언제 아닌지.
+
+## 무엇을 다루나
+
+<div class="path-grid">
+  <div class="path-card">
+    <h3><a href="/ko/playbooks/net-http-production-field-guide">net/http</a></h3>
+    <p>transport reuse, timeout boundary, body ownership, streaming caveat를 운영 규칙으로 바꿉니다.</p>
+  </div>
+  <div class="path-card">
+    <h3><a href="/ko/playbooks/grpc-go-production-playbook">grpc-go</a></h3>
+    <p>long-lived channel, RPC deadline, keepalive discipline, streaming ownership을 `Dial`/`WithBlock` 함정 없이 다룹니다.</p>
+  </div>
+  <div class="path-card">
+    <h3><a href="/ko/playbooks/go-redis-production-playbook">go-redis</a></h3>
+    <p>pooling, timeout budget, RESP2/RESP3 선택, pipeline, instrumentation을 cache-heavy 서비스 관점에서 정리합니다.</p>
+  </div>
+  <div class="path-card">
+    <h3><a href="/ko/playbooks/kafka-with-ibm-sarama">Kafka with IBM Sarama</a></h3>
+    <p>consumer group, producer, acks, offset, rebalance loop를 Kafka의 실제 semantics에 맞게 운영하는 법을 설명합니다.</p>
+  </div>
+</div>
+
+## 추천 읽기 순서
+
+1. 먼저 [net/http](/ko/playbooks/net-http-production-field-guide)를 읽습니다. 거의 모든 Go 서비스가 이 lifetime/timeout 모델 위에 있기 때문입니다.
+2. 다음으로 [grpc-go](/ko/playbooks/grpc-go-production-playbook)를 읽습니다. 여기서는 connection reuse, deadline, streaming, keepalive policy가 더 명시적으로 드러납니다.
+3. 그 다음 [go-redis](/ko/playbooks/go-redis-production-playbook)를 읽습니다. cache-heavy request path나 background worker를 운영한다면 특히 중요합니다.
+4. 마지막으로 [Kafka with IBM Sarama](/ko/playbooks/kafka-with-ibm-sarama)를 읽습니다. durable event flow, consumer-group ownership, offset discipline이 필요한 경우입니다.
+
+## 읽고 나면 답할 수 있어야 하는 질문
+
+- `http.Client.Timeout`은 언제 유용하고, 언제 너무 많은 경계를 한 번에 뭉개는가?
+- 왜 gRPC `ClientConn`은 한 RPC보다 훨씬 오래 살아야 하는가?
+- 왜 공격적인 gRPC keepalive 설정이 서버의 역반응을 부를 수 있는가?
+- 왜 go-redis client는 command helper가 아니라 pooled resource owner로 봐야 하는가?
+- RESP3가 있어도 왜 RESP2를 유지하는 편이 더 안전한 경우가 있는가?
+- 왜 Sarama의 `Config.Version`은 장식이 아니라 운영 요구사항인가?
+- 왜 synchronous Kafka producer도 end-to-end exactly once를 의미하지 않는가?
+- 왜 offset mark는 side effect 뒤에 와야 하지 앞서면 안 되는가?
+
+## Practical takeaway
+
+이 플레이북은 언어/런타임 지식을 서비스 정책으로 바꾸는 구간입니다.
+
+API 호출법보다, 트래픽, 재시도, 종료, 부분 실패 아래에서 시스템을 어떻게 정직하게 유지할지가 핵심입니다.

--- a/docs/ko/playbooks/kafka-with-ibm-sarama.md
+++ b/docs/ko/playbooks/kafka-with-ibm-sarama.md
@@ -1,0 +1,163 @@
+---
+title: Kafka with IBM Sarama
+description: IBM Sarama로 Kafka를 운영할 때 producer durability, consumer-group lifecycle, offset discipline을 어떻게 잡아야 하는지 설명합니다.
+---
+
+# Kafka with IBM Sarama
+
+Kafka와 Sarama는 한 주제로 다루는 편이 맞습니다.
+
+client API는 Kafka의 실제 semantics, 즉 acks, rebalance, offset, broker-version compatibility를 존중할 때만 의미가 있기 때문입니다.
+
+## Mental model
+
+아래 세 경계를 분리해서 봐야 합니다.
+
+- producer durability policy
+- consumer-group session lifecycle
+- side effect와 offset ownership의 순서
+
+많은 Kafka 장애는 이 셋을 그냥 “보내기”와 “읽기”로 뭉개는 순간 시작됩니다.
+
+## 안전한 producer 스케치
+
+```go
+config := sarama.NewConfig()
+config.Version = sarama.V3_6_0_0
+config.Producer.RequiredAcks = sarama.WaitForAll
+config.Producer.Idempotent = true
+config.Producer.Return.Successes = true
+config.Producer.Return.Errors = true
+
+producer, err := sarama.NewSyncProducer(brokers, config)
+if err != nil {
+	return err
+}
+defer producer.Close()
+```
+
+이 설정만으로 exactly once가 되지는 않지만, durability 기준선으로는 괜찮습니다.
+
+- 명시적인 broker version
+- 가장 강한 일반 ack 모드
+- idempotent producer 모드
+- Sarama가 요구하는 return channel 설정
+
+## 안전한 consumer-group 스케치
+
+```go
+config := sarama.NewConfig()
+config.Version = sarama.V3_6_0_0
+config.Consumer.Return.Errors = true
+config.Consumer.Offsets.Initial = sarama.OffsetNewest
+config.Consumer.Group.Rebalance.GroupStrategies = []sarama.BalanceStrategy{
+	sarama.NewBalanceStrategyRange(),
+}
+
+group, err := sarama.NewConsumerGroup(brokers, "payments", config)
+if err != nil {
+	return err
+}
+defer group.Close()
+
+for {
+	if err := group.Consume(ctx, topics, handler); err != nil {
+		return err
+	}
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+}
+```
+
+바깥 `for` 루프가 중요합니다. consumer-group session은 rebalance마다 끝나고 다시 시작됩니다. `Consume`를 한 번만 부르는 setup 함수처럼 보면 안 됩니다.
+
+## 운영 규칙
+
+### `Config.Version`을 명시한다
+
+공식 FAQ는 일부 기능의 동작이 `Config.Version`에 달려 있다고 명시합니다. cluster capability를 흐리게 두면, 오래된 동작으로 fallback하거나 새 기능을 예상 밖에 거부할 수 있습니다.
+
+### synchronous producer가 만능 durability 스위치는 아니다
+
+공식 패키지 문서는 `SyncProducer`가 대체로 `AsyncProducer`보다 비효율적이고, acknowledged message도 `Producer.RequiredAcks`에 따라 여전히 유실될 수 있다고 설명합니다.
+
+### async producer는 channel discipline이 필요하다
+
+`Producer.Return.Successes`를 켰다면 `Successes()`를 반드시 읽어야 하고, 그렇지 않으면 producer가 deadlock될 수 있습니다. `Errors()`도 마찬가지입니다.
+
+### consumer group은 endless loop가 아니라 session 단위다
+
+`ConsumerGroup` 문서는 `Consume`를 blocking session lifecycle로 설명합니다. rebalance, handler setup/cleanup, claim 처리까지 전부 session의 일부입니다.
+
+### offset은 side effect 뒤에 와야 한다
+
+DB write나 downstream publish가 아직 durable하지 않은데 offset을 먼저 마킹하면, 시스템은 아직 끝나지 않은 일을 끝났다고 선언한 셈이 됩니다.
+
+## 실패 패턴
+
+### Kafka version을 명시하지 않음
+
+```go
+config := sarama.NewConfig() // bad: cluster capability가 암묵적
+```
+
+### sync producer를 “충분히 안전하다”로 오해
+
+```go
+config.Producer.RequiredAcks = sarama.WaitForLocal // 생각보다 약한 설정
+producer, _ := sarama.NewSyncProducer(brokers, config)
+```
+
+### channel을 비우지 않는 async producer
+
+```go
+producer, _ := sarama.NewAsyncProducer(brokers, config)
+producer.Input() <- msg // bad: Successes/Errors를 비우는 goroutine이 없음
+```
+
+### rejoin loop가 없는 consumer group
+
+```go
+_ = group.Consume(ctx, topics, handler) // bad: 한 세션만 돌고 끝
+```
+
+### side effect 전에 offset mark
+
+```go
+sess.MarkMessage(msg, "")
+err := writeToDB(msg) // bad: offset이 먼저 움직임
+```
+
+## 주의해서 써야 할 것
+
+- throughput이 중요한데도 무조건 `SyncProducer`
+- idempotent handler 없이 높은 retry count
+- crash/rebalance 테스트 없이 믿는 auto-commit 가정
+- rebalance/session timing을 길게 잡아먹는 handler critical section
+
+## Observability와 테스트
+
+- consumer lag, rebalance count, rebalance duration, handler error rate를 봅니다.
+- producer error rate는 application error rate와 분리해서 봅니다.
+- offset commit과 side effect 사이 crash timing은 mock이 아니라 통합 테스트로 검증합니다.
+- partition skew를 봐야 합니다. hot partition은 handler가 느린 것처럼 보이게 만듭니다.
+
+## 언제 잘 맞는가
+
+Go에서 event durability, replay, partitioned throughput, consumer-group coordination이 필요하면 Kafka + Sarama는 잘 맞습니다.
+
+## 언제 다른 도구를 봐야 하나
+
+request-response RPC, ultra-low-latency cache access, 작은 in-process job dispatch라면 Kafka는 클라이언트 품질과 별개로 맞지 않는 추상화일 가능성이 큽니다.
+
+## 공식 자료
+
+- [`github.com/IBM/sarama` 패키지 문서](https://pkg.go.dev/github.com/IBM/sarama)
+- [IBM Sarama FAQ](https://github.com/IBM/sarama/wiki/Frequently-Asked-Questions)
+
+## Practical takeaway
+
+Kafka correctness는 Sarama를 import하는 것만으로 오지 않습니다.
+
+version, acks, consumer-session lifecycle, offset-after-side-effect 정책을 서비스에 명시해야만 안전해집니다.

--- a/docs/ko/playbooks/net-http-production-field-guide.md
+++ b/docs/ko/playbooks/net-http-production-field-guide.md
@@ -1,0 +1,151 @@
+---
+title: net/http 실전 필드 가이드
+description: Go HTTP client/server stack을 timeout, pooling, lifecycle 정책 관점에서 운영하는 법을 설명합니다.
+---
+
+# net/http 실전 필드 가이드
+
+이 문서는 [net/http 서버와 Transport 내부](/ko/stdlib/net-http-server-transport)와 의도가 다릅니다.
+
+저 문서가 패키지 내부 동작을 설명한다면, 이 문서는 그 패키지에 실제 트래픽을 어떻게 안전하게 태울지 설명합니다.
+
+## Mental model
+
+`net/http`에는 두 개의 장기 소유자가 있습니다.
+
+- `http.Server`: inbound connection lifetime 소유
+- `http.Client` + `Transport`: outbound connection lifetime 소유
+
+대부분의 프로덕션 문제는 둘 중 하나를 정책 경계가 아니라 일회성 helper처럼 다룰 때 시작됩니다.
+
+## 안전한 기본 스케치
+
+```go
+transport := http.DefaultTransport.(*http.Transport).Clone()
+transport.MaxIdleConns = 256
+transport.MaxIdleConnsPerHost = 64
+transport.MaxConnsPerHost = 128
+transport.IdleConnTimeout = 90 * time.Second
+transport.ResponseHeaderTimeout = 2 * time.Second
+transport.ExpectContinueTimeout = 1 * time.Second
+
+client := &http.Client{
+	Transport: transport,
+}
+
+srv := &http.Server{
+	Addr:              ":8080",
+	Handler:           mux,
+	ReadHeaderTimeout: 2 * time.Second,
+	IdleTimeout:       60 * time.Second,
+	BaseContext: func(net.Listener) context.Context {
+		return appCtx
+	},
+}
+```
+
+이 설정이 유일한 정답은 아니지만, 출발점으로는 안전합니다.
+
+- long-lived transport 하나,
+- long-lived client 하나,
+- 명시적인 server-side read 경계,
+- 그 위에 request-scoped deadline을 추가하는 구조
+
+이기 때문입니다.
+
+## 운영 규칙
+
+### client와 transport를 재사용한다
+
+요청마다 `Transport`를 새로 만들면 pooling을 스스로 깨는 셈입니다. transport는 outbound policy boundary 단위의 singleton으로 다루는 편이 맞습니다.
+
+### request context와 transport timeout을 같이 쓴다
+
+`Client.Timeout`은 전체 exchange를 한 번에 자르는 blunt tool입니다. 간단한 경우엔 유용하지만, 큰 시스템에서는 보통 다음을 같이 써야 합니다.
+
+- business budget용 request context deadline
+- 특정 네트워크 edge용 transport timeout
+- inbound 방어용 server read/idle timeout
+
+### response body는 connection ownership 문제다
+
+body를 닫는 것은 단순 cleanup이 아닙니다. transport가 이 connection을 재사용해도 되는지 판단하는 신호입니다.
+
+중간에 읽기를 포기할 때는 의식적으로 둘 중 하나를 택해야 합니다.
+
+- bounded drain 후 재사용
+- 즉시 close 후 재사용 포기
+
+실수로 둘 다 안 하면 안 됩니다.
+
+### streaming endpoint는 timeout 전략이 달라진다
+
+SSE나 긴 다운로드 같은 streaming response에는 server `WriteTimeout`이 오히려 맞지 않을 수 있습니다. 이런 endpoint는 generic timeout 하나로 덮지 말고 별도 정책을 가져가는 편이 낫습니다.
+
+## 실패 패턴
+
+### hot path에서 client를 매번 생성
+
+```go
+func fetch(url string) (*http.Response, error) {
+	client := &http.Client{Timeout: 2 * time.Second} // bad: 호출마다 새 transport 정책
+	return client.Get(url)
+}
+```
+
+### 중요한 dependency에서 숨은 default client 사용
+
+```go
+resp, err := http.Get(url) // bad: transport budget, proxy policy, reuse 설정이 보이지 않음
+```
+
+### body ownership 누락
+
+```go
+resp, err := client.Do(req)
+if err != nil {
+	return err
+}
+return decode(resp.Body) // bad: body를 닫지 않음
+```
+
+### 모든 걸 큰 timeout 하나로 처리
+
+```go
+client := &http.Client{Timeout: 30 * time.Second}
+```
+
+이렇게 하면 dial budget이 필요한지, response-header budget이 필요한지, handler deadline이 필요한지, shutdown contract가 필요한지가 모두 흐려집니다.
+
+## 주의해서 써야 할 것
+
+- 라이브러리 성격의 코드에서 `http.DefaultClient`, `http.DefaultTransport`
+- streaming handler에 대한 `WriteTimeout`
+- huge body나 attacker-controlled body에 대한 무조건적인 `io.Copy(io.Discard, resp.Body)`
+- 실제 context discipline 대신 `TimeoutHandler`로 덮는 방식
+
+## Observability와 테스트
+
+- `httptest.Server`로 client timeout edge와 body-close discipline을 검증합니다.
+- `Server.Shutdown` 테스트로 deploy 중 in-flight request 동작을 검증합니다.
+- reuse vs redial 증명이 필요하면 `httptrace`를 씁니다.
+- request duration, status code, inflight count, outbound dependency latency를 분리해서 봅니다. 섞으면 transport churn이 가려집니다.
+
+## 언제 잘 맞는가
+
+대부분의 Go 서비스, control plane, API, webhook, 내부 서비스 간 호출은 `net/http`가 기본값으로 맞습니다. 표준 라이브러리는 policy boundary만 의식해서 쓰면 대부분의 workload를 충분히 커버합니다.
+
+## 언제 다른 도구를 봐야 하나
+
+매우 특수한 L7 proxy, custom wire protocol gateway, 혹은 hot path의 추가 allocation 하나도 치명적인 환경이라면 더 특화된 스택이 필요할 수 있습니다. 그래도 그 전에 진짜 병목이 `net/http` 자체인지, 아니면 timeout/reuse/buffering discipline이 없는 것인지부터 증명해야 합니다.
+
+## 공식 자료
+
+- [`net/http` 패키지 문서](https://pkg.go.dev/net/http)
+- [net/http 서버와 Transport 내부](/ko/stdlib/net-http-server-transport)
+
+## Practical takeaway
+
+프로덕션 `net/http`는 대부분 ownership 문제입니다.
+
+client reuse, response body, timeout edge를 명시하면 이 패키지는 매우 믿을 만합니다. 그 정책을 암묵적으로 두면 latency와 resource usage를 설명하기 어려워집니다.

--- a/docs/playbooks/go-redis-production-playbook.md
+++ b/docs/playbooks/go-redis-production-playbook.md
@@ -1,0 +1,140 @@
+---
+title: go-redis Production Playbook
+description: Learn how to operate go-redis with explicit pooling, timeout, protocol, and instrumentation policy.
+---
+
+# go-redis Production Playbook
+
+`go-redis` is easy to call and easy to misuse.
+
+The client looks lightweight, but operationally it is a pool owner, a timeout boundary, and a protocol policy surface.
+
+## Mental model
+
+Treat a `go-redis` client as a long-lived resource boundary:
+
+- it owns connection pooling,
+- it owns dial, read, write, and pool wait budgets,
+- it owns protocol mode and hooks,
+- it should usually outlive individual requests.
+
+## Safe default sketch
+
+```go
+rdb := redis.NewClient(&redis.Options{
+	Addr:            "redis:6379",
+	Protocol:        2,
+	DialTimeout:     1 * time.Second,
+	ReadTimeout:     500 * time.Millisecond,
+	WriteTimeout:    500 * time.Millisecond,
+	PoolTimeout:     1 * time.Second,
+	PoolSize:        64,
+	MinIdleConns:    8,
+	ReadBufferSize:  32 * 1024,
+	WriteBufferSize: 32 * 1024,
+	MaxRetries:      2,
+})
+
+if err := errors.Join(
+	redisotel.InstrumentTracing(rdb),
+	redisotel.InstrumentMetrics(rdb),
+); err != nil {
+	return err
+}
+```
+
+This sketch is safe because it makes the main policy levers explicit:
+
+- connection reuse,
+- short network budgets,
+- bounded pool waiting,
+- deliberate RESP version,
+- instrumentation from day one.
+
+## Operating rules
+
+### Reuse the client
+
+Creating a new client per request throws away pooling and turns Redis into a dial-heavy dependency. Keep one long-lived client per policy boundary.
+
+### Pick RESP2 or RESP3 deliberately
+
+The official repository supports both. That does not mean RESP3 is automatically the right default. If you depend on RediSearch or query responses whose RESP3 shapes are still unstable, RESP2 can be safer.
+
+### Pipelines are batching, not transactions
+
+Pipelines reduce round trips. They do not give transactional isolation. If you need server-side atomicity, use Redis transactions or Lua/Functions appropriately.
+
+### Pool timeout matters as much as network timeout
+
+A Redis dependency can fail because the server is slow, because the network is slow, or because your own callers are queued behind the pool. Those are different operational states.
+
+### Tune buffers only when the workload proves it
+
+The project defaults to 32KiB read/write buffers now. That is a good default. Increase them when large pipelines or high-throughput workloads justify it, not because bigger sounds faster.
+
+## Failure patterns
+
+### Client per request
+
+```go
+func get(ctx context.Context, key string) (string, error) {
+	rdb := redis.NewClient(&redis.Options{Addr: "redis:6379"}) // bad
+	return rdb.Get(ctx, key).Result()
+}
+```
+
+### Using `context.Background()` in request paths
+
+```go
+val, err := rdb.Get(context.Background(), key).Result() // bad: no request budget
+```
+
+### Treating pipeline as atomic
+
+```go
+pipe := rdb.Pipeline()
+pipe.Incr(ctx, "balance")
+pipe.Set(ctx, "status", "ok", 0)
+_, _ = pipe.Exec(ctx) // bad assumption: batching is not a transaction
+```
+
+### Blind RESP3 upgrade on search-heavy code
+
+The official repo notes that some RediSearch/query response structures are still unstable under RESP3. Do not switch protocols without checking the command set you depend on.
+
+### No pool visibility
+
+If you never look at `PoolStats`, you can mistake self-inflicted queueing for remote Redis latency.
+
+## What to use carefully
+
+- very large pipelines without measuring memory and buffer impact
+- RESP3 on command families with unstable structures
+- high retry counts on non-idempotent workflows
+- `context.Background()` and wide-open timeouts on user-facing paths
+
+## Observability and testing
+
+- Export `PoolStats()` regularly and watch hits, misses, timeouts, and total connections.
+- Instrument tracing and metrics early with `redisotel`.
+- Separate Redis command latency from pool-wait latency in dashboards.
+- Test timeout and retry policy against a real Redis in integration tests before betting production load on it.
+
+## When it is the right tool
+
+go-redis is the default choice for most Go services that need Redis caching, lightweight state, rate limiting, queues, or ephemeral coordination.
+
+## When it is not the right tool
+
+If you need strict relational guarantees, large analytical scans, or multi-step business transactions with complex invariants, Redis plus go-redis is usually the wrong abstraction no matter how ergonomic the client feels.
+
+## Official reading
+
+- [go-redis repository](https://github.com/redis/go-redis)
+- [Go-Redis is now an official Redis client](https://redis.io/blog/go-redis-official-redis-client/)
+- [Package docs for `github.com/redis/go-redis/v9`](https://pkg.go.dev/github.com/redis/go-redis/v9)
+
+## Practical takeaway
+
+go-redis is safest when you treat it as a pooled network dependency with protocol and timeout policy, not as a tiny helper around Redis commands.

--- a/docs/playbooks/grpc-go-production-playbook.md
+++ b/docs/playbooks/grpc-go-production-playbook.md
@@ -1,0 +1,155 @@
+---
+title: grpc-go Production Playbook
+description: Learn how to operate grpc-go with long-lived channels, deadlines, keepalive discipline, and explicit streaming ownership.
+---
+
+# grpc-go Production Playbook
+
+`grpc-go` is not “HTTP but binary.”
+
+It is a transport, channel, and RPC policy stack that gets complicated quickly if you treat connections or deadlines casually.
+
+## Mental model
+
+The first rule is simple:
+
+- a `ClientConn` is a long-lived channel,
+- an RPC is short-lived work on top of that channel.
+
+If you reverse those lifetimes, the library becomes expensive and unreliable.
+
+## Safe default sketch
+
+```go
+cc, err := grpc.NewClient(
+	"dns:///api.example.com:443",
+	grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
+		MinVersion: tls.VersionTLS12,
+	})),
+	grpc.WithConnectParams(grpc.ConnectParams{
+		MinConnectTimeout: 5 * time.Second,
+		Backoff: backoff.Config{
+			BaseDelay:  200 * time.Millisecond,
+			Multiplier: 1.6,
+			MaxDelay:   3 * time.Second,
+		},
+	}),
+)
+if err != nil {
+	return err
+}
+defer cc.Close()
+
+ctx, cancel := context.WithTimeout(parent, 2*time.Second)
+defer cancel()
+
+resp, err := pb.NewUsersClient(cc).GetUser(ctx, req)
+```
+
+This sketch bakes in the right defaults:
+
+- `grpc.NewClient`, not deprecated `Dial`,
+- one long-lived channel,
+- per-RPC deadlines,
+- explicit transport credentials,
+- bounded connect backoff policy.
+
+## Operating rules
+
+### Prefer `grpc.NewClient`
+
+The official package docs now center `NewClient`. It creates the channel without doing I/O immediately. RPCs will connect as needed. That is usually what you want.
+
+### Avoid `Dial` and especially `WithBlock`
+
+`Dial` is deprecated, and `WithBlock` is explicitly discouraged. Blocking process startup on connection establishment often turns transient dependency issues into global outages.
+
+### One channel per authority or policy boundary
+
+Build one `ClientConn` per destination and policy set, then reuse it for many RPCs. Do not open a new channel per request.
+
+### Deadlines belong on RPCs, not only on startup
+
+Even if the channel exists, each RPC still needs a deadline. Otherwise queueing, retries, or network stalls become unbounded.
+
+### Streaming requires ownership discipline
+
+If you abandon a stream early, cancel its context. If you intend to consume it, drive `Recv()` to `io.EOF`. Leaving streams half-owned is the streaming equivalent of leaking response bodies.
+
+### Keepalive is a negotiated operating policy
+
+Aggressive client keepalive is not harmless. The official keepalive guide warns that unsupported settings can make the server respond with `GOAWAY` carrying `too_many_pings`.
+
+## Failure patterns
+
+### One channel per RPC
+
+```go
+func call(ctx context.Context, req *pb.Request) error {
+	cc, err := grpc.NewClient("dns:///api.example.com:443", grpc.WithTransportCredentials(creds))
+	if err != nil {
+		return err
+	}
+	defer cc.Close()
+	_, err = pb.NewAPIClient(cc).Handle(ctx, req)
+	return err
+}
+```
+
+This burns connection setup, resolver work, and transport warmup on the hot path.
+
+### No deadline on the RPC
+
+```go
+resp, err := client.GetUser(context.Background(), req) // bad: unbounded lifetime
+```
+
+### `WithBlock` as startup policy
+
+```go
+cc, err := grpc.Dial(target, grpc.WithTransportCredentials(creds), grpc.WithBlock()) // bad default
+```
+
+### Keepalive too aggressive
+
+If the service does not explicitly support your keepalive cadence, you can create avoidable reconnect churn.
+
+### Abandoning streams without canceling
+
+```go
+stream, _ := client.Subscribe(ctx, req)
+return nil // bad: stream context still owns transport resources
+```
+
+## What to use carefully
+
+- `WithBlock`
+- `WaitForReady` as a blanket default instead of an explicit retry policy
+- aggressive keepalive on quiet channels
+- service-config features you do not actively understand in staging
+- one `ClientConn` shared across unrelated trust or credential boundaries
+
+## Observability and testing
+
+- Track deadline-exceeded and unavailable rates separately.
+- Use interceptors or stats handlers to record method latency, size, and status code.
+- Use `bufconn` or dedicated integration environments for RPC-level tests without real networks.
+- During incidents, distinguish resolver, connect, TLS, and RPC handler latency rather than blaming “gRPC” as one blob.
+
+## When it is the right tool
+
+`grpc-go` is a strong default when you need typed internal APIs, streaming, deadlines, and cross-language protocol compatibility.
+
+## When it is not the right tool
+
+If your traffic is simple HTTP/JSON and most complexity comes from human-facing APIs or browser compatibility, raw HTTP may be cheaper to operate. Likewise, if the system only needs fire-and-forget event transfer, an RPC stack may be the wrong abstraction.
+
+## Official reading
+
+- [Package docs for `google.golang.org/grpc`](https://pkg.go.dev/google.golang.org/grpc)
+- [gRPC keepalive guide](https://grpc.io/docs/guides/keepalive/)
+- [net/http Server and Transport Internals](/stdlib/net-http-server-transport)
+
+## Practical takeaway
+
+grpc-go gets much easier once you stop thinking “connection per call” and start thinking “long-lived channel with short-lived RPC budgets.”

--- a/docs/playbooks/index.md
+++ b/docs/playbooks/index.md
@@ -1,0 +1,63 @@
+---
+title: Production Playbooks
+description: Operator-oriented guides for the Go libraries and client packages that define real production behavior.
+---
+
+# Production Playbooks
+
+The standard-library section explains how the packages work.
+
+This section explains how to bet production traffic on them without guessing.
+
+Every page in this section is organized around:
+
+- the mental model you need before touching config,
+- a safe default sketch,
+- the failure patterns that actually hurt teams,
+- observability and testing hooks,
+- when the tool is a good fit and when it is not.
+
+## What this section covers
+
+<div class="path-grid">
+  <div class="path-card">
+    <h3><a href="/playbooks/net-http-production-field-guide">net/http</a></h3>
+    <p>Turn transport reuse, timeout boundaries, body ownership, and streaming caveats into explicit operating rules.</p>
+  </div>
+  <div class="path-card">
+    <h3><a href="/playbooks/grpc-go-production-playbook">grpc-go</a></h3>
+    <p>Use long-lived channels, RPC deadlines, keepalive discipline, and streaming ownership without falling into `Dial` and `WithBlock` traps.</p>
+  </div>
+  <div class="path-card">
+    <h3><a href="/playbooks/go-redis-production-playbook">go-redis</a></h3>
+    <p>Understand pooling, timeout budgets, RESP2/RESP3 choices, pipelines, and instrumentation for cache-heavy services.</p>
+  </div>
+  <div class="path-card">
+    <h3><a href="/playbooks/kafka-with-ibm-sarama">Kafka with IBM Sarama</a></h3>
+    <p>Operate consumer groups, producers, acks, offsets, and rebalance loops with a client model that matches Kafka's actual semantics.</p>
+  </div>
+</div>
+
+## Suggested reading order
+
+1. Start with [net/http](/playbooks/net-http-production-field-guide), because almost every Go service depends on its lifetime and timeout model.
+2. Continue with [grpc-go](/playbooks/grpc-go-production-playbook), where connection reuse, deadlines, streaming, and keepalive policy become more explicit.
+3. Read [go-redis](/playbooks/go-redis-production-playbook) next if you operate cache-heavy request paths or background workers.
+4. Finish with [Kafka with IBM Sarama](/playbooks/kafka-with-ibm-sarama) when you need durable event flow, consumer-group ownership, and offset discipline.
+
+## What you should be able to answer afterward
+
+- When is `http.Client.Timeout` useful, and when does it blur too many edges together?
+- Why should a gRPC `ClientConn` live much longer than one RPC?
+- Why can aggressive gRPC keepalive settings make servers push back?
+- Why is a go-redis client primarily a pooled resource owner, not just a command helper?
+- When should you keep RESP2 even if RESP3 exists?
+- Why is `Config.Version` in Sarama an operating requirement, not optional decoration?
+- Why does a synchronous Kafka producer still not imply end-to-end exactly once?
+- Why does offset marking have to follow side effects, not lead them?
+
+## Practical takeaway
+
+These playbooks are where language knowledge becomes service policy.
+
+They are less about calling the API correctly and more about keeping the system honest under traffic, retries, shutdown, and partial failure.

--- a/docs/playbooks/kafka-with-ibm-sarama.md
+++ b/docs/playbooks/kafka-with-ibm-sarama.md
@@ -1,0 +1,163 @@
+---
+title: Kafka with IBM Sarama
+description: Learn how to operate Kafka from Go with IBM Sarama across producer durability, consumer-group lifecycle, and offset discipline.
+---
+
+# Kafka with IBM Sarama
+
+Kafka and Sarama belong in one topic.
+
+The client API only makes sense if you respect Kafka's actual semantics around acks, rebalances, offsets, and broker-version compatibility.
+
+## Mental model
+
+There are three separate boundaries to keep straight:
+
+- producer durability policy,
+- consumer-group session lifecycle,
+- offset ownership relative to your side effects.
+
+Most Kafka incidents happen when a team collapses those three into “send messages” and “read messages.”
+
+## Safe producer sketch
+
+```go
+config := sarama.NewConfig()
+config.Version = sarama.V3_6_0_0
+config.Producer.RequiredAcks = sarama.WaitForAll
+config.Producer.Idempotent = true
+config.Producer.Return.Successes = true
+config.Producer.Return.Errors = true
+
+producer, err := sarama.NewSyncProducer(brokers, config)
+if err != nil {
+	return err
+}
+defer producer.Close()
+```
+
+This sketch is not enough for exactly once by itself, but it is a sane durability baseline:
+
+- explicit broker version,
+- strongest normal ack mode,
+- idempotent producer mode,
+- the return channels enabled the way Sarama requires.
+
+## Safe consumer-group sketch
+
+```go
+config := sarama.NewConfig()
+config.Version = sarama.V3_6_0_0
+config.Consumer.Return.Errors = true
+config.Consumer.Offsets.Initial = sarama.OffsetNewest
+config.Consumer.Group.Rebalance.GroupStrategies = []sarama.BalanceStrategy{
+	sarama.NewBalanceStrategyRange(),
+}
+
+group, err := sarama.NewConsumerGroup(brokers, "payments", config)
+if err != nil {
+	return err
+}
+defer group.Close()
+
+for {
+	if err := group.Consume(ctx, topics, handler); err != nil {
+		return err
+	}
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+}
+```
+
+The outer `for` loop matters. Consumer-group sessions end and restart across rebalances. Treat `Consume` as a session boundary, not as a one-time setup call.
+
+## Operating rules
+
+### Set `Config.Version` deliberately
+
+The official Sarama FAQ is explicit that some features change behavior based on `Config.Version`. If you leave cluster capability vague, the client can fall back to older behavior or reject newer features unexpectedly.
+
+### A synchronous producer is not a magic durability switch
+
+The official package docs say `SyncProducer` is generally less efficient than `AsyncProducer`, and even acknowledged messages can still be lost depending on `Producer.RequiredAcks`.
+
+### Async producers require channel discipline
+
+If you enable `Producer.Return.Successes`, you must read the `Successes()` channel or the producer can deadlock. You must also read `Errors()` or disable returned errors explicitly.
+
+### Consumer groups are session-based, not endless loops
+
+The `ConsumerGroup` docs describe `Consume` as a blocking session lifecycle. Rebalances, handler setup, cleanup, and claims are part of that lifecycle.
+
+### Offsets follow side effects
+
+If you mark offsets before your database write, RPC, or downstream publish is actually durable, you have acknowledged work the system has not really completed.
+
+## Failure patterns
+
+### No explicit Kafka version
+
+```go
+config := sarama.NewConfig() // bad: cluster capability left implicit
+```
+
+### Sync producer assumed to mean “safe enough”
+
+```go
+config.Producer.RequiredAcks = sarama.WaitForLocal // weaker than many teams realize
+producer, _ := sarama.NewSyncProducer(brokers, config)
+```
+
+### Async producer without draining channels
+
+```go
+producer, _ := sarama.NewAsyncProducer(brokers, config)
+producer.Input() <- msg // bad: no goroutine draining Successes/Errors
+```
+
+### Consumer group without rejoin loop
+
+```go
+_ = group.Consume(ctx, topics, handler) // bad: one session, no rebalance loop
+```
+
+### Marking offsets before the real side effect
+
+```go
+sess.MarkMessage(msg, "")
+err := writeToDB(msg) // bad: offset moved first
+```
+
+## What to use carefully
+
+- `SyncProducer` when throughput matters more than synchronous call style
+- high retry counts without idempotent handlers
+- auto-commit assumptions you have never tested under crash and rebalance
+- large handler critical sections that extend rebalance or session timing
+
+## Observability and testing
+
+- Track consumer lag, rebalance count, rebalance duration, and handler error rates.
+- Track producer error rate separately from application error rate.
+- Test crash timing around offset commit and side effects with integration tests, not only mocks.
+- Watch partition skew. Hot partitions can make consumer-group health look like handler slowness.
+
+## When it is the right tool
+
+Kafka with Sarama is a good fit when you need event durability, replay, partitioned throughput, and consumer-group coordination from Go.
+
+## When it is not the right tool
+
+If the workload is request-response RPC, ultra-low-latency cache access, or tiny in-process job dispatch, Kafka is often the wrong abstraction regardless of how good the client is.
+
+## Official reading
+
+- [Package docs for `github.com/IBM/sarama`](https://pkg.go.dev/github.com/IBM/sarama)
+- [IBM Sarama FAQ](https://github.com/IBM/sarama/wiki/Frequently-Asked-Questions)
+
+## Practical takeaway
+
+Kafka correctness does not come from importing Sarama.
+
+It comes from making version, acks, consumer-session lifecycle, and offset-after-side-effect policy explicit in your service.

--- a/docs/playbooks/net-http-production-field-guide.md
+++ b/docs/playbooks/net-http-production-field-guide.md
@@ -1,0 +1,149 @@
+---
+title: net/http Production Field Guide
+description: Learn how to run Go's HTTP client and server stack with deliberate timeout, pooling, and lifecycle policy.
+---
+
+# net/http Production Field Guide
+
+This page is intentionally different from [net/http Server and Transport Internals](/stdlib/net-http-server-transport).
+
+That page explains how the package works. This page explains how to operate it safely in production.
+
+## Mental model
+
+`net/http` gives you two long-lived owners:
+
+- `http.Server` owns inbound connection lifetime,
+- `http.Client` plus `Transport` owns outbound connection lifetime.
+
+Most production mistakes happen when a team treats either one as a throwaway helper instead of a policy boundary.
+
+## Safe default sketch
+
+```go
+transport := http.DefaultTransport.(*http.Transport).Clone()
+transport.MaxIdleConns = 256
+transport.MaxIdleConnsPerHost = 64
+transport.MaxConnsPerHost = 128
+transport.IdleConnTimeout = 90 * time.Second
+transport.ResponseHeaderTimeout = 2 * time.Second
+transport.ExpectContinueTimeout = 1 * time.Second
+
+client := &http.Client{
+	Transport: transport,
+}
+
+srv := &http.Server{
+	Addr:              ":8080",
+	Handler:           mux,
+	ReadHeaderTimeout: 2 * time.Second,
+	IdleTimeout:       60 * time.Second,
+	BaseContext: func(net.Listener) context.Context {
+		return appCtx
+	},
+}
+```
+
+This is not the only valid policy. It is a safe starting point because it makes ownership explicit:
+
+- one long-lived transport,
+- one long-lived client,
+- explicit server-side read boundaries,
+- request-scoped deadlines layered on top.
+
+## Operating rules
+
+### Reuse clients and transports
+
+Constructing a new `Transport` per request destroys pooling and creates needless dial churn. Treat the transport as a singleton per outbound policy boundary.
+
+### Use per-request context and transport timeouts together
+
+`Client.Timeout` is a blunt whole-exchange cap. It is useful for simple cases, but in larger systems you usually want:
+
+- request context deadlines for business budgets,
+- transport timeouts for specific network edges,
+- server-side read and idle timeouts for inbound defense.
+
+### Response bodies are connection ownership
+
+Closing the body is not just cleanup. It tells the transport whether the connection can be reused.
+
+If you stop early on a response, decide consciously between:
+
+- bounded drain plus reuse, or
+- immediate close and loss of reuse.
+
+Do not accidentally do neither.
+
+### Streaming changes timeout strategy
+
+Server `WriteTimeout` can be the wrong tool for long-lived streaming responses such as SSE or large downloads. Streaming endpoints usually need their own policy rather than generic “cap everything” defaults.
+
+## Failure patterns
+
+### New client in a hot path
+
+```go
+func fetch(url string) (*http.Response, error) {
+	client := &http.Client{Timeout: 2 * time.Second} // bad: new transport policy every call
+	return client.Get(url)
+}
+```
+
+### Hidden default client on a critical dependency
+
+```go
+resp, err := http.Get(url) // bad: no explicit transport budget, proxy policy, or reuse settings
+```
+
+### Forgetting body ownership
+
+```go
+resp, err := client.Do(req)
+if err != nil {
+	return err
+}
+return decode(resp.Body) // bad: body never closed
+```
+
+### One giant timeout knob
+
+```go
+client := &http.Client{Timeout: 30 * time.Second}
+```
+
+This often hides whether you actually need a dial budget, a response-header budget, a handler deadline, or a shutdown contract.
+
+## What to use carefully
+
+- `http.DefaultClient` and `http.DefaultTransport` in library-like code paths
+- `WriteTimeout` on streaming handlers
+- blind `io.Copy(io.Discard, resp.Body)` on huge or attacker-controlled bodies
+- `TimeoutHandler` as a substitute for real context discipline
+
+## Observability and testing
+
+- Use `httptest.Server` to test client timeout edges and body-close discipline.
+- Use `Server.Shutdown` tests to verify in-flight request behavior during deploys.
+- Use `httptrace` when you need proof of reuse versus redial behavior.
+- Expose request duration, status code, inflight count, and outbound dependency latency separately. Mixing them hides transport churn.
+
+## When it is the right tool
+
+`net/http` is the right default for most Go services, control planes, APIs, webhooks, and internal service-to-service calls. The standard library gives you enough control for the vast majority of workloads if you treat its policy boundaries seriously.
+
+## When it is not the right tool
+
+If your problem is a highly specialized L7 proxy, custom wire protocol gateway, or an environment where every extra allocation on the hot path is existential, you may need a narrower or more specialized stack. Even then, you should first prove that the real problem is `net/http` itself and not your own timeout, reuse, or buffering discipline.
+
+## Official reading
+
+- [Package docs for `net/http`](https://pkg.go.dev/net/http)
+- [net/http Server and Transport Internals](/stdlib/net-http-server-transport)
+
+## Practical takeaway
+
+Production `net/http` is mostly an ownership problem.
+
+If you make client reuse, response bodies, and timeout edges explicit, the package is extremely reliable. If you leave those policies implicit, it becomes hard to reason about latency and resource usage.


### PR DESCRIPTION
## Summary
- add a new bilingual `Playbooks` section for `net/http`, `grpc-go`, `go-redis`, and `Kafka with IBM Sarama`
- add a bilingual `Go vs Rust` decision guide with a decision tree and subsystem migration model
- wire the new material into navigation, home pages, extras overview, and README

## Validation
- `go test ./...`
- `npm run docs:build`

Closes #25
