### PR TITLE
Update for golang-handbook rename and add production history docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Expert-level Go concurrency fundamentals, standard library deep dives, practical
 
 ## Where to view it
 
-- GitHub repository: `https://github.com/jaeyoung0509/golang-conccurency-patterns`
-- Expected GitHub Pages site: `https://jaeyoung0509.github.io/golang-conccurency-patterns/`
+- GitHub repository: `https://github.com/jaeyoung0509/golang-handbook`
+- Expected GitHub Pages site: `https://jaeyoung0509.github.io/golang-handbook/`
 - English docs source: `docs/`
 - Korean docs source: `docs/ko/`
 - Runnable examples and tests: `examples/`
@@ -33,7 +33,7 @@ VitePress will print a local preview URL in the terminal, usually `http://localh
 
 - Deployment branch flow: push to `develop`
 - Deployment workflow: `.github/workflows/deploy-docs.yml`
-- GitHub Actions page: `https://github.com/jaeyoung0509/golang-conccurency-patterns/actions`
+- GitHub Actions page: `https://github.com/jaeyoung0509/golang-handbook/actions`
 
 ## Included patterns
 
@@ -103,7 +103,9 @@ VitePress will print a local preview URL in the terminal, usually `http://localh
 ## Included production topics
 
 - Large-scale Go systems: admission control, goroutine ownership, memory budgets, and shutdown policy
+- Temporal and durable execution: history shards, task queues, worker polling, and why this kind of workflow engine fits Go well
 - Open-source case studies from Kubernetes, etcd/raft, Prometheus, NATS, gRPC-Go, CockroachDB, and go-redis
+- Go open-source histories: why Prometheus, NATS, etcd, Kubernetes, CockroachDB, Caddy, and Temporal landed in Go
 
 ## Included testing topics
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -92,7 +92,9 @@ const enSidebar = [
     items: [
       { text: "Overview", link: "/production/" },
       { text: "Large-Scale Go Systems", link: "/production/large-scale-go-systems" },
+      { text: "Temporal and Durable Execution", link: "/production/temporal-durable-execution" },
       { text: "Open-Source Case Studies", link: "/production/open-source-case-studies" },
+      { text: "Go Open-Source Histories", link: "/production/go-open-source-histories" },
     ],
   },
   {
@@ -209,7 +211,9 @@ const koSidebar = [
     items: [
       { text: "개요", link: "/ko/production/" },
       { text: "대규모 Go 시스템", link: "/ko/production/large-scale-go-systems" },
+      { text: "Temporal과 Durable Execution", link: "/ko/production/temporal-durable-execution" },
       { text: "오픈소스 사례", link: "/ko/production/open-source-case-studies" },
+      { text: "Go 오픈소스 역사 읽기", link: "/ko/production/go-open-source-histories" },
     ],
   },
   {
@@ -237,7 +241,7 @@ const koSidebar = [
 export default defineConfig({
   title: "Go Concurrency Patterns",
   description: "Detailed, practical Go concurrency patterns with tests and Mermaid diagrams.",
-  base: "/golang-conccurency-patterns/",
+  base: "/golang-handbook/",
   cleanUrls: true,
   lastUpdated: true,
   head: [

--- a/docs/advanced/actor-pattern.md
+++ b/docs/advanced/actor-pattern.md
@@ -39,7 +39,7 @@ flowchart LR
 
 ## What the implementation is doing
 
-The exported API in [`examples/actor/actor.go`](https://github.com/jaeyoung0509/golang-conccurency-patterns/blob/main/examples/actor/actor.go) hides the event loop behind method calls:
+The exported API in [`examples/actor/actor.go`](https://github.com/jaeyoung0509/golang-handbook/blob/main/examples/actor/actor.go) hides the event loop behind method calls:
 
 ```go
 func (actor *InventoryActor) Reserve(ctx context.Context, orderID string, quantity int) (StockSnapshot, error) {
@@ -85,7 +85,7 @@ That means:
 
 ## What the tests prove
 
-The tests in [`examples/actor/actor_test.go`](https://github.com/jaeyoung0509/golang-conccurency-patterns/blob/main/examples/actor/actor_test.go) verify:
+The tests in [`examples/actor/actor_test.go`](https://github.com/jaeyoung0509/golang-handbook/blob/main/examples/actor/actor_test.go) verify:
 
 - concurrent reservations do not oversell stock,
 - release and restock commands preserve a coherent snapshot,

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -102,6 +102,6 @@ The testing pages answer a sixth: how do you prove the behavior rather than mere
 ## Deployment model
 
 The repository includes a GitHub Pages workflow that builds VitePress on pushes to `develop`.
-The configured base path is `/golang-conccurency-patterns/`, which matches the current repository name.
+The configured base path is `/golang-handbook/`, which matches the current repository name.
 
 If you rename the repository later, update the `base` value in `docs/.vitepress/config.mts`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,7 +46,7 @@ features:
   - title: Advanced production topics
     details: "Structured concurrency, weighted semaphores, singleflight, actors, and load shedding are documented alongside the basics."
   - title: Production operating rules
-    details: "Admission control, queue budgets, lifecycle ownership, and large-system concurrency tradeoffs are documented as first-class topics."
+    details: "Admission control, queue budgets, lifecycle ownership, large-system concurrency tradeoffs, and real open-source history are documented as first-class topics."
   - title: Testing and observability
     details: "Race detection, synctest, real dependency integration tests, leak testing, traces, and contention profiles are treated as first-class concurrency skills."
   - title: English and Korean
@@ -100,7 +100,7 @@ features:
   </div>
   <div class="path-card">
     <h3>8. Production</h3>
-    <p>Study queue budgets, overload policy, goroutine ownership, and open-source concurrency designs from real Go systems.</p>
+    <p>Study queue budgets, overload policy, goroutine ownership, Temporal-style durable execution, and why so many real infrastructure systems ended up in Go.</p>
     <p><a href="/production/">Open production</a></p>
   </div>
   <div class="path-card">
@@ -139,6 +139,8 @@ features:
 | How to keep AI-generated Go code from compiling successfully and still shipping bugs | [AI-Assisted Go Safety](/testing/ai-assisted-go-safety) |
 | How to test timeout-heavy code without real sleeps | [Deterministic Tests with synctest](/testing/synctest) |
 | How to keep Postgres, Redis, and container-backed integration tests clean, isolated, and deterministic | [Integration Testing with Testcontainers](/testing/integration-testcontainers) |
+| How a durable workflow engine like Temporal becomes a Go system of history, matching, and workers | [Temporal and Durable Execution](/production/temporal-durable-execution) |
+| Why so many influential infrastructure projects ended up in Go in the first place | [Go Open-Source Histories](/production/go-open-source-histories) |
 | What large Go production systems care about beyond toy patterns | [Large-Scale Go Systems](/production/large-scale-go-systems) |
 | How major Go projects actually build queues, transport loops, stopper lifetimes, and pools | [Open-Source Case Studies](/production/open-source-case-studies) |
 | How Go differs from Rust Tokio's async runtime model | [Go CSP vs Rust Tokio](/extras/go-csp-vs-rust-tokio) |

--- a/docs/ko/advanced/actor-pattern.md
+++ b/docs/ko/advanced/actor-pattern.md
@@ -39,7 +39,7 @@ flowchart LR
 
 ## 구현의 핵심
 
-[`examples/actor/actor.go`](https://github.com/jaeyoung0509/golang-conccurency-patterns/blob/main/examples/actor/actor.go)의 공개 API는 이벤트 루프를 메서드 뒤에 숨깁니다.
+[`examples/actor/actor.go`](https://github.com/jaeyoung0509/golang-handbook/blob/main/examples/actor/actor.go)의 공개 API는 이벤트 루프를 메서드 뒤에 숨깁니다.
 
 ```go
 func (actor *InventoryActor) Reserve(ctx context.Context, orderID string, quantity int) (StockSnapshot, error) {
@@ -85,7 +85,7 @@ func loop(state *State, mailbox <-chan envelope) {
 
 ## 테스트가 증명하는 것
 
-[`examples/actor/actor_test.go`](https://github.com/jaeyoung0509/golang-conccurency-patterns/blob/main/examples/actor/actor_test.go)는 다음을 검증합니다.
+[`examples/actor/actor_test.go`](https://github.com/jaeyoung0509/golang-handbook/blob/main/examples/actor/actor_test.go)는 다음을 검증합니다.
 
 - 동시 예약이 들어와도 oversell이 발생하지 않는가
 - release와 restock 이후 snapshot이 일관적인가

--- a/docs/ko/guide/getting-started.md
+++ b/docs/ko/guide/getting-started.md
@@ -104,5 +104,5 @@ go test ./...
 
 GitHub Pages 워크플로가 포함되어 있어서 `develop` 브랜치에 push 하면 VitePress 사이트가 빌드됩니다.
 
-현재 `docs/.vitepress/config.mts`의 `base` 값은 저장소 이름에 맞춰 `/golang-conccurency-patterns/`로 설정되어 있습니다.
+현재 `docs/.vitepress/config.mts`의 `base` 값은 저장소 이름에 맞춰 `/golang-handbook/`로 설정되어 있습니다.
 저장소 이름을 바꾸면 이 값도 함께 수정해야 합니다.

--- a/docs/ko/index.md
+++ b/docs/ko/index.md
@@ -46,7 +46,7 @@ features:
   - title: 고급 운영 주제 포함
     details: "구조화된 동시성, 가중 세마포어, singleflight, 액터, 로드 셰딩까지 운영 관점의 주제를 다룹니다."
   - title: 프로덕션 운영 규칙 포함
-    details: "admission control, queue budget, lifetime ownership, 대규모 시스템 동시성 tradeoff를 별도 섹션으로 다룹니다."
+    details: "admission control, queue budget, lifetime ownership, 대규모 시스템 동시성 tradeoff, 그리고 실제 오픈소스 역사까지 별도 섹션으로 다룹니다."
   - title: 테스트와 관측도 포함
     details: "Race detector, synctest, 실제 의존성 통합 테스트, leak test, trace, contention profile을 동시성 역량의 일부로 다룹니다."
   - title: 영어/한국어 지원
@@ -100,7 +100,7 @@ features:
   </div>
   <div class="path-card">
     <h3>8. 프로덕션</h3>
-    <p>queue budget, overload policy, goroutine ownership, 실제 오픈소스의 concurrency 구조를 같이 봅니다.</p>
+    <p>queue budget, overload policy, goroutine ownership, Temporal류 durable execution, 그리고 왜 많은 인프라 시스템이 Go를 택했는지도 같이 봅니다.</p>
     <p><a href="/ko/production/">프로덕션 보기</a></p>
   </div>
   <div class="path-card">
@@ -139,6 +139,8 @@ features:
 | AI가 만든 Go 코드가 컴파일은 되는데 여전히 위험할 때 어떻게 조기 발견하는지 | [AI 보조 Go 안전성](/ko/testing/ai-assisted-go-safety) |
 | timeout-heavy 코드를 실제 sleep 없이 어떻게 테스트하는지 | [synctest로 결정적 테스트](/ko/testing/synctest) |
 | Postgres, Redis, container-backed 통합 테스트를 어떻게 깨끗하고 결정적으로 유지하는지 | [Testcontainers로 통합 테스트하기](/ko/testing/integration-testcontainers) |
+| Temporal 같은 durable workflow 엔진이 history, matching, worker를 가진 Go 시스템으로 어떻게 구성되는지 | [Temporal과 Durable Execution](/ko/production/temporal-durable-execution) |
+| 왜 중요한 인프라 오픈소스들이 하필 Go를 많이 택했는지 | [Go 오픈소스 역사 읽기](/ko/production/go-open-source-histories) |
 | 토이 패턴을 넘어 대규모 Go 운영에서 무엇이 중요한지 | [대규모 Go 시스템](/ko/production/large-scale-go-systems) |
 | 주요 Go 오픈소스가 queue, transport loop, stopper lifetime, pool을 어떻게 구현하는지 | [오픈소스 사례](/ko/production/open-source-case-studies) |
 | Go와 Rust Tokio의 async runtime 모델이 어떻게 다른지 | [Go CSP vs Rust Tokio](/ko/extras/go-csp-vs-rust-tokio) |

--- a/docs/ko/production/go-open-source-histories.md
+++ b/docs/ko/production/go-open-source-histories.md
@@ -1,0 +1,301 @@
+---
+title: Go 오픈소스 역사 읽기
+description: 왜 그렇게 많은 인프라 오픈소스가 Go를 선택했는지, 주요 프로젝트의 공개 시점과 시스템 형태를 통해 읽어봅니다.
+---
+
+# Go 오픈소스 역사 읽기
+
+지금의 Go 생태계만 보면, 중요한 인프라 프로젝트가 많이 Go로 만들어진 게 당연해 보일 수 있습니다.
+
+하지만 그건 당연했던 일이 아니라 "시대와 문제 형태가 맞아떨어진 결과"였습니다.
+
+Go는 정확히 많은 팀이 아래를 원하던 시점에 등장했습니다.
+
+- 네트워크 기반 시스템
+- 더 단순한 배포
+- 적은 런타임 의존성
+- callback-heavy 설계보다 읽기 쉬운 동시성
+- 작은 인프라 팀도 감당 가능한 생산성
+
+이 문서는 production 섹션의 곁다리이자, 재밌게 읽는 역사 파트입니다.
+단순히 "어떻게 동작하는가"가 아니라 "왜 이 시기에 이런 프로젝트들이 Go로 공개되었는가"를 같이 봅니다.
+
+## 날짜에 대한 한 가지 주의점
+
+아래 날짜는 GitHub 공개 저장소 생성 시점을 기준으로 잡았습니다.
+
+이건 공적인 출발 시점을 보기엔 유용하지만, 항상 전체 기원을 뜻하진 않습니다.
+예를 들어 Temporal은 2019년 10월 16일 공개 저장소 기준으로 잡을 수 있지만, README는 Uber Cadence의 fork에서 시작했다고 분명히 말합니다.
+
+## 타임라인
+
+```mermaid
+flowchart LR
+    A["2012-10 NATS Server"] --> B["2012-11 Prometheus"]
+    B --> C["2013-07 etcd"]
+    C --> D["2014-02 CockroachDB"]
+    D --> E["2014-06 Kubernetes"]
+    E --> F["2015-01 Caddy"]
+    F --> G["2019-10 Temporal"]
+```
+
+## 빠른 지도
+
+| 공개 저장소 날짜 | 프로젝트 | 시스템 형태 | Go가 말해주는 것 |
+| --- | --- | --- | --- |
+| 2012-10-29 | NATS Server | 저지연 메시징 서버 | Go는 C++급 ceremony 없이도 진지한 네트워크 데몬을 만들 수 있었다 |
+| 2012-11-24 | Prometheus | 모니터링 시스템 + TSDB | self-contained ops binary와 periodic worker loop에 Go가 강했다 |
+| 2013-07-06 | etcd | 분산 coordination store | consensus-heavy control plane과 service API에 Go가 잘 맞았다 |
+| 2014-02-06 | CockroachDB | 분산 SQL 데이터베이스 | Go는 CLI나 proxy만이 아니라 야심찬 distributed data system도 감당할 수 있었다 |
+| 2014-06-06 | Kubernetes | 클러스터 control plane | Go는 controller, API, reconciliation loop의 언어가 되었다 |
+| 2015-01-13 | Caddy | operator-first 웹 서버 | deployability와 표준 라이브러리 networking의 가치가 컸다 |
+| 2019-10-16 | Temporal | durable execution 플랫폼 | Go는 persistence-backed state machine과 workflow orchestration까지 확장됐다 |
+
+## 왜 이런 파동이 생겼나
+
+이 프로젝트들은 서로 다르지만, 공통 형태가 있습니다.
+
+- 장기 실행 서버 프로세스
+- 많은 I/O
+- background loop가 많음
+- 운영 경계가 중요함
+- build/test/release workflow가 단순해야 함
+- 수동 메모리 최적화보다 팀 생산성이 더 중요함
+
+이 지점에서 Go는 유난히 강했습니다.
+
+## 1기: 운영이 쉬운 네트워크 소프트웨어
+
+### NATS Server
+
+공개 저장소 날짜: 2012년 10월 29일.
+
+NATS는 Go가 단순 스크립팅 대체제가 아니었다는 걸 아주 일찍 보여준 사례입니다.
+
+여기서 보이는 건:
+
+- hot socket path
+- 장기 실행 read/write loop
+- 저지연 메시징 서버
+- 운영하기 쉬운 compact binary
+
+입니다.
+
+읽을 곳:
+
+- [NATS Server repository](https://github.com/nats-io/nats-server)
+- [`server/client.go`의 read/write ownership](https://github.com/nats-io/nats-server/blob/main/server/client.go)
+
+왜 중요했나:
+
+Go가 네트워크 인프라의 "주변"이 아니라 "핵심"에 들어갈 수 있다는 신호였습니다.
+
+### Prometheus
+
+공개 저장소 날짜: 2012년 11월 24일.
+
+Prometheus는 다른 강점을 보여줍니다.
+
+- scrape loop
+- storage ingestion
+- service discovery
+- HTTP API
+- 운영자가 바로 실행할 수 있는 self-contained binary
+
+읽을 곳:
+
+- [Prometheus repository](https://github.com/prometheus/prometheus)
+- [`scrape/scrape.go`](https://github.com/prometheus/prometheus/blob/main/scrape/scrape.go)
+
+왜 중요했나:
+
+"single-binary operational software"를 자연스럽게 만든 프로젝트였습니다.
+이건 Go 문화 전체에 큰 영향을 줬습니다.
+
+## 2기: control plane과 분산 coordination
+
+### etcd
+
+공개 저장소 날짜: 2013년 7월 6일.
+
+etcd는 Go 이야기를 아주 인프라답게 만듭니다.
+
+- distributed coordination store
+- Raft
+- API
+- watch stream
+- maximal feature complexity보다 operational safety 우선
+
+읽을 곳:
+
+- [etcd repository](https://github.com/etcd-io/etcd)
+- [raft `node.go`](https://github.com/etcd-io/raft/blob/main/node.go)
+
+왜 중요했나:
+
+Go가 correctness와 networked coordination이 핵심인 control-plane 언어라는 인식을 굳히는 데 큰 역할을 했습니다.
+
+### Kubernetes
+
+공개 저장소 날짜: 2014년 6월 6일.
+
+Kubernetes는 Go adoption wave를 생태계 수준으로 키운 프로젝트입니다.
+
+그 핵심 모양은 사실 Go의 강점 선언문에 가깝습니다.
+
+- API
+- controller
+- reconciliation loop
+- work queue
+- shared informer
+- CLI + server tooling
+- 대규모 contributor base
+
+읽을 곳:
+
+- [Kubernetes repository](https://github.com/kubernetes/kubernetes)
+- [`client-go/util/workqueue`](https://github.com/kubernetes/client-go/tree/master/util/workqueue)
+
+왜 중요했나:
+
+cloud-native control plane이 Go 모양을 띠게 되면서, 주변 프로젝트들도 같은 방향으로 따라가기 쉬워졌습니다.
+
+## 3기: 더 야심찬 데이터 시스템
+
+### CockroachDB
+
+공개 저장소 날짜: 2014년 2월 6일.
+
+CockroachDB는 Go에 대한 너무 좁은 이야기를 깨는 프로젝트입니다.
+
+Go는 단지:
+
+- CLI
+- proxy
+- orchestration layer
+
+만을 위한 언어가 아니라,
+
+- consensus
+- task lifetime
+- admission control
+- quiesce / shutdown contract
+- 큰 내부 동시성 표면
+
+을 가진 분산 SQL DB도 담을 수 있다는 걸 보여줍니다.
+
+읽을 곳:
+
+- [CockroachDB repository](https://github.com/cockroachdb/cockroach)
+- [`pkg/util/stop/stopper.go`](https://github.com/cockroachdb/cockroach/blob/master/pkg/util/stop/stopper.go)
+
+왜 중요했나:
+
+Go를 "운영 툴 언어"에서 "진지한 distributed system 구현 언어"로 올려서 보게 만든 사례 중 하나입니다.
+
+## 4기: operator-first 서버
+
+### Caddy
+
+공개 저장소 날짜: 2015년 1월 13일.
+
+Caddy는 Go의 성장이 클러스터와 consensus에만 있지 않았다는 걸 보여줍니다.
+이건 제품 형태의 이야기이기도 했습니다.
+
+Caddy는 웹 서버가 다음일 수 있음을 강하게 보여줬습니다.
+
+- one binary
+- 쉬운 설정
+- 쉬운 확장
+- default가 운영 친화적
+
+읽을 곳:
+
+- [Caddy repository](https://github.com/caddyserver/caddy)
+- [`caddy.go`](https://github.com/caddyserver/caddy/blob/master/caddy.go)
+
+왜 중요했나:
+
+Go의 표준 라이브러리와 바이너리 모델은 운영자가 직접 배포해야 하는 인프라 소프트웨어와 궁합이 좋았습니다.
+
+## 5기: durable orchestration과 workflow 엔진
+
+### Temporal
+
+공개 저장소 날짜: 2019년 10월 16일.
+
+Temporal은 더 새롭고 더 흥미로운 파동입니다.
+
+README는 이 프로젝트가 Uber Cadence의 fork에서 시작했다고 설명합니다.
+이 시스템은 단순한 API 서버가 아니라:
+
+- workflow history
+- matching / task queue
+- worker polling
+- event sourcing
+- deterministic replay
+
+를 중심으로 돌아가는 durable execution 플랫폼입니다.
+
+읽을 곳:
+
+- [Temporal repository](https://github.com/temporalio/temporal)
+- [Temporal architecture docs](https://github.com/temporalio/temporal/blob/main/docs/architecture/README.md)
+- [Temporal과 Durable Execution](/ko/production/temporal-durable-execution)
+
+왜 중요했나:
+
+"Go 인프라" 이야기가 orchestration이나 monitoring에서 끝난 게 아니라 durable workflow control plane까지 확장됐음을 보여줍니다.
+
+## 이 프로젝트들이 공통으로 보여주는 것
+
+이 프로젝트들은 서로 다르지만 같은 engineering sweet spot에 모입니다.
+
+- API와 네트워크 서비스
+- background work loop
+- 강한 운영 ergonomics
+- explicit하게 유지해야 하는 concurrency
+- 언어 묘기보다 읽기 쉬운 시스템을 원하는 팀
+
+그래서 "Go가 인프라에서 인기 있다"는 말은 너무 넓습니다.
+더 정확히 말하면:
+
+Go는 coordination, lifecycle, throughput, operability가 핵심인 시스템에 유난히 잘 맞았습니다.
+
+## 시스템 형태별 읽기 지도
+
+| 이런 시스템이 궁금하면 | 여기부터 |
+| --- | --- |
+| control plane과 reconciler loop | Kubernetes, etcd |
+| messaging과 hot socket ownership | NATS Server |
+| periodic work와 scrape ownership | Prometheus |
+| 대규모 task lifetime과 shutdown | CockroachDB |
+| deployable operator-first edge/server software | Caddy |
+| durable workflow orchestration | Temporal |
+
+## 다음으로 읽을 곳
+
+- 실제 concurrency boundary를 더 깊게 보려면 [오픈소스 사례](/ko/production/open-source-case-studies)를 읽습니다.
+- 현대 workflow engine 한 개를 깊게 보려면 [Temporal과 Durable Execution](/ko/production/temporal-durable-execution)을 읽습니다.
+- 프로젝트 역사보다 운영 규칙이 궁금하면 [대규모 Go 시스템](/ko/production/large-scale-go-systems)을 읽습니다.
+
+## 공식 프로젝트 소스
+
+- [Temporal repository metadata](https://github.com/temporalio/temporal)
+- [CockroachDB repository metadata](https://github.com/cockroachdb/cockroach)
+- [Kubernetes repository metadata](https://github.com/kubernetes/kubernetes)
+- [etcd repository metadata](https://github.com/etcd-io/etcd)
+- [Prometheus repository metadata](https://github.com/prometheus/prometheus)
+- [NATS Server repository metadata](https://github.com/nats-io/nats-server)
+- [Caddy repository metadata](https://github.com/caddyserver/caddy)
+
+## Practical takeaway
+
+이 역사는 "Go가 이겼다"가 아닙니다.
+
+대신 2012년 이후 많은 오픈소스 팀이 아래 문제군에서 Go가 유난히 강하다고 느꼈다는 뜻입니다.
+
+- distributed control plane
+- operator-run binary
+- network service
+- manual memory control보다 coordination과 lifecycle이 더 어려운 concurrency-heavy system

--- a/docs/ko/production/index.md
+++ b/docs/ko/production/index.md
@@ -14,7 +14,9 @@ description: Go 코드가 실제 대규모 트래픽을 받을 때 중요해지�
 | 주제 | 왜 중요한가 |
 | --- | --- |
 | [대규모 Go 시스템](/ko/production/large-scale-go-systems) | 런타임 지식을 실제 latency, memory, overload, shutdown 규칙으로 바꿉니다 |
+| [Temporal과 Durable Execution](/ko/production/temporal-durable-execution) | 현대 workflow 엔진이 history shard, task queue, worker polling을 가진 Go 시스템으로 어떻게 구성되는지 보여줍니다 |
 | [오픈소스 사례](/ko/production/open-source-case-studies) | Kubernetes, etcd, Prometheus, NATS, gRPC-Go, CockroachDB, go-redis가 concurrency policy를 어떻게 코드에 드러내는지 봅니다 |
+| [Go 오픈소스 역사 읽기](/ko/production/go-open-source-histories) | 왜 Go가 인프라 소프트웨어에 강했는지, 주요 프로젝트의 공개 시점과 형태를 통해 읽습니다 |
 
 ## 프로덕션에서 질문이 달라진다
 

--- a/docs/ko/production/open-source-case-studies.md
+++ b/docs/ko/production/open-source-case-studies.md
@@ -9,6 +9,9 @@ description: 대표적인 Go 오픈소스가 실제로 concurrency를 어떻게 
 
 이 문서는 프로젝트 소개 모음이 아니라, 실제로 훔쳐올 만한 concurrency boundary를 읽는 가이드입니다.
 
+왜 이런 프로젝트들이 많이 Go로 왔는지 더 넓은 역사 맥락이 궁금하면 [Go 오픈소스 역사 읽기](/ko/production/go-open-source-histories)를 읽으면 됩니다.
+현대 durable execution 시스템 하나를 깊게 보고 싶으면 [Temporal과 Durable Execution](/ko/production/temporal-durable-execution)을 같이 보면 됩니다.
+
 ## 빠른 지도
 
 | 프로젝트 | 핵심 교훈 | 주 소스 |

--- a/docs/ko/production/temporal-durable-execution.md
+++ b/docs/ko/production/temporal-durable-execution.md
@@ -1,0 +1,318 @@
+---
+title: Temporal과 Durable Execution
+description: Temporal이 event sourcing, task queue, 여러 Go 서비스로 durable execution 엔진을 어떻게 구성하는지 설명합니다.
+---
+
+# Temporal과 Durable Execution
+
+Temporal은 "Go로 아주 큰 시스템을 어디까지 만들 수 있는가?"라는 질문에 대한 가장 현대적인 답 중 하나입니다.
+
+이건 단순 queue도 아니고, 단순 workflow DSL도 아니고, 단순 retry 엔진도 아닙니다.
+
+Temporal은 아래를 조합한 durable execution 시스템입니다.
+
+- gRPC 서비스들
+- history shard
+- task queue
+- worker polling
+- deterministic workflow replay
+- persistence-backed event log
+
+여기서 중요한 교훈은 "Go는 고루틴을 30일 재울 수 있다"가 아닙니다.
+
+진짜 교훈은:
+
+Go는 상태 기계, RPC, queue processor, background work를 ownership boundary와 함께 조정하는 장기 실행 control-plane 서비스를 만들기에 아주 잘 맞는다는 점입니다.
+
+## Temporal이 스스로 요구하는 시스템 조건
+
+Temporal 공식 아키텍처 문서는 핵심 요구사항을 이렇게 설명합니다.
+
+- workflow는 지원되는 SDK 언어의 코드로 정의되고
+- durable execution은 transient failure를 견뎌야 하며
+- 시스템은 arbitrarily many concurrent workflow execution으로 확장 가능해야 하고
+- 사용자 코드는 core server 안이 아니라 user-owned worker process에서 실행됩니다.
+
+이 조건 조합은 자연스럽게 boundary가 분명한 multi-service Go 시스템으로 이어집니다.
+
+## 전체 구조
+
+```mermaid
+flowchart LR
+    A["앱 / SDK client"] --> B["Frontend Service"]
+    B --> C["History Service"]
+    C --> D["Persistence"]
+    C --> E["Matching Service"]
+    E --> F["Worker poller"]
+    F --> B
+    F --> C
+    G["Internal Workers Service"] --> C
+```
+
+이 그림만 봐도 Go가 왜 잘 맞는지 감이 옵니다.
+
+- 장기 실행 RPC 서비스가 많고
+- concurrent request handling이 많고
+- background queue processor가 분명하고
+- 거대한 별도 런타임 모델 없이 practical server binary로 배포하기 좋기 때문입니다.
+
+## 왜 Go가 이 문제에 맞는가
+
+Temporal이 Go로 가능하다고 해서 Go가 마법이라는 뜻은 아닙니다.
+문제의 형태가 Go의 강점과 잘 맞는다는 뜻입니다.
+
+### 1. 여러 네트워크 서비스, 하나의 코드베이스
+
+Temporal server 저장소는 분명한 서비스 축을 드러냅니다.
+
+- `frontend`
+- `history`
+- `matching`
+- `worker`
+
+이건 전형적인 Go의 지형입니다.
+
+- protobuf + gRPC 통합
+- 단순한 서비스 바이너리
+- 분명한 패키지 경계
+- 언어 차원의 async state machine 대신 goroutine, context, queue, lock으로 표현되는 동시성
+
+### 2. ownership이 분명한 background processor
+
+Temporal 안에는 다음 종류의 loop가 매우 많습니다.
+
+- poll
+- state append
+- follow-up work enqueue
+- queue progress checkpoint
+- ack / retry
+
+Go는 hot loop를 하나의 goroutine 또는 하나의 컴포넌트가 소유하고, 나머지 시스템이 explicit API나 queue로 말 거는 구조에 매우 강합니다.
+
+### 3. 운영 단순성이 중요하다
+
+Temporal은 인프라 소프트웨어입니다. 클러스터로 운영됩니다.
+
+즉 build/deploy ergonomics가 중요합니다.
+
+- static binary
+- 예측 가능한 toolchain
+- 직접 profiling / tracing 하기 쉬움
+- 표준 라이브러리의 networking / TLS
+- 컨테이너 패키징 단순성
+
+### 4. 진짜 어려운 건 coordination이다
+
+Temporal의 어려움은 수동 메모리 최적화가 아닙니다.
+어려운 건:
+
+- correctness boundary
+- persistence ordering
+- replay semantics
+- queue ownership
+- sharding
+- backpressure
+
+입니다.
+
+이건 Go가 역사적으로 가장 생산적이었던 문제군과 정확히 겹칩니다.
+
+## 핵심: durable execution은 "goroutine + timer"가 아니다
+
+workflow가 프로세스 crash, 머신 재시작, worker 교체를 견뎌야 한다면 그 workflow는 서버 메모리에만 살아 있으면 안 됩니다.
+
+Temporal의 아키텍처 문서는 이를 아주 분명하게 말합니다.
+
+- workflow history는 append-only이고
+- mutable state는 persisted 되고
+- worker는 task를 poll하고
+- workflow 코드는 history에서 deterministic하게 replay 됩니다.
+
+즉 Temporal 같은 시스템이 Go로 가능한 이유는 런타임이 durable해서가 아니라,
+durability boundary를 persistence와 history replay에 두기 때문입니다.
+
+## 진짜 correctness core는 History Service다
+
+Temporal의 History Service는 하나의 workflow execution에 연결된 요청을 받아서 다음으로 바꿉니다.
+
+- 새 history event
+- mutable-state update
+- future work를 위한 transfer task
+- delayed work를 위한 timer task
+
+공식 History Service 문서는 이 서비스가:
+
+- workflow history를 소유하고
+- history shard로 분할하고
+- queue progress를 persisted 하고
+- queue processor를 통해 후속 작업을 dispatch 한다고 설명합니다.
+
+### 단순화한 멘탈 모델
+
+```go
+func handleWorkerCompletion(req Completion) {
+	state := loadMutableState(req.WorkflowKey)
+
+	events, commands := applyDeterministicTransition(state, req)
+	appendHistory(events)
+	persistMutableState(state)
+
+	for _, cmd := range commands {
+		switch cmd.Kind {
+		case ScheduleActivity:
+			enqueueTransferTask(cmd)
+		case StartTimer:
+			enqueueTimerTask(cmd)
+		case ContinueWorkflow:
+			enqueueTransferTask(cmd)
+		}
+	}
+}
+```
+
+실제 코드는 훨씬 복잡하지만, 중요한 형태는 맞습니다.
+
+- 먼저 상태 전이
+- 먼저 durable record
+- 그 다음 dispatch 가능한 follow-up work
+
+이건 앞에서 본 `etcd/raft`의 `Ready` / `Advance`와도 닮아 있습니다.
+통신 경계가 correctness boundary인 경우가 많다는 뜻입니다.
+
+## History shard가 이 설계를 어떻게 스케일시키는가
+
+Temporal은 모든 workflow execution 상태를 하나의 global lock이나 하나의 global loop 뒤에 두지 않습니다.
+
+대신 history를 shard로 분할합니다.
+각 shard owner는:
+
+- 요청 처리
+- 내부 queue
+- checkpoint
+- task execution plumbing
+
+을 가집니다.
+
+이 구조는 Go와 잘 맞습니다. 고루틴, queue processor, RPC handler를 많이 돌리더라도 전체 코드가 async/await 중심의 다른 프로그래밍 모델로 밀려나지 않기 때문입니다.
+
+## Matching Service는 throughput shock absorber다
+
+Matching Service는 worker가 poll하는 task queue를 소유합니다.
+이 서비스의 역할은 workflow correctness를 결정하는 게 아니라, delivery와 throughput을 다루는 것입니다.
+
+공식 문서가 강조하는 축은 이렇습니다.
+
+- task queue
+- long polling
+- partition을 통한 throughput 확장
+- 비어 있는 partition이나 poller가 없는 partition을 parent로 forward 하는 메커니즘
+
+### 단순화한 멘탈 모델
+
+```go
+func pollTask(queue Partition) Task {
+	for {
+		if task := queue.LocalBacklog.Pop(); task != nil {
+			return task
+		}
+
+		if task := queue.ParentForwarder.TryPoll(); task != nil {
+			return task
+		}
+
+		queue.WaitForTaskOrPoller()
+	}
+}
+```
+
+여기서 유용한 핵심은 간단합니다.
+
+- History는 무엇을 해야 하는지를 결정하고
+- Matching은 그 task를 worker에게 어떻게 전달할지를 결정합니다.
+
+이 분리가 있어야 core state machine이 transport mechanics와 뒤섞이지 않습니다.
+
+## Frontend와 worker 경계도 중요하다
+
+Frontend는 RPC edge입니다.
+Worker는 core server 밖에서 workflow / activity task를 poll합니다.
+
+이 분리는 Temporal이 durable하면서도 language-agnostic할 수 있는 핵심 이유 중 하나입니다.
+
+- server는 history와 task routing을 소유하고
+- 사용자 코드는 SDK worker에서 실행되고
+- 시스템 경계는 explicit한 gRPC boundary가 됩니다.
+
+이건 아주 Go다운 분해 방식입니다.
+
+- boring service boundary
+- explicit process ownership
+- 분명한 responsibility split
+
+이건 약점이 아니라, 시스템이 이해 가능하게 유지되는 이유입니다.
+
+## 더 작은 시스템을 만들 때 가져갈 것
+
+대부분의 팀은 Temporal 자체를 만들 필요는 없습니다.
+하지만 Temporal의 설계 감각은 가져올 가치가 있습니다.
+
+### correctness state와 throughput plumbing을 분리하라
+
+다음을 분리하세요.
+
+- state transition engine
+- persistence boundary
+- dispatch queue
+
+### durable follow-up work를 명시하라
+
+요청이 future work를 의미한다면, 그걸 fire-and-forget goroutine에 숨기지 말고 real task와 real lifecycle로 만들세요.
+
+### 모든 걸 중앙집중시키지 말고 shard ownership으로 풀어라
+
+workload가 본질적으로 많은 독립 key나 workflow라면, shard별 책임과 수명을 분명히 두는 편이 낫습니다.
+
+### user code를 control plane 안에 넣지 마라
+
+Temporal은 workflow/activity 실행을 worker process에 둡니다.
+이건 safety와 operability 측면에서 아주 강한 경계입니다.
+
+## 피해야 할 실패 패턴
+
+### "workflow state는 메모리에만 두면 되지"
+
+그건 durable execution이 아니라 in-memory orchestrator입니다.
+
+### "모든 poller가 workflow state를 직접 바꾸면 되지"
+
+이건 state ownership 경계를 깨뜨립니다.
+
+### "잠든 goroutine은 persisted timer와 같다"
+
+같지 않습니다. 프로세스 crash가 나면 전자는 사라지고 후자는 남습니다.
+
+### "queue와 state machine을 한 덩어리로 둬도 된다"
+
+Temporal을 읽을 가치가 있는 이유는 정확히 이 경계를 분리하기 때문입니다.
+
+## 소스 맵
+
+- [Temporal server README](https://github.com/temporalio/temporal/blob/main/README.md)
+- [Temporal architecture overview](https://github.com/temporalio/temporal/blob/main/docs/architecture/README.md)
+- [History Service architecture](https://github.com/temporalio/temporal/blob/main/docs/architecture/history-service.md)
+- [Matching Service architecture](https://github.com/temporalio/temporal/blob/main/docs/architecture/matching-service.md)
+- [Frontend service code](https://github.com/temporalio/temporal/tree/main/service/frontend)
+- [History service code](https://github.com/temporalio/temporal/tree/main/service/history)
+- [Matching service code](https://github.com/temporalio/temporal/tree/main/service/matching)
+- [Worker service code](https://github.com/temporalio/temporal/tree/main/service/worker)
+
+## Practical takeaway
+
+Temporal은 Go가 진짜 잘하는 시스템의 예시입니다.
+
+- distributed control plane
+- stateful orchestrator
+- task-queue 기반 시스템
+- raw low-level memory control보다 correctness, scale, operability가 더 어려운 multi-service backend
+
+그래서 이 정도로 야심찬 시스템도 여전히 아주 "Go답게" 보입니다.

--- a/docs/production/go-open-source-histories.md
+++ b/docs/production/go-open-source-histories.md
@@ -1,0 +1,297 @@
+---
+title: Go Open-Source Histories
+description: Learn why so many influential infrastructure projects adopted Go and what each one says about the language.
+---
+
+# Go Open-Source Histories
+
+If you only look at today's Go ecosystem, it can feel inevitable that so many cloud and infrastructure projects ended up in Go.
+
+It was not inevitable.
+
+It was a historical fit.
+
+Go arrived at exactly the moment when many teams wanted:
+
+- networked systems,
+- simpler deployment,
+- fewer runtime dependencies,
+- concurrency that was easier to reason about than callback-heavy designs,
+- and a language productive enough for small infrastructure teams.
+
+This page is the "fun side quest" version of the production section: not just how these systems work, but what their timelines say about why Go spread so hard through open infrastructure.
+
+## One important note about dates
+
+The dates below use public GitHub repository creation dates as a concrete proxy for when each project became public.
+
+That is useful, but it is not always the full origin story.
+Temporal, for example, publicly appeared on October 16, 2019, but its README explicitly says it originated as a fork of Uber Cadence.
+
+## Timeline
+
+```mermaid
+flowchart LR
+    A["2012-10 NATS Server"] --> B["2012-11 Prometheus"]
+    B --> C["2013-07 etcd"]
+    C --> D["2014-02 CockroachDB"]
+    D --> E["2014-06 Kubernetes"]
+    E --> F["2015-01 Caddy"]
+    F --> G["2019-10 Temporal"]
+```
+
+## Quick map
+
+| Public repo date | Project | System shape | What it says about Go |
+| --- | --- | --- | --- |
+| 2012-10-29 | NATS Server | low-latency messaging server | Go could build serious network daemons without C++-level ceremony |
+| 2012-11-24 | Prometheus | monitoring system + TSDB | Go was a strong fit for self-contained ops binaries and periodic worker loops |
+| 2013-07-06 | etcd | distributed coordination store | Go fit consensus-heavy control planes and service APIs well |
+| 2014-02-06 | CockroachDB | distributed SQL database | Go was not only for CLIs and proxies; it could host ambitious distributed data systems |
+| 2014-06-06 | Kubernetes | cluster control plane | Go became the language of controllers, APIs, and reconciliation loops |
+| 2015-01-13 | Caddy | operations-first web server | deployability and standard-library networking mattered a lot |
+| 2019-10-16 | Temporal | durable execution platform | Go could also host workflow orchestration and persistence-backed state machines |
+
+## Why this wave happened
+
+These projects are different, but they share a shape:
+
+- long-lived server processes,
+- lots of I/O,
+- many background loops,
+- clear operational boundaries,
+- a need for easy build/test/release workflows,
+- and a bigger premium on team productivity than on hand-managed memory tricks.
+
+That is where Go was unusually strong.
+
+## Era 1: operationally simple network software
+
+### NATS Server
+
+Public repo date: October 29, 2012.
+
+NATS is a great early signal that Go was never just a scripting replacement.
+It showed that Go could build:
+
+- hot socket paths,
+- long-lived read/write loops,
+- low-latency messaging servers,
+- operationally compact binaries.
+
+What to read:
+
+- [NATS Server repository](https://github.com/nats-io/nats-server)
+- [client read/write loop ownership in `server/client.go`](https://github.com/nats-io/nats-server/blob/main/server/client.go)
+
+Why it mattered:
+
+This was evidence that Go could be credible in the core of network infrastructure, not only around it.
+
+### Prometheus
+
+Public repo date: November 24, 2012.
+
+Prometheus showed a different strength:
+
+- scrape loops,
+- storage ingestion,
+- service discovery,
+- HTTP APIs,
+- one self-contained binary that operators could run easily.
+
+What to read:
+
+- [Prometheus repository](https://github.com/prometheus/prometheus)
+- [`scrape/scrape.go`](https://github.com/prometheus/prometheus/blob/main/scrape/scrape.go)
+
+Why it mattered:
+
+Prometheus made "single-binary operational software" feel normal.
+That was a huge cultural win for Go.
+
+## Era 2: control planes and distributed coordination
+
+### etcd
+
+Public repo date: July 6, 2013.
+
+etcd is where the Go story becomes very infrastructure-shaped:
+
+- a distributed coordination store,
+- Raft,
+- APIs,
+- watch streams,
+- operational safety over maximal feature complexity.
+
+What to read:
+
+- [etcd repository](https://github.com/etcd-io/etcd)
+- [raft `node.go`](https://github.com/etcd-io/raft/blob/main/node.go)
+
+Why it mattered:
+
+It helped establish Go as a control-plane language, especially for systems that need correctness and networked coordination more than raw embedded-database style tight loops.
+
+### Kubernetes
+
+Public repo date: June 6, 2014.
+
+Kubernetes turned the Go adoption wave into an ecosystem.
+
+Its core shape is almost a manifesto for Go's strengths:
+
+- APIs,
+- controllers,
+- reconciliation loops,
+- work queues,
+- shared informers,
+- CLI + server tooling,
+- large contributor base.
+
+What to read:
+
+- [Kubernetes repository](https://github.com/kubernetes/kubernetes)
+- [`client-go/util/workqueue`](https://github.com/kubernetes/client-go/tree/master/util/workqueue)
+
+Why it mattered:
+
+Once the cloud-native control plane became a Go-shaped system, a huge number of adjacent projects followed that shape.
+
+## Era 3: ambitious data systems
+
+### CockroachDB
+
+Public repo date: February 6, 2014.
+
+CockroachDB is important because it breaks an overly narrow story about Go.
+
+It showed that Go was not only for:
+
+- CLIs,
+- proxies,
+- and orchestration layers.
+
+It could also host a very ambitious distributed SQL database with:
+
+- consensus,
+- task lifecycles,
+- admission control,
+- quiesce/shutdown contracts,
+- large internal concurrency surfaces.
+
+What to read:
+
+- [CockroachDB repository](https://github.com/cockroachdb/cockroach)
+- [`pkg/util/stop/stopper.go`](https://github.com/cockroachdb/cockroach/blob/master/pkg/util/stop/stopper.go)
+
+Why it mattered:
+
+It pushed the industry view of Go upward from "operational tooling language" toward "serious distributed system implementation language."
+
+## Era 4: operator-first servers
+
+### Caddy
+
+Public repo date: January 13, 2015.
+
+Caddy is a reminder that Go's rise was not only about clusters and consensus.
+It was also about product shape.
+
+Caddy made a strong case that a web server could be:
+
+- one binary,
+- easy to configure,
+- easy to extend,
+- and operationally friendly by default.
+
+What to read:
+
+- [Caddy repository](https://github.com/caddyserver/caddy)
+- [`caddy.go`](https://github.com/caddyserver/caddy/blob/master/caddy.go)
+
+Why it mattered:
+
+Go's standard library and binary model made it a natural fit for infrastructure software that people actually had to deploy themselves.
+
+## Era 5: durable orchestration and workflow engines
+
+### Temporal
+
+Public repo date: October 16, 2019.
+
+Temporal is a newer, more interesting wave.
+
+Its README says it originated as a fork of Uber Cadence.
+The system is not simply another API server.
+It is a durable execution platform built around:
+
+- workflow histories,
+- matching/task queues,
+- worker polling,
+- event sourcing,
+- and deterministic replay.
+
+What to read:
+
+- [Temporal repository](https://github.com/temporalio/temporal)
+- [Temporal architecture docs](https://github.com/temporalio/temporal/blob/main/docs/architecture/README.md)
+- [Temporal and Durable Execution](/production/temporal-durable-execution)
+
+Why it mattered:
+
+Temporal shows that the "Go infrastructure" story did not stop at orchestration or monitoring.
+It extended into durable workflow control planes as well.
+
+## What all of these projects have in common
+
+They are not identical, but they cluster around the same engineering sweet spot:
+
+- APIs and network services,
+- background work loops,
+- strong operational ergonomics,
+- concurrency that should stay explicit,
+- teams that want readable systems more than language pyrotechnics.
+
+This is why "Go became popular in infra" is too vague.
+More precisely:
+
+Go became unusually good for systems whose hardest problems are coordination, lifecycle, throughput, and operability.
+
+## Reading map by system shape
+
+| If you care about... | Read... |
+| --- | --- |
+| control planes and reconciler loops | Kubernetes, etcd |
+| messaging and hot socket ownership | NATS Server |
+| periodic work and scrape ownership | Prometheus |
+| large-system task lifetime and shutdown | CockroachDB |
+| deployable operator-first edge/server software | Caddy |
+| durable workflow orchestration | Temporal |
+
+## Where to go next
+
+- Read [Open-Source Case Studies](/production/open-source-case-studies) for deeper concurrency boundaries in source code.
+- Read [Temporal and Durable Execution](/production/temporal-durable-execution) for a modern workflow-engine example.
+- Read [Large-Scale Go Systems](/production/large-scale-go-systems) when you want operating rules rather than project history.
+
+## Official project sources
+
+- [Temporal repository metadata](https://github.com/temporalio/temporal)
+- [CockroachDB repository metadata](https://github.com/cockroachdb/cockroach)
+- [Kubernetes repository metadata](https://github.com/kubernetes/kubernetes)
+- [etcd repository metadata](https://github.com/etcd-io/etcd)
+- [Prometheus repository metadata](https://github.com/prometheus/prometheus)
+- [NATS Server repository metadata](https://github.com/nats-io/nats-server)
+- [Caddy repository metadata](https://github.com/caddyserver/caddy)
+
+## Practical takeaway
+
+The history is not "Go won."
+
+The history is that, from roughly 2012 onward, many open-source teams found that Go was an unusually strong tool for:
+
+- distributed control planes,
+- operator-run binaries,
+- network services,
+- and concurrency-heavy systems whose hardest problems were coordination and lifecycle, not manual memory control.

--- a/docs/production/index.md
+++ b/docs/production/index.md
@@ -14,7 +14,9 @@ This section is about what changes when the code is no longer a neat example and
 | Topic | Why it matters |
 | --- | --- |
 | [Large-Scale Go Systems](/production/large-scale-go-systems) | Turns runtime knowledge into operating rules for latency, memory, shutdown, and overload |
+| [Temporal and Durable Execution](/production/temporal-durable-execution) | Shows how a modern workflow engine becomes a Go system of history shards, task queues, and worker polling |
 | [Open-Source Case Studies](/production/open-source-case-studies) | Shows how Kubernetes, etcd, Prometheus, NATS, gRPC-Go, CockroachDB, and go-redis make concurrency policy visible in real source code |
+| [Go Open-Source Histories](/production/go-open-source-histories) | Explains why Go became such a strong fit for infrastructure software and where to read the story in major projects |
 
 ## The production shift
 

--- a/docs/production/open-source-case-studies.md
+++ b/docs/production/open-source-case-studies.md
@@ -9,6 +9,9 @@ The fastest way to sharpen your concurrency taste is to read real Go systems tha
 
 This page is not a project summary catalog. It is a source-reading guide focused on the concurrency boundaries that are actually worth stealing.
 
+If you want the broader "why did so many of these projects end up in Go?" story, read [Go Open-Source Histories](/production/go-open-source-histories).
+If you want one modern durable-execution system in detail, read [Temporal and Durable Execution](/production/temporal-durable-execution).
+
 ## Quick map
 
 | Project | Main lesson | Primary source |

--- a/docs/production/temporal-durable-execution.md
+++ b/docs/production/temporal-durable-execution.md
@@ -1,0 +1,317 @@
+---
+title: Temporal and Durable Execution
+description: Learn how Temporal turns event sourcing, task queues, and Go services into a durable execution engine.
+---
+
+# Temporal and Durable Execution
+
+Temporal is one of the clearest modern answers to the question:
+
+"What kind of very large system can Go build well?"
+
+It is not just a queue, not just a workflow DSL, and not just a retry engine.
+It is a durable execution system built from:
+
+- gRPC services,
+- history shards,
+- task queues,
+- worker polling,
+- deterministic workflow replay,
+- and a persistence-backed event log.
+
+The important lesson is not "Go can sleep a goroutine for 30 days."
+
+The real lesson is:
+
+Go is very good at building long-lived control-plane services that coordinate state machines, RPCs, queue processors, and background work with explicit ownership boundaries.
+
+## What Temporal says its system must do
+
+Temporal's own architecture docs describe four core requirements:
+
+- workflows are defined as code in supported SDK languages,
+- durable execution must survive transient failures,
+- the system must scale to arbitrarily many concurrent workflow executions,
+- user code runs in user-owned worker processes, not inside the core server.
+
+That set of constraints naturally leads to a multi-service Go system with strict boundaries.
+
+## High-level shape
+
+```mermaid
+flowchart LR
+    A["App / SDK client"] --> B["Frontend Service"]
+    B --> C["History Service"]
+    C --> D["Persistence"]
+    C --> E["Matching Service"]
+    E --> F["Worker pollers"]
+    F --> B
+    F --> C
+    G["Internal Workers Service"] --> C
+```
+
+This is already a strong hint about why Go fits:
+
+- many long-lived RPC services,
+- lots of concurrent request handling,
+- explicit background queue processors,
+- deployment as practical server binaries rather than a huge runtime stack.
+
+## Why Go is a fit here
+
+Temporal does not work because Go is magical. It works because the problem shape matches what Go is strong at.
+
+### 1. Many networked services, one codebase
+
+The Temporal server repository exposes distinct services such as:
+
+- `frontend`
+- `history`
+- `matching`
+- `worker`
+
+That is classic Go terrain:
+
+- protobuf + gRPC integration,
+- straightforward service binaries,
+- clear package boundaries,
+- concurrency expressed with goroutines, contexts, queues, and locks rather than language-level async state machines.
+
+### 2. Background processors with explicit ownership
+
+Temporal is full of loops that:
+
+- poll,
+- append state,
+- enqueue follow-up work,
+- checkpoint queue progress,
+- acknowledge or retry tasks.
+
+Go is excellent when one goroutine or one component clearly owns a hot loop and the rest of the system talks to it through explicit APIs or queues.
+
+### 3. Operational simplicity matters
+
+Temporal is infrastructure software. People run it as a cluster.
+
+That means build and deployment ergonomics matter:
+
+- static binaries,
+- predictable toolchain,
+- direct profiling and tracing support,
+- standard library networking and TLS,
+- straightforward container packaging.
+
+### 4. The hard part is coordination, not SIMD
+
+Temporal is not primarily a handwritten-memory-layout system.
+Its hard problems are:
+
+- correctness boundaries,
+- persistence ordering,
+- replay semantics,
+- queue ownership,
+- sharding,
+- and backpressure.
+
+That is exactly the class of problem where Go has historically been very productive.
+
+## The key idea: durable execution is not "goroutines with timers"
+
+If a workflow must survive process crashes, machine restarts, and worker replacement, the workflow cannot simply live in server memory.
+
+Temporal's architecture docs make that explicit:
+
+- workflow history is append-only,
+- mutable state is persisted,
+- workers poll for tasks,
+- workflow code is replayed deterministically from history.
+
+This is why a system like Temporal can be written in Go without pretending the runtime itself is durable.
+
+The durability boundary lives in persistence plus history replay, not in goroutine suspension.
+
+## The History Service is the real correctness core
+
+Temporal's History Service handles requests tied to one workflow execution and turns them into:
+
+- new history events,
+- mutable-state updates,
+- transfer tasks for future work,
+- timer tasks for delayed work.
+
+The official History Service docs explain that this service:
+
+- owns workflow histories,
+- partitions them into history shards,
+- persists queue progress,
+- and uses queue processors to dispatch work onward.
+
+### Simplified mental model
+
+```go
+func handleWorkerCompletion(req Completion) {
+	state := loadMutableState(req.WorkflowKey)
+
+	events, commands := applyDeterministicTransition(state, req)
+	appendHistory(events)
+	persistMutableState(state)
+
+	for _, cmd := range commands {
+		switch cmd.Kind {
+		case ScheduleActivity:
+			enqueueTransferTask(cmd)
+		case StartTimer:
+			enqueueTimerTask(cmd)
+		case ContinueWorkflow:
+			enqueueTransferTask(cmd)
+		}
+	}
+}
+```
+
+That sketch is intentionally smaller than the real code, but the shape is correct:
+
+- state transition first,
+- durable record first,
+- dispatchable follow-up work after that.
+
+This is the same design instinct you saw earlier in `etcd/raft` with `Ready` / `Advance`: communication boundaries often double as correctness boundaries.
+
+## History shards explain how Go scales the design
+
+Temporal does not put all workflow execution state behind one global lock or one global loop.
+
+Instead, history is partitioned into shards.
+Each owned shard has:
+
+- its own request handling,
+- internal queues,
+- checkpointing,
+- task execution plumbing.
+
+That maps well to Go because the runtime is comfortable running many independent service loops, queue processors, and RPC handlers inside one process without forcing a whole async/await programming model on the codebase.
+
+## Matching Service is the concurrency shock absorber
+
+The Matching Service owns task queues polled by workers.
+Its job is not to decide workflow correctness. Its job is to make delivery and throughput work.
+
+The official docs highlight:
+
+- task queues,
+- long polling,
+- partitions for higher throughput,
+- forwarding when an empty partition or unpolled task needs help finding a worker.
+
+### Simplified mental model
+
+```go
+func pollTask(queue Partition) Task {
+	for {
+		if task := queue.LocalBacklog.Pop(); task != nil {
+			return task
+		}
+
+		if task := queue.ParentForwarder.TryPoll(); task != nil {
+			return task
+		}
+
+		queue.WaitForTaskOrPoller()
+	}
+}
+```
+
+Again, the exact code is richer than this, but the useful idea is simple:
+
+- History decides what should happen,
+- Matching decides how tasks are handed to workers at scale.
+
+That separation keeps the core state machine from collapsing into transport mechanics.
+
+## Frontend and worker boundaries matter too
+
+Frontend is the RPC edge.
+Workers are outside the core server and poll for workflow or activity tasks.
+
+That separation is one of the biggest reasons Temporal can be both durable and language-agnostic:
+
+- the server owns history and task routing,
+- user code runs in SDK workers,
+- the system boundary is explicit and gRPC-shaped.
+
+This is a very Go-like system decomposition:
+
+- boring service boundaries,
+- explicit process ownership,
+- clear responsibility split.
+
+That is not a weakness. It is one of the reasons the system is understandable.
+
+## What to steal if you are building something smaller
+
+Most teams should not build Temporal.
+But many teams should steal some of its design instincts.
+
+### Separate correctness state from throughput plumbing
+
+Keep:
+
+- the state transition engine,
+- the persistence boundary,
+- the dispatch queue,
+
+as separate concerns.
+
+### Make durable follow-up work explicit
+
+If a request implies future work, turn that into a real task with a real lifecycle.
+Do not hide it in a fire-and-forget goroutine.
+
+### Shard ownership instead of centralizing everything
+
+If the workload is fundamentally many independent keys or workflows, shard the responsibility and keep the per-shard lifecycle explicit.
+
+### Keep user code out of the control plane
+
+Temporal keeps user workflow/activity execution in worker processes.
+That is a powerful boundary for safety and operability.
+
+## Failure patterns to avoid
+
+### "We'll just keep workflow state in memory"
+
+That is not durable execution. That is an in-memory orchestrator.
+
+### "Every poller can mutate workflow state directly"
+
+This destroys the state-ownership boundary.
+
+### "A goroutine sleeping is the same as a persisted timer"
+
+It is not. A process crash destroys the first and not the second.
+
+### "The queue and the state machine can be one blob"
+
+Temporal is useful to study precisely because it keeps these boundaries explicit.
+
+## Source map
+
+- [Temporal server README](https://github.com/temporalio/temporal/blob/main/README.md)
+- [Temporal architecture overview](https://github.com/temporalio/temporal/blob/main/docs/architecture/README.md)
+- [History Service architecture](https://github.com/temporalio/temporal/blob/main/docs/architecture/history-service.md)
+- [Matching Service architecture](https://github.com/temporalio/temporal/blob/main/docs/architecture/matching-service.md)
+- [Frontend service code](https://github.com/temporalio/temporal/tree/main/service/frontend)
+- [History service code](https://github.com/temporalio/temporal/tree/main/service/history)
+- [Matching service code](https://github.com/temporalio/temporal/tree/main/service/matching)
+- [Worker service code](https://github.com/temporalio/temporal/tree/main/service/worker)
+
+## Practical takeaway
+
+Temporal is a strong example of what Go is genuinely good at:
+
+- distributed control planes,
+- stateful orchestrators,
+- task-queue based systems,
+- and multi-service backends whose hardest problems are correctness, scale, and operability rather than raw low-level memory control.
+
+That is why a system this ambitious can still feel recognizably Go-shaped.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jaeyoung0509/golang-conccurency-patterns
+module github.com/jaeyoung0509/golang-handbook
 
 go 1.25.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "golang-conccurency-patterns",
+  "name": "golang-handbook",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "golang-conccurency-patterns",
+      "name": "golang-handbook",
       "devDependencies": {
         "mermaid": "^11.12.3",
         "vitepress": "^1.6.4"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "golang-conccurency-patterns",
+  "name": "golang-handbook",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- update repo-name-dependent config and docs for the `golang-handbook` rename
- add bilingual production pages for Temporal durable execution and Go open-source histories
- surface the new production topics in navigation, overview pages, and README

## Testing
- go test ./...
- npm run docs:build

## Linked Issue
- Closes #31
