### PR TITLE
Improve testing docs quality and factual precision

### DIFF
--- a/docs/ko/testing/leaks-and-shutdowns.md
+++ b/docs/ko/testing/leaks-and-shutdowns.md
@@ -14,6 +14,10 @@ description: goroutine 종료, queue drain, shutdown deadline을 어떻게 검�
 
 이건 race detector만으로 잘 안 잡힙니다. 명시적인 종료 테스트가 필요합니다.
 
+:::tip Quick takeaway
+component에 `Start`, `Run`, `Submit`, `Check`가 있다면 lifetime contract도 있습니다. 좋은 테스트는 admission path와 exit path를 둘 다 증명합니다.
+:::
+
 ## 무엇을 검증해야 하나
 
 nontrivial concurrent component라면 최소한 다음을 테스트해야 합니다.
@@ -22,6 +26,18 @@ nontrivial concurrent component라면 최소한 다음을 테스트해야 합니
 2. shutdown 시작 후 새 작업은 명확히 거부되는가
 3. blocked goroutine에 escape path가 있는가
 4. shutdown이 hard deadline을 존중하는가
+
+## 테스트 가능한 shutdown contract
+
+테스트 전에 contract를 먼저 분명히 해야 합니다. 좋은 concurrent component라면 최소한 아래 질문에 답이 있어야 합니다.
+
+- shutdown 시작 후 어떤 작업까지 받는가
+- 이미 받은 작업은 drain되는가, cancel되는가, drop되는가
+- admission이 닫힌 뒤 caller는 어떤 에러를 받는가
+- shutdown은 얼마나 기다릴 수 있는가
+- background goroutine의 owner는 누구이고, 언제 종료가 보장되는가
+
+구현이 이 질문에 답하지 못하면 테스트도 흐려집니다.
 
 ## 이 저장소의 예시
 
@@ -39,6 +55,23 @@ nontrivial concurrent component라면 최소한 다음을 테스트해야 합니
 
 ## 유용한 테스트 형태
 
+### shutdown 이후 admission 거부
+
+```go
+func TestSubmitRejectedAfterShutdown(t *testing.T) {
+	processor := newProcessor(t)
+
+	require.NoError(t, processor.Shutdown(context.Background()))
+
+	err := processor.Submit(context.Background(), Event{OrderID: "ord-1"})
+	if !errors.Is(err, ErrClosed) {
+		t.Fatalf("Submit error = %v, want ErrClosed", err)
+	}
+}
+```
+
+이 테스트는 "가끔 막히고 가끔 들어가는" 애매한 동작 대신, caller가 항상 같은 답을 받는지 증명합니다.
+
 ### deadline-bounded shutdown
 
 ```go
@@ -50,6 +83,56 @@ if err := processor.Shutdown(ctx); err == nil {
 }
 ```
 
+### blocked sender의 escape path
+
+```go
+func TestWorkerExitsOnCancel(t *testing.T) {
+	done := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		defer close(done)
+		runWorker(ctx)
+	}()
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("worker did not exit after cancellation")
+	}
+}
+```
+
+핵심은 `100ms`가 아니라 explicit completion signal입니다. timeout은 테스트가 영원히 걸리지 않게 막는 장치일 뿐입니다.
+
+### caller-abandoned reply path
+
+```go
+func TestReplyPathDoesNotLeakAfterCallerTimeout(t *testing.T) {
+	release := make(chan struct{})
+	broker := newBroker(func() Result {
+		<-release
+		return Result{}
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	if err := broker.Check(ctx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Check error = %v, want deadline exceeded", err)
+	}
+
+	close(release)
+	if err := broker.Check(context.Background()); err != nil {
+		t.Fatalf("follow-up request failed after timeout path: %v", err)
+	}
+}
+```
+
+이게 `examples/requestreply/requestreply_test.go`가 증명하는 핵심입니다. caller 하나가 떠났다고 broker 전체가 오염되면 안 됩니다.
+
 ### 명시적 completion protocol
 
 goroutine 수를 전역적으로 세기보다:
@@ -59,6 +142,8 @@ goroutine 수를 전역적으로 세기보다:
 - `context` cancellation + wait
 
 같은 completion protocol을 더 선호하는 편이 안정적입니다.
+
+`runtime.NumGoroutine` 같은 전역 카운트는 CI smoke test 정도로는 쓸 수 있지만, runtime background activity 때문에 1차 oracle로 쓰기엔 약합니다.
 
 ## 실패 패턴
 
@@ -86,6 +171,18 @@ lifecycle bug는 happy path에서는 잘 안 보입니다.
 ### caller-abandoned path를 빼먹는 것
 
 reply를 보내는 background worker / broker는 caller가 먼저 timeout되는 경우를 꼭 테스트해야 합니다.
+
+### cleanup에서 `t.Context()`를 재사용하는 것
+
+`testing.T.Context()`는 cleanup 직전에 cancel됩니다. teardown에 살아 있는 context가 필요하면 cleanup 안에서 별도 bounded background context를 새로 만들어야 합니다.
+
+## 실전 리뷰 체크리스트
+
+1. admission이 언제 닫히는지 증명하는가
+2. 이미 받은 작업이 어떻게 끝나는지 증명하는가
+3. 모든 blocked goroutine에 cancel/close path가 있는가
+4. 테스트가 sleep이 아니라 explicit completion을 쓰는가
+5. teardown이 bounded deadline 안에 끝나는가
 
 ## Practical takeaway
 

--- a/docs/ko/testing/race-detector.md
+++ b/docs/ko/testing/race-detector.md
@@ -7,6 +7,18 @@ description: Go race detector가 무엇을 잡고 무엇을 보장하지 않는�
 
 nontrivial한 동시성 코드라면 가장 먼저 돌려야 하는 도구가 race detector입니다.
 
+:::tip Quick takeaway
+`go test -race`는 concurrent Go의 최소 기준이지 끝이 아닙니다. shared memory에 대한 빠진 동기화는 잘 잡지만, shutdown, leak, timeout correctness 자체를 증명해주지는 못합니다.
+:::
+
+## 머릿속 모델
+
+race detector가 묻는 질문은 하나입니다.
+
+> 같은 메모리를 두 goroutine이 동시에 만졌는데, 그 사이에 유효한 happens-before edge가 있었는가?
+
+그래서 이 도구는 [Go Memory Model](https://go.dev/ref/mem)과 같이 봐야 합니다. channel ownership transfer, mutex, atomic, `WaitGroup` completion 같은 경계를 설계했다면, detector는 코드가 실제로 그 계약을 지키는지 확인하는 데 도움을 줍니다.
+
 ## 무엇을 잡나
 
 같은 메모리 위치에 대한 concurrent access 중 하나 이상이 write이고, 그 사이에 동기화 경계가 없을 때 발생하는 data race를 잡습니다.
@@ -16,6 +28,8 @@ nontrivial한 동시성 코드라면 가장 먼저 돌려야 하는 도구가 ra
 - 한 goroutine이 map을 읽고 다른 goroutine이 동시에 쓰는 경우,
 - channel protocol이 보호해야 할 상태를 바깥에서 따로 읽거나 쓰는 경우,
 - cache update에 lock을 빠뜨린 경우.
+
+즉, "공유 mutable state를 실수로 열어둔 경우"를 잡는 데 특화된 도구이지, 모든 동시성 버그를 잡는 도구는 아닙니다.
 
 ## 작은 race 예시
 
@@ -29,6 +43,31 @@ func TestRacyMap(t *testing.T) {
 ```
 
 이 코드는 casual run에서는 조용히 지나갈 수도 있습니다. `-race`를 돌리면 바로 잡아야 하는 버그라는 점이 드러납니다.
+
+일부 map race는 `-race` 없이도 panic이 나지만, 대부분의 shared-state 버그는 그렇게 친절하지 않습니다. 그래서 detector가 필요합니다.
+
+## `-race`가 깨끗해도 여전히 깨지는 예시
+
+아래 코드는 race-free지만 여전히 잘못됐습니다.
+
+```go
+func fetchWithTimeout(ctx context.Context) error {
+	reply := make(chan Result)
+
+	go func() {
+		reply <- slowQuery()
+	}()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-reply:
+		return nil
+	}
+}
+```
+
+caller가 먼저 timeout되면 goroutine은 `reply <- slowQuery()`에서 영원히 막힐 수 있습니다. shared-memory race는 없으니 race detector는 조용합니다. 그래서 leak / shutdown 테스트가 별도로 필요합니다.
 
 ## 무엇을 보장하지 않나
 
@@ -44,11 +83,51 @@ func TestRacyMap(t *testing.T) {
 
 ## 사용법
 
+기본은 전체 모듈입니다.
+
 ```bash
 go test -race ./...
 ```
 
+빠르게 돌릴 땐 이렇게 줄일 수 있습니다.
+
+```bash
+go test -race ./examples/workerpool -run TestGenerateQuotesCancelsSlowJobsAfterError
+go test -race -count=20 -shuffle=on ./...
+go test -race -cpu=1,4 ./...
+```
+
+자주 쓰는 형태는 다음과 같습니다.
+
+| 커맨드 | 용도 |
+| --- | --- |
+| `go test -race ./...` | 전체 baseline |
+| `go test -race ./pkg -run TestName` | 특정 테스트 빠른 반복 |
+| `go test -race -count=20 -shuffle=on ./...` | 스케줄 민감한 경로 흔들기 |
+| `go test -race -cpu=1,4 ./...` | 높은 병렬도에서만 깨지는 코드 찾기 |
+
 느리고 무거운 건 정상입니다. 동시성 코드에선 그 비용을 감수할 가치가 충분합니다.
+
+## race report는 어떻게 읽어야 하나
+
+report에서 중요한 건 두 가지입니다.
+
+1. 충돌한 access 두 개
+2. 그 access를 만든 goroutine 생성 스택
+
+보통 진짜 원인은 그 두 줄보다 한 단계 위에 있습니다.
+
+- state owner가 우회됐거나
+- mutex가 보호해야 할 map이 밖으로 새었거나
+- background goroutine이 context lifetime 밖으로 나갔거나
+- 리팩터링이 synchronization fast path를 깨뜨린 경우입니다.
+
+## report를 본 뒤의 정석 순서
+
+1. ownership을 잃은 mutable state가 무엇인지 찾습니다.
+2. ownership, mutex, atomic, message passing 중 어떤 경계가 맞는지 결정합니다.
+3. 임시 lock 추가보다 우회 경로 자체를 제거합니다.
+4. 가장 좁은 `-race` 명령으로 다시 확인하고 마지막에 전체 스위트를 돌립니다.
 
 ## 좋은 사용 방식
 
@@ -70,6 +149,15 @@ func TestSomething(t *testing.T) {
 ```
 
 이런 테스트는 한동안은 통과하면서 잘못된 자신감만 줍니다. `-race`로 돌리고, 그다음 timing luck을 실제 synchronization으로 바꿔야 합니다.
+
+또 다른 실패 패턴은 "`-race`가 깨끗하니 프로토콜도 맞다"라고 생각하는 것입니다. 실제 버그가 goroutine leak, shutdown wedge, timeout 이후 reply block이라면 detector는 평생 초록일 수 있습니다.
+
+## `-race` 친화적인 설계 패턴
+
+- mutable state machine마다 single owner goroutine 두기
+- 짧은 critical section을 가진 `map + mutex`
+- one-shot response에는 explicit reply channel 쓰기
+- 테스트를 sleep 기반이 아니라 실제 completion signal 기반으로 쓰기
 
 ## 공식 자료
 

--- a/docs/ko/testing/synctest.md
+++ b/docs/ko/testing/synctest.md
@@ -30,6 +30,12 @@ description: testing/synctest를 사용해 실제 시간 sleep 없이 timeout-he
 
 즉, 벽시계 시간에 기대지 않고 timeout 로직을 검증할 수 있습니다.
 
+머릿속 모델은 이렇습니다.
+
+- bubble이 자신이 만든 goroutine을 소유하고
+- bubble이 fake clock을 소유하며
+- bubble이 안정된 blocked 상태에 들어갔을 때만 시간이 전진합니다.
+
 ## 실전 예시
 
 ```go
@@ -55,6 +61,35 @@ func TestContextTimeout(t *testing.T) {
 
 이 테스트는 실제 5초를 기다리지 않습니다. 즉시, 그리고 결정적으로 실행됩니다.
 
+## 또 다른 좋은 예시: `context.AfterFunc`
+
+```go
+func TestAfterFuncRunsAfterCancel(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		called := false
+		context.AfterFunc(ctx, func() {
+			called = true
+		})
+
+		synctest.Wait()
+		if called {
+			t.Fatal("AfterFunc ran before cancellation")
+		}
+
+		cancel()
+		synctest.Wait()
+		if !called {
+			t.Fatal("AfterFunc did not run after cancellation")
+		}
+	})
+}
+```
+
+예전 같으면 임의 sleep을 넣기 쉬운 테스트인데, 이제는 그럴 필요가 없습니다.
+
 ## "durably blocked"가 왜 중요하나
 
 표준 라이브러리 문서 기준으로:
@@ -66,15 +101,45 @@ func TestContextTimeout(t *testing.T) {
 
 등은 durably blocked로 간주될 수 있습니다.
 
-반면:
+반면, block될 수는 있어도 durably blocked는 아닌 것들이 있습니다.
 
-- network I/O,
-- 외부 syscall,
-- bubble 바깥 이벤트에 의존한 block
-
-은 같은 방식으로 다뤄지지 않습니다.
+- `sync.Mutex` / `sync.RWMutex` lock 획득
+- network I/O
+- system call
+- bubble 바깥 goroutine이나 이벤트에 의존한 block
 
 그래서 `synctest`는 fake dependency와 self-contained 테스트에서 특히 강합니다.
+
+## 잘 맞는 곳과 안 맞는 곳
+
+| 잘 맞는 곳 | 잘 안 맞는 곳 |
+| --- | --- |
+| `time` 기반 timeout / retry loop | 실제 socket과 live network service |
+| cancellation propagation | bubble 밖에서 시작된 goroutine |
+| internal worker coordination | external process, OS event |
+| `AfterFunc`, timer, ticker | `sync.Mutex` blocking semantics 자체를 검증하는 테스트 |
+
+프로토콜 수준 I/O를 검증하고 싶다면 loopback socket보다 `net.Pipe` 같은 in-process fake transport가 더 잘 맞습니다.
+
+## 실전에서 중요한 isolation 규칙
+
+bubble은 생각보다 엄격합니다.
+
+- bubble 안에서 만든 channel, timer, ticker는 bubble에 귀속되고
+- 그 객체를 bubble 밖에서 만지면 panic이 날 수 있으며
+- `WaitGroup`은 첫 `Add` 또는 `Go` 시점에 bubble과 연결되고
+- package-global `WaitGroup` 값은 기술적 제한 때문에 피하는 편이 좋습니다.
+
+즉, `synctest`는 테스트에서도 ownership boundary를 더 깔끔하게 만들라고 압박합니다.
+
+## deadlock 동작
+
+두 규칙은 꼭 알아야 합니다.
+
+1. 모든 goroutine이 durably blocked이고 다음 timer가 있으면 fake time이 그 시점까지 전진합니다.
+2. 모든 goroutine이 durably blocked인데 앞으로 아무도 깨울 수 없으면 `synctest.Test`는 deadlock panic을 냅니다.
+
+그리고 root goroutine이 끝나면 fake time은 더 이상 전진하지 않습니다. background work도 결국은 명시적으로 ownership과 wait가 있어야 합니다.
 
 ## 어디에 잘 맞나
 
@@ -92,6 +157,8 @@ func TestContextTimeout(t *testing.T) {
 - real network integration test
 - trace / profile 분석
 - 외부 시스템과 얽힌 leak test
+
+즉, 기존 테스트 스택 위에 얹는 새 레이어이지 만능 대체재는 아닙니다.
 
 ## 실패 패턴
 
@@ -111,7 +178,7 @@ time.Sleep(10 * time.Millisecond) // bad: 그냥 timing guess
 ## 공식 자료
 
 - [Testing Time (Go Blog)](https://go.dev/blog/testing-time)
-- [Go 1.24 Release Notes](https://go.dev/doc/go1.24)
+- [testing/synctest package docs](https://pkg.go.dev/testing/synctest)
 
 ## Practical takeaway
 

--- a/docs/ko/testing/tracing-and-profiling.md
+++ b/docs/ko/testing/tracing-and-profiling.md
@@ -9,15 +9,29 @@ description: runtime trace, block profile, mutex profile, scheduler debug output
 
 그 경우 unit test만으로는 부족합니다.
 
+:::tip Quick takeaway
+질문이 "runtime이 실제로 뭘 하고 있나"면 execution trace부터 시작하는 게 맞습니다. 질문이 "시간이 어디서 새나"라면 block, mutex, heap, CPU profile로 내려가면 됩니다.
+:::
+
 ## 주요 도구
 
-| 도구 | 잘 맞는 문제 |
-| --- | --- |
-| `go test -trace` | goroutine state, scheduler activity, netpoll, syscall, GC |
-| block profile | 어디서 goroutine이 block되는지 |
-| mutex profile | lock contention hotspot |
-| heap / alloc profile | allocation pressure와 GC 연결 |
-| `GODEBUG=schedtrace=...` | scheduler snapshot과 run queue pressure |
+| 도구 | 잘 맞는 문제 | 대표 커맨드 |
+| --- | --- | --- |
+| `go test -trace` | goroutine state, scheduler activity, netpoll, syscall, GC | `go test -trace=trace.out ./pkg` |
+| block profile | 어디서 goroutine이 block되는지 | `go test -blockprofile=block.out ./pkg` |
+| mutex profile | lock contention hotspot | `go test -mutexprofile=mutex.out ./pkg` |
+| heap / alloc profile | allocation pressure와 GC 연결 | `go test -memprofile=mem.out ./pkg` |
+| `GODEBUG=schedtrace=...` | scheduler snapshot과 run queue pressure | `GODEBUG=schedtrace=1000,scheddetail=1 go test ./pkg` |
+
+## 어떤 도구부터 볼까
+
+| 증상 | 먼저 볼 것 | 이유 |
+| --- | --- | --- |
+| "요청이 멈추는데 어디가 문제인지 모르겠다" | trace | runnable, blocked, syscall, GC 흐름을 한 번에 봄 |
+| "lock이 뜨거운 것 같다" | mutex profile | contended lock 지점을 바로 보여줌 |
+| "worker가 영원히 기다리는 것 같다" | block profile | channel, select, cond 같은 wait 지점을 찍어줌 |
+| "CPU는 괜찮은데 지연이 튄다" | trace + heap profile | GC나 queueing 문제일 수 있음 |
+| "scheduler가 이상해 보인다" | `schedtrace` 또는 trace | run queue buildup과 P 사용 상태를 봄 |
 
 ## execution trace
 
@@ -30,6 +44,20 @@ description: runtime trace, block profile, mutex profile, scheduler debug output
 - user region과 task.
 
 즉, "runtime이 실제로 뭘 하고 있는가"를 보기에 가장 좋은 출발점입니다.
+
+기본 workflow는 이렇습니다.
+
+```bash
+go test -trace=trace.out ./...
+go tool trace trace.out
+```
+
+전체 모듈이 너무 크면 좁혀서 봅니다.
+
+```bash
+go test -trace=trace.out ./examples/workerpool -run TestGenerateQuotesCancelsSlowJobsAfterError
+go tool trace trace.out
+```
 
 ## 작은 instrumentation 스케치
 
@@ -55,6 +83,28 @@ trace.WithRegion(ctx, "load-metadata", func() {
 
 profile은 이런 걸 눈에 보이게 만듭니다.
 
+자주 쓰는 커맨드는 이렇습니다.
+
+```bash
+go test -blockprofile=block.out ./...
+go tool pprof -http=:0 block.out
+
+go test -mutexprofile=mutex.out ./...
+go tool pprof -http=:0 mutex.out
+
+go test -memprofile=mem.out ./...
+go tool pprof -http=:0 mem.out
+```
+
+장기 실행 프로세스에서 직접 profile을 수집할 땐 runtime knob도 알아야 합니다.
+
+```go
+runtime.SetBlockProfileRate(1)
+runtime.SetMutexProfileFraction(5)
+```
+
+다만 이 값들은 오버헤드가 있습니다. 평상시 상시 최고 강도로 두기보다, 짧은 진단 구간이나 디버그 모드에서 켜는 편이 낫습니다.
+
 ## scheduler debug output
 
 `GODEBUG=schedtrace=1000,scheddetail=1`은 trace만큼 세밀하지는 않지만 빠른 점검에는 유용합니다.
@@ -64,16 +114,16 @@ profile은 이런 걸 눈에 보이게 만듭니다.
 - spinning worker,
 - 전체 scheduler pressure.
 
+완전한 trace를 뜨기 전에 빠른 텍스트 스냅샷이 필요할 때 특히 쓸모가 있습니다.
+
 ## 실전 사용 순서
 
-먼저:
+이 순서를 고정해두면 좋습니다.
 
-```bash
-go test -trace=trace.out ./...
-go tool trace trace.out
-```
-
-그다음 contention 냄새가 나면 block / mutex profile로 넘어가면 됩니다.
+1. 믿을 수 있는 가장 작은 재현 경로를 만듭니다.
+2. 문제가 GC인지 queueing인지 syscall인지 아직 모르면 trace부터 뜹니다.
+3. trace가 waiting/lock 쪽을 가리키면 block / mutex profile로 내려갑니다.
+4. trace는 맞는데 읽기 어렵다면 task / region annotation을 추가하고 다시 봅니다.
 
 ## 실패 패턴
 
@@ -83,9 +133,12 @@ go tool trace trace.out
 
 이 정도 관측으로는 scheduler state, lock contention, queue delay, GC interaction을 제대로 볼 수 없습니다. runtime 문제는 runtime-facing tool이 필요합니다.
 
+또 다른 실패 패턴은 질문 없이 profile만 모으는 것입니다. lock 문제를 찾는지, queue delay를 찾는지, allocation churn을 찾는지 명확하지 않으면 결과가 그냥 노이즈가 됩니다.
+
 ## 공식 자료
 
 - [runtime/trace package docs](https://pkg.go.dev/runtime/trace)
+- [net/http/pprof package docs](https://pkg.go.dev/net/http/pprof)
 
 ## Practical takeaway
 

--- a/docs/testing/leaks-and-shutdowns.md
+++ b/docs/testing/leaks-and-shutdowns.md
@@ -14,6 +14,10 @@ Many concurrency regressions are lifecycle bugs:
 
 These are not always race detector failures. You need explicit tests for them.
 
+:::tip Quick takeaway
+If a component has `Start`, `Run`, `Submit`, or `Check`, it also has a lifetime contract. Good tests prove both the admission path and the exit path.
+:::
+
 ## What to verify
 
 For any nontrivial concurrent component, write tests that prove:
@@ -22,6 +26,18 @@ For any nontrivial concurrent component, write tests that prove:
 2. rejected work fails clearly once shutdown begins,
 3. blocked goroutines have an escape path,
 4. shutdown honors a hard deadline.
+
+## A shutdown contract worth testing
+
+Before writing tests, make the contract concrete. A good concurrent component usually answers all of these:
+
+- what work is still accepted after shutdown begins,
+- whether already accepted work drains, cancels, or is dropped,
+- which error the caller sees after admission is closed,
+- how long shutdown may wait,
+- who owns background goroutines and when they are guaranteed to exit.
+
+If the implementation cannot answer those questions, the tests will stay vague too.
 
 ## Example checklist
 
@@ -41,6 +57,23 @@ The test does not only assert an error. It asserts that slow jobs observe cancel
 
 ## Useful test shapes
 
+### Admission closes once shutdown starts
+
+```go
+func TestSubmitRejectedAfterShutdown(t *testing.T) {
+	processor := newProcessor(t)
+
+	require.NoError(t, processor.Shutdown(context.Background()))
+
+	err := processor.Submit(context.Background(), Event{OrderID: "ord-1"})
+	if !errors.Is(err, ErrClosed) {
+		t.Fatalf("Submit error = %v, want ErrClosed", err)
+	}
+}
+```
+
+This is the test that proves callers get a stable answer instead of "sometimes blocked, sometimes accepted."
+
 ### Deadline-bounded shutdown
 
 ```go
@@ -52,6 +85,56 @@ if err := processor.Shutdown(ctx); err == nil {
 }
 ```
 
+### Blocked sender must have an escape path
+
+```go
+func TestWorkerExitsOnCancel(t *testing.T) {
+	done := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		defer close(done)
+		runWorker(ctx)
+	}()
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("worker did not exit after cancellation")
+	}
+}
+```
+
+The point is not the `100ms`. The point is the explicit completion signal. The timeout only prevents the test from hanging forever.
+
+### Caller-abandoned reply path
+
+```go
+func TestReplyPathDoesNotLeakAfterCallerTimeout(t *testing.T) {
+	release := make(chan struct{})
+	broker := newBroker(func() Result {
+		<-release
+		return Result{}
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	if err := broker.Check(ctx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Check error = %v, want deadline exceeded", err)
+	}
+
+	close(release)
+	if err := broker.Check(context.Background()); err != nil {
+		t.Fatalf("follow-up request failed after timeout path: %v", err)
+	}
+}
+```
+
+This is the pattern behind `examples/requestreply/requestreply_test.go`: prove that one abandoned caller does not poison the whole broker.
+
 ### Leak detection by completion protocol
 
 Instead of counting goroutines globally, prefer explicit completion signals:
@@ -61,6 +144,8 @@ Instead of counting goroutines globally, prefer explicit completion signals:
 - `context` cancellation plus wait.
 
 These are usually more robust than asserting raw goroutine counts.
+
+Raw goroutine counts can still be useful as a coarse smoke test in CI, but they are a poor primary oracle because the runtime and unrelated tests create background activity of their own.
 
 ## Failure pattern
 
@@ -88,6 +173,20 @@ The happy path almost never finds lifecycle bugs.
 ### Forgetting the caller-abandoned path
 
 Any background worker or broker that replies to a caller should be tested for the case where the caller times out or leaves first.
+
+### Reusing `t.Context()` inside cleanup
+
+`testing.T.Context()` is canceled just before cleanup runs. If teardown needs a live context, create a fresh bounded background context in the cleanup function instead of reusing `t.Context()`.
+
+## A practical review checklist
+
+When you review a lifecycle test, ask:
+
+1. Does the test prove when admission closes?
+2. Does it prove how accepted work ends?
+3. Does every blocked goroutine have a cancellation or close path?
+4. Does the test use explicit completion, not "sleep and hope"?
+5. Does teardown finish within a bounded deadline?
 
 ## Practical takeaway
 

--- a/docs/testing/race-detector.md
+++ b/docs/testing/race-detector.md
@@ -7,6 +7,18 @@ description: Use Go's race detector to catch unsynchronized shared-memory access
 
 The race detector is the first tool you should run against nontrivial concurrency code.
 
+:::tip Quick takeaway
+`go test -race` is the minimum bar for concurrent Go, not the finish line. It is excellent at catching missing synchronization around shared memory, and useless for proving shutdown, leak, or timeout correctness by itself.
+:::
+
+## Mental model
+
+The detector is asking one narrow question:
+
+> Did two goroutines touch the same memory concurrently without a valid happens-before edge between them?
+
+That is why it pairs naturally with the [Go Memory Model](https://go.dev/ref/mem). If your design relies on ownership transfer through channels, mutexes, atomics, or `WaitGroup` completion, the detector helps confirm that the code actually follows that contract.
+
 ## What it catches
 
 It detects data races: concurrent accesses to the same memory location where at least one access is a write and there is no synchronization edge between them.
@@ -16,6 +28,8 @@ Typical examples:
 - reading a map while another goroutine writes it,
 - mutating shared state outside the channel protocol that is supposed to protect it,
 - forgetting to lock around a cache update.
+
+The practical reading is simple: it catches unsynchronized shared mutable memory, not general concurrency bugs.
 
 ## Tiny race example
 
@@ -29,6 +43,31 @@ func TestRacyMap(t *testing.T) {
 ```
 
 That code may appear to "work" in a casual run. Under `-race`, it is exactly the kind of bug you want flagged immediately.
+
+Some map races panic even without `-race`, but many other races do not. The detector matters because most unsafe shared-state bugs are not that obvious.
+
+## A design bug that still passes `-race`
+
+This code is race-free and still broken:
+
+```go
+func fetchWithTimeout(ctx context.Context) error {
+	reply := make(chan Result)
+
+	go func() {
+		reply <- slowQuery()
+	}()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-reply:
+		return nil
+	}
+}
+```
+
+If the caller times out first, the goroutine can block forever on `reply <- slowQuery()`. The race detector stays clean because there is no shared-memory race. This is why leak and shutdown tests still matter.
 
 ## What it does not prove
 
@@ -44,11 +83,53 @@ It also only catches executions that actually happen during the test run.
 
 ## How to use it
 
+Start with the full suite:
+
 ```bash
 go test -race ./...
 ```
 
+Then narrow it when you need faster iteration:
+
+```bash
+go test -race ./examples/workerpool -run TestGenerateQuotesCancelsSlowJobsAfterError
+go test -race -count=20 -shuffle=on ./...
+go test -race -cpu=1,4 ./...
+```
+
+Useful patterns:
+
+| Command | Use it for |
+| --- | --- |
+| `go test -race ./...` | module-wide baseline |
+| `go test -race ./pkg -run TestName` | quick fix/verify loop on one test |
+| `go test -race -count=20 -shuffle=on ./...` | shaking out schedule-sensitive paths |
+| `go test -race -cpu=1,4 ./...` | catching code that only breaks at higher parallelism |
+
 The detector is slower and more expensive than ordinary test runs. That is normal and worth the cost for concurrency-heavy code.
+
+## How to read a race report
+
+A report gives you two things that matter:
+
+1. the conflicting accesses,
+2. the goroutine creation stacks that made those accesses possible.
+
+Do not stop at the two lines that raced. The real bug is usually one layer higher:
+
+- a state owner got bypassed,
+- a map escaped the mutex that was meant to guard it,
+- a background goroutine outlived the context that defined its lifetime,
+- a refactor added a fast path that skipped synchronization.
+
+## What to do after a report
+
+Use a fixed workflow:
+
+1. Identify the piece of mutable state that has lost a clear owner.
+2. Decide whether it should be guarded by ownership, a mutex, atomics, or message passing.
+3. Remove the accidental side path instead of stacking random locks on top.
+4. Re-run the smallest relevant `-race` command first, then the full suite.
 
 ## The right workflow
 
@@ -71,12 +152,15 @@ func TestSomething(t *testing.T) {
 
 Tests like this often pass just long enough to create false confidence. Run them with `-race`, then replace timing luck with real synchronization.
 
+Another common failure pattern is assuming a clean race run means the protocol is correct. If the bug is "goroutine never exits" or "reply path wedges after timeout," `-race` may stay green forever.
+
 ## Good design patterns under `-race`
 
 - single owner goroutine per mutable state machine,
 - `map + mutex` with short critical sections,
 - explicit reply channels for one-shot responses,
-- cancellation paths that cannot leave background goroutines mutating shared state after the test returns.
+- cancellation paths that cannot leave background goroutines mutating shared state after the test returns,
+- tests that drive real protocol completion instead of sleeping and hoping.
 
 ## Official reading
 

--- a/docs/testing/synctest.md
+++ b/docs/testing/synctest.md
@@ -30,6 +30,12 @@ Inside a `synctest.Test` bubble:
 
 This lets you test timeout logic without waiting in wall-clock time.
 
+The mental model is:
+
+- the bubble owns the goroutines it starts,
+- the bubble owns its fake clock,
+- time moves only when the bubble has reached a stable blocked point.
+
 ## A practical example
 
 ```go
@@ -55,6 +61,35 @@ func TestContextTimeout(t *testing.T) {
 
 That test is deterministic and immediate. No "sleep 200ms and hope."
 
+## Another useful example: `context.AfterFunc`
+
+```go
+func TestAfterFuncRunsAfterCancel(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		called := false
+		context.AfterFunc(ctx, func() {
+			called = true
+		})
+
+		synctest.Wait()
+		if called {
+			t.Fatal("AfterFunc ran before cancellation")
+		}
+
+		cancel()
+		synctest.Wait()
+		if !called {
+			t.Fatal("AfterFunc did not run after cancellation")
+		}
+	})
+}
+```
+
+This is the kind of test that used to invite arbitrary sleeps and now does not need any.
+
 ## What "durably blocked" means
 
 This definition matters.
@@ -68,7 +103,45 @@ According to the standard library docs, operations such as:
 
 can durably block a goroutine inside the bubble.
 
-By contrast, network I/O and external syscalls are not durably blocked in the same way. That is why `synctest` works best with self-contained tests and fake dependencies.
+By contrast, some things may block but are **not** durably blocked:
+
+- `sync.Mutex` or `sync.RWMutex` lock acquisition,
+- network I/O,
+- system calls,
+- events driven by goroutines outside the bubble.
+
+That distinction is why `synctest` works best with self-contained tests and fake dependencies.
+
+## What it is good at and where it is a poor fit
+
+| Great fit | Poor fit |
+| --- | --- |
+| timeout and retry loops driven by `time` | real sockets and live network services |
+| cancellation propagation | goroutines started outside the bubble |
+| internal worker coordination | external processes and OS-driven events |
+| `AfterFunc`, timers, tickers | tests that depend on `sync.Mutex` blocking semantics |
+
+If you need protocol-level I/O but still want bubble control, prefer fake in-process transports such as `net.Pipe` over loopback sockets.
+
+## Isolation rules that matter in practice
+
+The bubble is stricter than it first appears:
+
+- a channel, timer, or ticker created in the bubble is associated with that bubble,
+- operating on those bubbled objects from outside the bubble panics,
+- a `WaitGroup` becomes bubble-associated on its first `Add` or `Go`,
+- package-global `WaitGroup` values are a technical limitation; prefer test-owned or heap-allocated wait groups instead.
+
+This is one reason `synctest` pushes you toward cleaner ownership boundaries in tests.
+
+## Deadlock behavior
+
+Two rules are easy to miss:
+
+1. if every goroutine is durably blocked and the next timer can fire, fake time advances,
+2. if every goroutine is durably blocked and nothing can make progress, `synctest.Test` panics with a deadlock.
+
+Also, fake time stops advancing once the root goroutine for the bubble exits. That means background work must still be owned and awaited properly.
 
 ## Where it fits well
 
@@ -86,6 +159,8 @@ It does not replace:
 - integration tests with real networking,
 - trace and profile analysis,
 - leak tests for code that interacts with external systems.
+
+Use it as a new layer in the stack, not as a universal concurrency test runner.
 
 ## Failure pattern
 
@@ -105,7 +180,7 @@ time.Sleep(10 * time.Millisecond) // bad: timing guess
 ## Official reading
 
 - [Testing Time (Go Blog)](https://go.dev/blog/testing-time)
-- [Go 1.24 Release Notes](https://go.dev/doc/go1.24)
+- [testing/synctest package docs](https://pkg.go.dev/testing/synctest)
 
 ## Practical takeaway
 

--- a/docs/testing/tracing-and-profiling.md
+++ b/docs/testing/tracing-and-profiling.md
@@ -9,15 +9,29 @@ Some concurrency bugs are visible only when you look at runtime behavior directl
 
 For those cases, unit tests are not enough by themselves.
 
+:::tip Quick takeaway
+If the question is "what is the runtime actually doing," start with an execution trace. If the question is "where is time being lost," move next to block, mutex, heap, or CPU profiles.
+:::
+
 ## The main tools
 
-| Tool | Best for |
-| --- | --- |
-| `go test -trace` | goroutine states, scheduler activity, netpoll, syscalls, GC |
-| block profile | where goroutines wait on blocking operations |
-| mutex profile | lock contention hotspots |
-| heap / alloc profile | allocation pressure that feeds GC and latency |
-| `GODEBUG=schedtrace=...` | scheduler snapshots and run queue pressure |
+| Tool | Best for | Typical command |
+| --- | --- | --- |
+| `go test -trace` | goroutine states, scheduler activity, netpoll, syscalls, GC | `go test -trace=trace.out ./pkg` |
+| block profile | where goroutines wait on blocking operations | `go test -blockprofile=block.out ./pkg` |
+| mutex profile | lock contention hotspots | `go test -mutexprofile=mutex.out ./pkg` |
+| heap / alloc profile | allocation pressure that feeds GC and latency | `go test -memprofile=mem.out ./pkg` |
+| `GODEBUG=schedtrace=...` | scheduler snapshots and run queue pressure | `GODEBUG=schedtrace=1000,scheddetail=1 go test ./pkg` |
+
+## Which tool first?
+
+| Symptom | Start with | Why |
+| --- | --- | --- |
+| "Requests stall, but I do not know where" | trace | shows runnable, blocked, syscall, GC, and wakeup flow together |
+| "It feels lock-heavy" | mutex profile | shows where contended locks are held |
+| "Workers are waiting forever" | block profile | points at channel, select, cond, and other blocking sites |
+| "CPU is fine, but latency spikes during load" | trace plus heap profile | often GC or queueing, not raw CPU |
+| "The scheduler looks unhealthy" | `schedtrace` or trace | shows run-queue growth and idle/busy processor state |
 
 ## Execution traces
 
@@ -30,6 +44,20 @@ The `runtime/trace` package and `go test -trace=trace.out` let you inspect:
 - user regions and tasks.
 
 This is the best first tool when the question is "what is the runtime actually doing?"
+
+The basic workflow is:
+
+```bash
+go test -trace=trace.out ./...
+go tool trace trace.out
+```
+
+When the full module is too noisy, narrow it:
+
+```bash
+go test -trace=trace.out ./examples/workerpool -run TestGenerateQuotesCancelsSlowJobsAfterError
+go tool trace trace.out
+```
 
 ## Tiny instrumentation sketch
 
@@ -55,6 +83,28 @@ If a service feels "concurrent but slow," the real issue may be:
 
 Profiles make these visible.
 
+Useful commands:
+
+```bash
+go test -blockprofile=block.out ./...
+go tool pprof -http=:0 block.out
+
+go test -mutexprofile=mutex.out ./...
+go tool pprof -http=:0 mutex.out
+
+go test -memprofile=mem.out ./...
+go tool pprof -http=:0 mem.out
+```
+
+If you are collecting profiles in a long-running process instead of a test binary, the relevant runtime knobs are:
+
+```go
+runtime.SetBlockProfileRate(1)
+runtime.SetMutexProfileFraction(5)
+```
+
+Use those deliberately. Full block profiling and aggressive mutex sampling have real overhead, so they are usually better as a targeted debug mode than a permanent production default.
+
 ## Scheduler debug output
 
 `GODEBUG=schedtrace=1000,scheddetail=1` is crude compared with traces, but still useful for quick inspection:
@@ -64,16 +114,16 @@ Profiles make these visible.
 - spinning workers,
 - overall scheduler pressure.
 
+It is especially useful when you want a fast text snapshot before taking a full trace, or when a workload is hard to reproduce under a test harness.
+
 ## How to use this in practice
 
-Start with:
+Use a fixed escalation order:
 
-```bash
-go test -trace=trace.out ./...
-go tool trace trace.out
-```
-
-Then escalate to block or mutex profiles when the problem smells like contention.
+1. Reproduce the problem with the narrowest test, benchmark, or workload you trust.
+2. Take an execution trace first when you do not yet know whether the issue is GC, queueing, scheduler pressure, or syscalls.
+3. Move to block or mutex profiles when the trace points toward waiting or contention.
+4. Add task and region annotations if the trace is technically correct but hard to interpret.
 
 ## Failure pattern
 
@@ -83,9 +133,12 @@ Then escalate to block or mutex profiles when the problem smells like contention
 
 That is not enough once the issue is scheduler state, lock contention, queue delay, or GC interaction. Runtime behavior needs runtime-facing tools.
 
+Another common failure is collecting a profile without a question. If you do not know whether you are looking for lock contention, queue delay, or allocation churn, the output becomes noise.
+
 ## Official reading
 
 - [runtime/trace package docs](https://pkg.go.dev/runtime/trace)
+- [net/http/pprof package docs](https://pkg.go.dev/net/http/pprof)
 
 ## Practical takeaway
 


### PR DESCRIPTION
## Summary
- expand the thinnest English and Korean testing docs with more concrete code sketches and command examples
- clarify what `-race`, `testing/synctest`, traces, and lifecycle tests do and do not prove
- tighten guidance around shutdown contracts, cleanup contexts, profiling workflow, and bubble isolation rules

## Testing
- `go test ./...`
- `npm run docs:build`

Closes #37.
