### PR TITLE
Add Traefik case study and desktop sidebar toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ VitePress will print a local preview URL in the terminal, usually `http://localh
 
 - Large-scale Go systems: admission control, goroutine ownership, memory budgets, and shutdown policy
 - Temporal and durable execution: history shards, task queues, worker polling, and why this kind of workflow engine fits Go well
-- Open-source case studies from Kubernetes, etcd/raft, Prometheus, NATS, gRPC-Go, CockroachDB, and go-redis
-- Go open-source histories: why Prometheus, NATS, etcd, Kubernetes, CockroachDB, Caddy, and Temporal landed in Go
+- Open-source case studies from Kubernetes, etcd/raft, Prometheus, NATS, gRPC-Go, Traefik, CockroachDB, and go-redis
+- Go open-source histories: why Prometheus, NATS, etcd, Kubernetes, CockroachDB, Caddy, Traefik, and Temporal landed in Go
 
 ## Included testing topics
 

--- a/docs/.vitepress/theme/components/SidebarToggle.vue
+++ b/docs/.vitepress/theme/components/SidebarToggle.vue
@@ -1,0 +1,76 @@
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from "vue";
+import { useData } from "vitepress";
+
+const storageKey = "vp-sidebar-collapsed";
+const sidebarCollapsedClass = "sidebar-collapsed";
+
+const { lang, frontmatter } = useData();
+const isCollapsed = ref(false);
+const isMounted = ref(false);
+
+const isKorean = computed(() => lang.value.startsWith("ko"));
+const buttonLabel = computed(() =>
+  isKorean.value
+    ? isCollapsed.value
+      ? "사이드바 펼치기"
+      : "사이드바 접기"
+    : isCollapsed.value
+      ? "Show sidebar"
+      : "Hide sidebar"
+);
+
+const helperText = computed(() =>
+  isKorean.value ? "읽기 집중 모드" : "Focus mode"
+);
+
+const showToggle = computed(() => frontmatter.value.layout !== "home");
+
+function applyCollapsedState(value: boolean) {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  document.documentElement.classList.toggle(sidebarCollapsedClass, value);
+}
+
+function toggleSidebar() {
+  isCollapsed.value = !isCollapsed.value;
+}
+
+onMounted(() => {
+  const stored = window.localStorage.getItem(storageKey);
+  isCollapsed.value = stored === "1";
+  applyCollapsedState(isCollapsed.value);
+  isMounted.value = true;
+});
+
+watch(isCollapsed, (value) => {
+  applyCollapsedState(value);
+
+  if (!isMounted.value) {
+    return;
+  }
+
+  window.localStorage.setItem(storageKey, value ? "1" : "0");
+});
+</script>
+
+<template>
+  <div
+    v-if="showToggle"
+    class="sidebar-toggle-shell"
+    :class="{ 'is-collapsed': isCollapsed }"
+  >
+    <button
+      type="button"
+      class="sidebar-toggle-button"
+      :aria-label="buttonLabel"
+      :aria-pressed="isCollapsed"
+      @click="toggleSidebar"
+    >
+      <span class="sidebar-toggle-kicker">{{ helperText }}</span>
+      <span class="sidebar-toggle-label">{{ buttonLabel }}</span>
+    </button>
+  </div>
+</template>

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -185,6 +185,91 @@
   font-weight: 600;
 }
 
+@media (min-width: 960px) {
+  :root.sidebar-collapsed {
+    --vp-sidebar-width: 0px;
+  }
+
+  .sidebar-collapsed .VPSidebar {
+    width: 0 !important;
+    padding: 0 !important;
+    border-right: 0 !important;
+    transform: translateX(-100%);
+    pointer-events: none;
+  }
+
+  .sidebar-collapsed .VPNavBar.has-sidebar .title {
+    width: 0 !important;
+    padding: 0 !important;
+    opacity: 0;
+    overflow: hidden;
+    pointer-events: none;
+  }
+
+  .sidebar-collapsed .VPNavBar.has-sidebar .divider {
+    padding-left: 0 !important;
+  }
+}
+
+.sidebar-toggle-shell {
+  display: none;
+}
+
+@media (min-width: 960px) {
+  .sidebar-toggle-shell {
+    position: sticky;
+    top: calc(var(--vp-nav-height) + 12px);
+    z-index: 12;
+    display: flex;
+    justify-content: flex-start;
+    margin: 0 0 1.1rem;
+    pointer-events: none;
+  }
+
+  .sidebar-toggle-shell.is-collapsed {
+    margin-bottom: 1.35rem;
+  }
+
+  .sidebar-toggle-button {
+    pointer-events: auto;
+    display: inline-flex;
+    flex-direction: column;
+    gap: 0.15rem;
+    padding: 0.7rem 0.85rem;
+    border: 1px solid var(--vp-c-divider);
+    border-radius: 999px;
+    background:
+      radial-gradient(circle at top right, rgba(15, 118, 110, 0.14), transparent 42%),
+      var(--vp-c-bg-soft);
+    box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
+    color: var(--vp-c-text-1);
+    line-height: 1.1;
+    transition:
+      transform 0.18s ease,
+      border-color 0.18s ease,
+      box-shadow 0.18s ease;
+  }
+
+  .sidebar-toggle-button:hover {
+    border-color: rgba(15, 118, 110, 0.45);
+    transform: translateY(-1px);
+    box-shadow: 0 16px 36px rgba(15, 23, 42, 0.11);
+  }
+
+  .sidebar-toggle-kicker {
+    color: var(--vp-c-text-2);
+    font-size: 0.73rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  .sidebar-toggle-label {
+    font-size: 0.92rem;
+    font-weight: 700;
+  }
+}
+
 @media (max-width: 768px) {
   .vp-doc {
     font-size: 16px;

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,10 +1,17 @@
 import DefaultTheme from "vitepress/theme";
 import type { Theme } from "vitepress";
+import { h } from "vue";
 import MermaidDiagram from "./components/MermaidDiagram.vue";
+import SidebarToggle from "./components/SidebarToggle.vue";
 import "./custom.css";
 
 export default {
   extends: DefaultTheme,
+  Layout() {
+    return h(DefaultTheme.Layout, null, {
+      "doc-before": () => h(SidebarToggle),
+    });
+  },
   enhanceApp({ app }) {
     app.component("MermaidDiagram", MermaidDiagram);
   },

--- a/docs/ko/production/go-open-source-histories.md
+++ b/docs/ko/production/go-open-source-histories.md
@@ -36,7 +36,8 @@ flowchart LR
     C --> D["2014-02 CockroachDB"]
     D --> E["2014-06 Kubernetes"]
     E --> F["2015-01 Caddy"]
-    F --> G["2019-10 Temporal"]
+    F --> G["2015-09 Traefik"]
+    G --> H["2019-10 Temporal"]
 ```
 
 ## 빠른 지도
@@ -49,6 +50,7 @@ flowchart LR
 | 2014-02-06 | CockroachDB | 분산 SQL 데이터베이스 | Go는 CLI나 proxy만이 아니라 야심찬 distributed data system도 감당할 수 있었다 |
 | 2014-06-06 | Kubernetes | 클러스터 control plane | Go는 controller, API, reconciliation loop의 언어가 되었다 |
 | 2015-01-13 | Caddy | operator-first 웹 서버 | deployability와 표준 라이브러리 networking의 가치가 컸다 |
+| 2015-09-13 | Traefik | 동적 edge proxy와 routing control plane | Go는 orchestrator 상태를 restart 없이 live routing으로 바꾸는 시스템과도 잘 맞았다 |
 | 2019-10-16 | Temporal | durable execution 플랫폼 | Go는 persistence-backed state machine과 workflow orchestration까지 확장됐다 |
 
 ## 왜 이런 파동이 생겼나
@@ -193,7 +195,7 @@ Go는 단지:
 
 Go를 "운영 툴 언어"에서 "진지한 distributed system 구현 언어"로 올려서 보게 만든 사례 중 하나입니다.
 
-## 4기: operator-first 서버
+## 4기: operator-first 서버와 edge control plane
 
 ### Caddy
 
@@ -217,6 +219,32 @@ Caddy는 웹 서버가 다음일 수 있음을 강하게 보여줬습니다.
 왜 중요했나:
 
 Go의 표준 라이브러리와 바이너리 모델은 운영자가 직접 배포해야 하는 인프라 소프트웨어와 궁합이 좋았습니다.
+
+### Traefik
+
+공개 저장소 날짜: 2015년 9월 13일.
+
+Traefik은 같은 Go 역사에서 조금 다른 갈래를 보여줍니다.
+이건 단순 웹 서버라기보다:
+
+- orchestrator/provider 상태를 감시하고
+- 여러 source의 설정을 merge하고
+- live router를 rebuild하고
+- 운영용 hook을 노출하고
+- 여전히 practical한 인프라 소프트웨어로 배포되는
+
+동적 reverse proxy / routing control plane입니다.
+
+읽을 곳:
+
+- [Traefik repository](https://github.com/traefik/traefik)
+- [`pkg/provider/aggregator/aggregator.go`](https://github.com/traefik/traefik/blob/master/pkg/provider/aggregator/aggregator.go)
+- [`pkg/server/configurationwatcher.go`](https://github.com/traefik/traefik/blob/master/pkg/server/configurationwatcher.go)
+- [`pkg/server/routerfactory.go`](https://github.com/traefik/traefik/blob/master/pkg/server/routerfactory.go)
+
+왜 중요했나:
+
+Traefik은 Go가 단순한 edge server뿐 아니라, control-plane 상태를 지속적으로 ingest해서 live routing behavior로 바꾸는 동적 edge 시스템에도 잘 맞았다는 걸 보여줬습니다.
 
 ## 5기: durable orchestration과 workflow 엔진
 
@@ -271,6 +299,7 @@ Go는 coordination, lifecycle, throughput, operability가 핵심인 시스템에
 | periodic work와 scrape ownership | Prometheus |
 | 대규모 task lifetime과 shutdown | CockroachDB |
 | deployable operator-first edge/server software | Caddy |
+| dynamic reverse proxy와 routing control plane | Traefik |
 | durable workflow orchestration | Temporal |
 
 ## 다음으로 읽을 곳
@@ -288,6 +317,7 @@ Go는 coordination, lifecycle, throughput, operability가 핵심인 시스템에
 - [Prometheus repository metadata](https://github.com/prometheus/prometheus)
 - [NATS Server repository metadata](https://github.com/nats-io/nats-server)
 - [Caddy repository metadata](https://github.com/caddyserver/caddy)
+- [Traefik repository metadata](https://github.com/traefik/traefik)
 
 ## Practical takeaway
 

--- a/docs/ko/production/open-source-case-studies.md
+++ b/docs/ko/production/open-source-case-studies.md
@@ -21,6 +21,7 @@ description: 대표적인 Go 오픈소스가 실제로 concurrency를 어떻게 
 | Prometheus | periodic work를 owner loop 하나로 묶는 법 | [`scrape/scrape.go`](https://github.com/prometheus/prometheus/blob/3b44b8b463be9291a5605b935a5fbeda88db1366/scrape/scrape.go#L822-L1308) |
 | NATS Server | `sync.Cond`로 read/write socket ownership을 분리하는 법 | [`server/client.go`](https://github.com/nats-io/nats-server/blob/bae1d6c752e0550901d0a79a76fb2fabe79c1eff/server/client.go#L355-L355), [`writeLoop`](https://github.com/nats-io/nats-server/blob/bae1d6c752e0550901d0a79a76fb2fabe79c1eff/server/client.go#L1274-L1355), [`readLoop`](https://github.com/nats-io/nats-server/blob/bae1d6c752e0550901d0a79a76fb2fabe79c1eff/server/client.go#L1358-L1415) |
 | gRPC-Go | single writer goroutine과 control buffer | [`internal/transport/controlbuf.go`](https://github.com/grpc/grpc-go/blob/b9f7967353473f3b585092ac5d961de3878e1f12/internal/transport/controlbuf.go#L307-L629) |
+| Traefik | dynamic provider aggregation과 live router rebuild를 restart 없이 처리하는 법 | [`pkg/provider/aggregator/aggregator.go`](https://github.com/traefik/traefik/blob/master/pkg/provider/aggregator/aggregator.go), [`pkg/server/configurationwatcher.go`](https://github.com/traefik/traefik/blob/master/pkg/server/configurationwatcher.go), [`pkg/server/routerfactory.go`](https://github.com/traefik/traefik/blob/master/pkg/server/routerfactory.go) |
 | CockroachDB | 서비스 전체의 task ownership과 quiesce contract | [`pkg/util/stop/stopper.go`](https://github.com/cockroachdb/cockroach/blob/41c5df3d4a4cd26e8852677aebb513184e78ccd9/pkg/util/stop/stopper.go#L152-L670) |
 | go-redis | pool admission, wait budget, connection handoff | [`internal/pool/pool.go`](https://github.com/redis/go-redis/blob/6193e530d612d362359a6709b46dc2c159e1455d/internal/pool/pool.go#L306-L1078) |
 
@@ -298,6 +299,77 @@ stream goroutine이 shared `net.Conn`에 직접 HTTP/2 frame을 쓰게 두면 �
 핵심 takeaway:
 
 multiplexed transport는 대개 command queue + writer owner 구조가 맞습니다.
+
+## Traefik dynamic configuration control plane
+
+왜 읽을 가치가 있는가:
+
+Traefik은 여러 provider에서 들어오는 설정 변화를 restart 없이 live routing state로 재구성하는 edge proxy/control-plane 시스템이기 때문에, Go가 이런 종류의 동적 인프라 소프트웨어에 왜 잘 맞는지 보여주는 좋은 사례입니다.
+
+주 소스:
+
+- [`ProviderAggregator`](https://github.com/traefik/traefik/blob/master/pkg/provider/aggregator/aggregator.go)
+- [`ConfigurationWatcher`](https://github.com/traefik/traefik/blob/master/pkg/server/configurationwatcher.go)
+- [`RouterFactory`](https://github.com/traefik/traefik/blob/master/pkg/server/routerfactory.go)
+
+핵심 concurrency boundary:
+
+provider가 live proxy를 직접 바꾸지 않습니다. 대신 설정 메시지를 aggregation pipeline으로 밀어 넣고, 그 파이프라인이:
+
+- provider를 시작하고
+- update flow를 throttle하고
+- unchanged configuration을 건너뛰고
+- 전체 merged configuration을 transform한 뒤
+- 안정화된 runtime view에서 router를 rebuild 합니다.
+
+단순화한 형태:
+
+```go
+func Start() {
+	go providerAggregator.Provide(allProviderConfigs, pool)
+	go receiveConfigurations()
+	go applyConfigurations()
+}
+
+func receiveConfigurations() {
+	for msg := range allProviderConfigs {
+		if unchanged(msg) {
+			continue
+		}
+
+		merged[msg.ProviderName] = copyConfig(msg.Configuration)
+		latest := transform(merged)
+		publishLatestNonBlocking(latest)
+	}
+}
+
+func applyConfigurations() {
+	for confs := range newConfigs {
+		runtimeConf := mergeConfiguration(confs)
+		listeners.Apply(runtimeConf)
+	}
+}
+```
+
+왜 이게 중요한가:
+
+Traefik은:
+
+- provider discovery
+- configuration stabilization
+- router rebuild
+
+을 분리합니다.
+
+그래서 noisy한 Docker/Kubernetes/file provider가 live routing state를 직접 건드리지 못합니다. 서버는 하나의 coherent view에서 deduplicate, throttle, merge, rebuild를 수행합니다.
+
+실패 패턴:
+
+각 config source가 active proxy graph를 직접 mutate하게 두면 안 됩니다. 그건 race-heavy edge state, restart pressure, 관측 불가능한 현재 상태로 이어집니다.
+
+핵심 takeaway:
+
+dynamic edge proxy는 discovery event가 data plane rebuild 전에 하나의 ownership boundary를 통과하게 만드는 편이 훨씬 강합니다.
 
 ## CockroachDB stopper
 

--- a/docs/production/go-open-source-histories.md
+++ b/docs/production/go-open-source-histories.md
@@ -37,7 +37,8 @@ flowchart LR
     C --> D["2014-02 CockroachDB"]
     D --> E["2014-06 Kubernetes"]
     E --> F["2015-01 Caddy"]
-    F --> G["2019-10 Temporal"]
+    F --> G["2015-09 Traefik"]
+    G --> H["2019-10 Temporal"]
 ```
 
 ## Quick map
@@ -50,6 +51,7 @@ flowchart LR
 | 2014-02-06 | CockroachDB | distributed SQL database | Go was not only for CLIs and proxies; it could host ambitious distributed data systems |
 | 2014-06-06 | Kubernetes | cluster control plane | Go became the language of controllers, APIs, and reconciliation loops |
 | 2015-01-13 | Caddy | operations-first web server | deployability and standard-library networking mattered a lot |
+| 2015-09-13 | Traefik | dynamic edge proxy and routing control plane | Go fit systems that merge orchestrator state into live routing without restart-heavy operations |
 | 2019-10-16 | Temporal | durable execution platform | Go could also host workflow orchestration and persistence-backed state machines |
 
 ## Why this wave happened
@@ -189,7 +191,7 @@ Why it mattered:
 
 It pushed the industry view of Go upward from "operational tooling language" toward "serious distributed system implementation language."
 
-## Era 4: operator-first servers
+## Era 4: operator-first servers and edge control planes
 
 ### Caddy
 
@@ -213,6 +215,30 @@ What to read:
 Why it mattered:
 
 Go's standard library and binary model made it a natural fit for infrastructure software that people actually had to deploy themselves.
+
+### Traefik
+
+Public repo date: September 13, 2015.
+
+Traefik represents a slightly different branch of the same Go story.
+It is not only a web server. It is a dynamic reverse proxy and routing control plane that:
+
+- watches orchestrator/provider state,
+- merges configuration from many sources,
+- rebuilds live routers,
+- exposes operational hooks,
+- and stays deployable as practical infrastructure software.
+
+What to read:
+
+- [Traefik repository](https://github.com/traefik/traefik)
+- [`pkg/provider/aggregator/aggregator.go`](https://github.com/traefik/traefik/blob/master/pkg/provider/aggregator/aggregator.go)
+- [`pkg/server/configurationwatcher.go`](https://github.com/traefik/traefik/blob/master/pkg/server/configurationwatcher.go)
+- [`pkg/server/routerfactory.go`](https://github.com/traefik/traefik/blob/master/pkg/server/routerfactory.go)
+
+Why it mattered:
+
+Traefik showed that Go fit not just static edge servers, but dynamic edge systems that continuously ingest control-plane state and translate it into live routing behavior.
 
 ## Era 5: durable orchestration and workflow engines
 
@@ -267,6 +293,7 @@ Go became unusually good for systems whose hardest problems are coordination, li
 | periodic work and scrape ownership | Prometheus |
 | large-system task lifetime and shutdown | CockroachDB |
 | deployable operator-first edge/server software | Caddy |
+| dynamic reverse proxy and routing control plane | Traefik |
 | durable workflow orchestration | Temporal |
 
 ## Where to go next
@@ -284,6 +311,7 @@ Go became unusually good for systems whose hardest problems are coordination, li
 - [Prometheus repository metadata](https://github.com/prometheus/prometheus)
 - [NATS Server repository metadata](https://github.com/nats-io/nats-server)
 - [Caddy repository metadata](https://github.com/caddyserver/caddy)
+- [Traefik repository metadata](https://github.com/traefik/traefik)
 
 ## Practical takeaway
 

--- a/docs/production/open-source-case-studies.md
+++ b/docs/production/open-source-case-studies.md
@@ -21,6 +21,7 @@ If you want one modern durable-execution system in detail, read [Temporal and Du
 | Prometheus | One owner loop for periodic work and shutdown | [`scrape/scrape.go`](https://github.com/prometheus/prometheus/blob/3b44b8b463be9291a5605b935a5fbeda88db1366/scrape/scrape.go#L822-L1308) |
 | NATS Server | Split read/write socket ownership with `sync.Cond` signaling | [`server/client.go`](https://github.com/nats-io/nats-server/blob/bae1d6c752e0550901d0a79a76fb2fabe79c1eff/server/client.go#L355-L355), [`writeLoop`](https://github.com/nats-io/nats-server/blob/bae1d6c752e0550901d0a79a76fb2fabe79c1eff/server/client.go#L1274-L1355), [`readLoop`](https://github.com/nats-io/nats-server/blob/bae1d6c752e0550901d0a79a76fb2fabe79c1eff/server/client.go#L1358-L1415) |
 | gRPC-Go | Single writer goroutine plus explicit control buffer | [`internal/transport/controlbuf.go`](https://github.com/grpc/grpc-go/blob/b9f7967353473f3b585092ac5d961de3878e1f12/internal/transport/controlbuf.go#L307-L629) |
+| Traefik | Dynamic provider aggregation and live router rebuilds without restart | [`pkg/provider/aggregator/aggregator.go`](https://github.com/traefik/traefik/blob/master/pkg/provider/aggregator/aggregator.go), [`pkg/server/configurationwatcher.go`](https://github.com/traefik/traefik/blob/master/pkg/server/configurationwatcher.go), [`pkg/server/routerfactory.go`](https://github.com/traefik/traefik/blob/master/pkg/server/routerfactory.go) |
 | CockroachDB | Service-wide task ownership and quiesce semantics | [`pkg/util/stop/stopper.go`](https://github.com/cockroachdb/cockroach/blob/41c5df3d4a4cd26e8852677aebb513184e78ccd9/pkg/util/stop/stopper.go#L152-L670) |
 | go-redis | Pool admission, wait budgets, and connection handoff | [`internal/pool/pool.go`](https://github.com/redis/go-redis/blob/6193e530d612d362359a6709b46dc2c159e1455d/internal/pool/pool.go#L306-L1078) |
 
@@ -298,6 +299,75 @@ Do not let per-stream goroutines write HTTP/2 frames directly to a shared `net.C
 Takeaway:
 
 Multiplexed transports usually want a command queue plus one writer owner.
+
+## Traefik dynamic configuration control plane
+
+Why it is worth reading:
+
+Traefik is a good study in how Go can power an edge proxy that continuously rebuilds live routing state from many upstream providers without restart-heavy configuration management.
+
+Primary source:
+
+- [`ProviderAggregator`](https://github.com/traefik/traefik/blob/master/pkg/provider/aggregator/aggregator.go)
+- [`ConfigurationWatcher`](https://github.com/traefik/traefik/blob/master/pkg/server/configurationwatcher.go)
+- [`RouterFactory`](https://github.com/traefik/traefik/blob/master/pkg/server/routerfactory.go)
+
+Main concurrency boundary:
+
+Providers do not mutate the live proxy directly. They emit configuration messages into a controlled aggregation pipeline, which:
+
+- starts providers,
+- throttles update flow,
+- drops unchanged configurations,
+- transforms the full merged configuration,
+- then rebuilds routers from a stabilized runtime view.
+
+Simplified shape:
+
+```go
+func Start() {
+	go providerAggregator.Provide(allProviderConfigs, pool)
+	go receiveConfigurations()
+	go applyConfigurations()
+}
+
+func receiveConfigurations() {
+	for msg := range allProviderConfigs {
+		if unchanged(msg) {
+			continue
+		}
+
+		merged[msg.ProviderName] = copyConfig(msg.Configuration)
+		latest := transform(merged)
+		publishLatestNonBlocking(latest)
+	}
+}
+
+func applyConfigurations() {
+	for confs := range newConfigs {
+		runtimeConf := mergeConfiguration(confs)
+		listeners.Apply(runtimeConf)
+	}
+}
+```
+
+Why this works:
+
+Traefik separates:
+
+- provider discovery,
+- configuration stabilization,
+- and router rebuild.
+
+That means a noisy Docker/Kubernetes/file provider does not get to poke at live routing state directly. The server can deduplicate, throttle, merge, and rebuild from one coherent view.
+
+Failure pattern to avoid:
+
+Do not let every config source mutate the active proxy graph directly. That creates race-heavy edge state, restart pressure, and no stable place to observe what the system currently believes.
+
+Takeaway:
+
+Dynamic edge proxies work better when discovery events flow through one ownership boundary before the data plane is rebuilt.
 
 ## CockroachDB stopper
 


### PR DESCRIPTION
## Summary
- add Traefik to the bilingual open-source case studies and Go open-source history pages
- add a desktop sidebar collapse/expand toggle with persisted state in the custom VitePress theme
- update the README production summary to mention Traefik

## Testing
- go test ./...
- npm run docs:build

## Linked Issue
- Closes #35
