### PR TITLE
Add regulated systems production chapter

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -92,6 +92,7 @@ const enSidebar = [
     items: [
       { text: "Overview", link: "/production/" },
       { text: "Large-Scale Go Systems", link: "/production/large-scale-go-systems" },
+      { text: "Regulated Go Systems", link: "/production/regulated-systems" },
       { text: "Temporal and Durable Execution", link: "/production/temporal-durable-execution" },
       { text: "Open-Source Case Studies", link: "/production/open-source-case-studies" },
       { text: "Go Open-Source Histories", link: "/production/go-open-source-histories" },
@@ -211,6 +212,7 @@ const koSidebar = [
     items: [
       { text: "개요", link: "/ko/production/" },
       { text: "대규모 Go 시스템", link: "/ko/production/large-scale-go-systems" },
+      { text: "규제 환경의 Go 시스템", link: "/ko/production/regulated-systems" },
       { text: "Temporal과 Durable Execution", link: "/ko/production/temporal-durable-execution" },
       { text: "오픈소스 사례", link: "/ko/production/open-source-case-studies" },
       { text: "Go 오픈소스 역사 읽기", link: "/ko/production/go-open-source-histories" },

--- a/docs/index.md
+++ b/docs/index.md
@@ -140,6 +140,7 @@ features:
 | How to test timeout-heavy code without real sleeps | [Deterministic Tests with synctest](/testing/synctest) |
 | How to keep Postgres, Redis, and container-backed integration tests clean, isolated, and deterministic | [Integration Testing with Testcontainers](/testing/integration-testcontainers) |
 | How a durable workflow engine like Temporal becomes a Go system of history, matching, and workers | [Temporal and Durable Execution](/production/temporal-durable-execution) |
+| How to combine event sourcing, erasure, retention, and audit constraints in a real Go system | [Regulated Go Systems](/production/regulated-systems) |
 | Why so many influential infrastructure projects ended up in Go in the first place | [Go Open-Source Histories](/production/go-open-source-histories) |
 | What large Go production systems care about beyond toy patterns | [Large-Scale Go Systems](/production/large-scale-go-systems) |
 | How major Go projects actually build queues, transport loops, stopper lifetimes, and pools | [Open-Source Case Studies](/production/open-source-case-studies) |

--- a/docs/ko/index.md
+++ b/docs/ko/index.md
@@ -140,6 +140,7 @@ features:
 | timeout-heavy 코드를 실제 sleep 없이 어떻게 테스트하는지 | [synctest로 결정적 테스트](/ko/testing/synctest) |
 | Postgres, Redis, container-backed 통합 테스트를 어떻게 깨끗하고 결정적으로 유지하는지 | [Testcontainers로 통합 테스트하기](/ko/testing/integration-testcontainers) |
 | Temporal 같은 durable workflow 엔진이 history, matching, worker를 가진 Go 시스템으로 어떻게 구성되는지 | [Temporal과 Durable Execution](/ko/production/temporal-durable-execution) |
+| event sourcing, erasure, retention, audit 제약을 실제 Go 시스템에서 어떻게 함께 풀어야 하는지 | [규제 환경의 Go 시스템](/ko/production/regulated-systems) |
 | 왜 중요한 인프라 오픈소스들이 하필 Go를 많이 택했는지 | [Go 오픈소스 역사 읽기](/ko/production/go-open-source-histories) |
 | 토이 패턴을 넘어 대규모 Go 운영에서 무엇이 중요한지 | [대규모 Go 시스템](/ko/production/large-scale-go-systems) |
 | 주요 Go 오픈소스가 queue, transport loop, stopper lifetime, pool을 어떻게 구현하는지 | [오픈소스 사례](/ko/production/open-source-case-studies) |

--- a/docs/ko/production/index.md
+++ b/docs/ko/production/index.md
@@ -14,6 +14,7 @@ description: Go 코드가 실제 대규모 트래픽을 받을 때 중요해지�
 | 주제 | 왜 중요한가 |
 | --- | --- |
 | [대규모 Go 시스템](/ko/production/large-scale-go-systems) | 런타임 지식을 실제 latency, memory, overload, shutdown 규칙으로 바꿉니다 |
+| [규제 환경의 Go 시스템](/ko/production/regulated-systems) | event sourcing, cryptographic erase, retention, audit 제약이 Go 시스템 설계를 어떻게 바꾸는지 설명합니다 |
 | [Temporal과 Durable Execution](/ko/production/temporal-durable-execution) | 현대 workflow 엔진이 history shard, task queue, worker polling을 가진 Go 시스템으로 어떻게 구성되는지 보여줍니다 |
 | [오픈소스 사례](/ko/production/open-source-case-studies) | Kubernetes, etcd, Prometheus, NATS, gRPC-Go, CockroachDB, go-redis가 concurrency policy를 어떻게 코드에 드러내는지 봅니다 |
 | [Go 오픈소스 역사 읽기](/ko/production/go-open-source-histories) | 왜 Go가 인프라 소프트웨어에 강했는지, 주요 프로젝트의 공개 시점과 형태를 통해 읽습니다 |

--- a/docs/ko/production/regulated-systems.md
+++ b/docs/ko/production/regulated-systems.md
@@ -1,0 +1,353 @@
+---
+title: 규제 환경의 Go 시스템
+description: event sourcing, cryptographic erase, retention, legal hold, audit 제약 아래에서 Go 시스템을 설계하는 방법을 설명합니다.
+---
+
+# 규제 환경의 Go 시스템
+
+가장 어려운 프로덕션 Go 시스템은 단지 빠르거나 concurrent한 시스템이 아닙니다.
+
+규제를 받는 시스템입니다.
+
+이런 질문에 답해야 합니다.
+
+- canonical event log에는 어떤 데이터를 넣어도 되는가
+- 지워야 하는 데이터와 남겨야 하는 비즈니스 기록을 어떻게 분리할 것인가
+- 데이터는 얼마나 오래 보관해야 하는가
+- backup, cache, search index는 어떻게 정리할 것인가
+- erase나 purge workflow가 실제로 끝났다는 사실을 어떻게 증명할 것인가
+
+:::warning 법률 자문이 아닙니다
+이 페이지는 privacy / audit-sensitive 시스템을 위한 엔지니어링 패턴 문서입니다. 실제 retention, disclosure, erasure 의무는 관할권, 계약, 산업 규정에 따라 달라집니다.
+:::
+
+## 왜 이 주제가 중요한가
+
+긴장은 분명합니다.
+
+- event sourcing은 durable한 append-only history를 원하고
+- GDPR 같은 privacy 체계는 data minimization, storage limitation, erasure pressure를 만들며
+- NIST SP 800-88 같은 보안 가이드는 key handling이 맞다면 cryptographic erase를 실질적 sanitization 기법으로 인정합니다
+
+즉, "그냥 immutable event에 다 넣고 영원히 보관하자"는 건 프로덕션 설계가 아니라 나중에 compliance review에서 터질 구조입니다.
+
+## 가장 중요한 엔지니어링 규칙
+
+나중에 철회되거나 지워질 수 있는 개인 데이터를, 영원히 보존하고 싶은 경계에 직접 넣지 마십시오.
+
+기본 구조는 이렇습니다.
+
+1. canonical event log는 business fact 중심으로 유지하고
+2. 민감한 개인정보는 별도 boundary 뒤에 두고
+3. 그 민감 데이터는 explicit key ownership 하에 암호화하며
+4. erasure / retention workflow를 1급 background job으로 만들고
+5. audit trail에는 지워진 payload가 아니라 workflow 완료 사실만 남깁니다
+
+## 규제가 시스템 설계를 어떻게 바꾸는가
+
+GDPR 원문은 최종 해석은 법무가 하더라도 시스템 설계에 직접 영향을 줍니다.
+
+- Article 5는 data minimization과 storage limitation을 요구하고
+- Article 17은 erasure pressure를 만들며
+- Article 25는 privacy by design / by default를 요구합니다
+
+이건 policy 문서만의 문제가 아니라 architecture 문제입니다.
+
+Go 서비스가 direct identifier를 immutable stream, hot projection, cache, log, object storage에 모두 흩뿌린다면, erase path는 이미 필요 이상으로 어려워집니다.
+
+## 규제가 달라도 요구사항 패턴은 자주 반복된다
+
+규정 이름이 꼭 GDPR이 아니더라도, 엔지니어링 압력은 비슷한 경우가 많습니다.
+
+- subject에 연결된 일부 데이터는 erase 또는 anonymize되어야 하고
+- 일부 business record는 정해진 기간 동안 retention되어야 하며
+- legal hold나 조사 상태에서는 deletion이 멈춰야 하고
+- 보안 검토에서는 방어 가능한 sanitization 설명이 필요하며
+- audit / risk 팀은 workflow가 실제로 실행됐다는 증거를 원합니다
+
+그래서 이 페이지의 패턴은 privacy law, 산업별 retention 정책, 내부 governance control에도 꽤 잘 일반화됩니다.
+
+## 실전 아키텍처 형태
+
+```mermaid
+flowchart LR
+    A["Command / API layer"] --> B["Event store<br/>business facts only"]
+    A --> C["PII vault<br/>encrypted subject data"]
+    B --> D["Projection rebuilders"]
+    C --> D
+    B --> E["Audit log"]
+    F["Key management"] --> C
+    G["Erasure workflow"] --> C
+    G --> D
+    G --> E
+    H["Retention / legal hold service"] --> C
+    H --> D
+    H --> E
+```
+
+이 구조가 해결하는 건 분명합니다.
+
+- event store는 business history를 유지하고
+- PII vault는 delete, redact, cryptographic erase가 가능하며
+- projection은 삭제된 subject 데이터를 다시 살려내지 않게 rebuild할 수 있고
+- retention / legal hold는 tribal knowledge가 아니라 explicit workflow가 됩니다
+
+## 규제 환경에서의 event sourcing
+
+event sourcing은 여전히 쓸 수 있습니다. 다만 boundary를 엄격하게 잡아야 합니다.
+
+### 좋은 event 형태
+
+```go
+type OrderPlaced struct {
+	EventID         string
+	AggregateID     string
+	SubjectRef      string
+	PlacedAt        time.Time
+	TotalCents      int64
+	Currency        string
+	ShippingZone    string
+	CustomerTier    string
+	EncryptedPIIRef string
+}
+```
+
+중요한 점은:
+
+- `SubjectRef`는 email이나 주민번호가 아니라 내부 참조값이고
+- `EncryptedPIIRef`는 다른 저장 경계를 가리키며
+- canonical event는 여전히 state rebuild에 필요한 business meaning을 유지한다는 점입니다
+
+### 나쁜 event 형태
+
+```go
+type OrderPlaced struct {
+	EventID      string
+	AggregateID  string
+	Email        string
+	Phone        string
+	Street       string
+	PassportNo   string
+	CardLastFour string
+}
+```
+
+이건 한 번은 편하고 그 뒤로는 계속 비쌉니다.
+
+직접적인 personal data를 immutable append-only stream에 넣는 순간, replay, replica, backup, analytics export, incident dump까지 모두 cleanup burden을 떠안게 됩니다.
+
+## "Crypto-shredding"의 실체는 cryptographic erase
+
+실무에서는 흔히 crypto-shredding이라고 부르지만, 더 공식적인 표현은 cryptographic erase입니다.
+
+아이디어는 단순합니다.
+
+- 민감 payload를 data encryption key로 암호화하고
+- 그 key를 명시적인 계층과 ownership 아래 두고
+- 해당 payload를 복구 불가능하게 해야 할 때 관련 key material을 파기합니다
+
+이 패턴은 key boundary가 정확할 때만 의미가 있습니다.
+
+### 단순화한 Go 스케치
+
+```go
+type PersonalRecord struct {
+	SubjectRef string
+	KeyID      string
+	Ciphertext []byte
+}
+
+type Vault interface {
+	Store(ctx context.Context, r PersonalRecord) error
+	DeleteMetadata(ctx context.Context, subjectRef string) error
+	ListBySubject(ctx context.Context, subjectRef string) ([]PersonalRecord, error)
+}
+
+type KeyManager interface {
+	DestroyKey(ctx context.Context, keyID string) error
+}
+
+func CryptographicallyEraseSubject(ctx context.Context, vault Vault, km KeyManager, subjectRef string) error {
+	records, err := vault.ListBySubject(ctx, subjectRef)
+	if err != nil {
+		return err
+	}
+
+	for _, record := range records {
+		if err := km.DestroyKey(ctx, record.KeyID); err != nil {
+			return err
+		}
+	}
+
+	return vault.DeleteMetadata(ctx, subjectRef)
+}
+```
+
+여기서 중요한 건 syntax가 아니라, 파기 가능한 key boundary가 설계 안에 실제로 존재하느냐입니다.
+
+### cryptographic erase가 약해지는 경우
+
+단순히 "암호화했음"으로는 부족합니다.
+
+다음 경우 이 패턴은 약해지거나 의미가 거의 없어집니다.
+
+- 하나의 장수 master key가 너무 많은 unrelated data를 보호하는 경우
+- plaintext copy가 projection, log, cache, data lake, support dump에 이미 퍼진 경우
+- backup에 같은 live key가 그대로 남아 있는 경우
+- 어떤 subject가 어떤 key로 보호됐는지 증명할 수 없는 경우
+- erase 중에도 application이 해당 subject에 대한 새 쓰기를 계속 받는 경우
+
+## Retention과 legal hold는 workflow 문제다
+
+대부분의 규제 시스템은 erase만 하지 않습니다. 일정 기간 retention을 요구하고, legal hold가 걸리면 삭제를 멈추고, 어떤 policy가 적용됐는지 감사 가능해야 합니다.
+
+즉, retention은 문서 없는 cron job이 아니라 state machine이어야 합니다.
+
+```go
+type RetentionClass string
+
+const (
+	RetentionCustomerPII RetentionClass = "customer_pii"
+	RetentionInvoice     RetentionClass = "invoice"
+)
+
+type RetentionPolicy struct {
+	Class       RetentionClass
+	KeepFor     time.Duration
+	LegalHold   bool
+	ArchiveOnly bool
+}
+
+func ShouldPurge(now, createdAt time.Time, p RetentionPolicy) bool {
+	if p.LegalHold {
+		return false
+	}
+	return now.Sub(createdAt) >= p.KeepFor
+}
+```
+
+프로덕션 규칙은 간단합니다.
+
+- policy는 typed여야 하고
+- policy decision은 inspection 가능해야 하며
+- legal hold는 일반 purge보다 우선하고
+- purge는 idempotent하며 restart-safe해야 합니다
+
+## Go 서비스에서의 erasure workflow
+
+실전에서 erasure는 거의 항상 단일 SQL `DELETE`가 아닙니다.
+
+보통은 이런 흐름에 가깝습니다.
+
+```go
+func HandleEraseRequest(ctx context.Context, subjectRef string) error {
+	if err := admission.StopNewWrites(ctx, subjectRef); err != nil {
+		return err
+	}
+
+	if err := vault.CryptographicallyErase(ctx, subjectRef); err != nil {
+		return err
+	}
+
+	if err := projections.RedactSubject(ctx, subjectRef); err != nil {
+		return err
+	}
+
+	if err := search.RemoveSubject(ctx, subjectRef); err != nil {
+		return err
+	}
+
+	return audit.Append(ctx, AuditEvent{
+		Kind:       "subject_erasure_completed",
+		SubjectRef: subjectRef,
+		At:         time.Now(),
+	})
+}
+```
+
+이 구조가 좋은 이유는:
+
+- 먼저 admission boundary를 닫고
+- vault, projection, search를 각각 별도 cleanup target으로 다루며
+- 민감 payload를 다시 저장하지 않고도 workflow completion을 기록하기 때문입니다
+
+## Event sourcing과 erasure의 진짜 tradeoff
+
+질문은 "event sourcing이 erasure를 절대 만족시킬 수 있나?"가 아닙니다.
+
+올바른 질문은 이것입니다.
+
+> immutable history가 revocable personal payload 없이도 business truth를 유지할 수 있는가?
+
+그렇다면 event sourcing은 여전히 강한 선택지입니다.
+
+그렇지 않다면 다음 중 하나가 필요합니다.
+
+- indirection이 들어간 다른 event model
+- personal payload를 redactable side store에 두는 split history
+- 해당 record에 대해서는 완전한 append-only가 아닌 시스템
+- 혹은 아예 다른 architecture
+
+## 실패 패턴
+
+### email, address, ID를 immutable event에 바로 넣는 것
+
+가장 흔한 구조적 실수입니다.
+
+### projection만 지우면 끝이라고 생각하는 것
+
+PII는 보통 한 군데에만 있지 않습니다. search index, cache, analytics export도 같이 봐야 합니다.
+
+### 모든 tenant나 subject가 같은 key hierarchy를 공유하는 것
+
+키 하나의 blast radius가 넓을수록 erase boundary는 약해집니다.
+
+### erasure를 best effort로 만드는 것
+
+resume, retry, audit가 안 되는 workflow는 꼭 필요할 때 실패합니다.
+
+### audit log에 민감 payload를 다시 남기는 것
+
+audit trail은 workflow가 일어났음을 증명해야지, 삭제된 데이터를 복원할 수 있게 만들면 안 됩니다.
+
+## 왜 Go가 잘 맞는가
+
+이 문제 형태는 Go와 잘 맞습니다.
+
+- `context.Context`로 request / job lifetime을 명시하고
+- implicit script 대신 typed policy를 만들 수 있으며
+- retention, redaction, reconciliation을 background worker로 운영하고
+- SQL, Kafka, Redis, object storage 경계를 비교적 명확하게 감쌀 수 있고
+- 긴 workflow를 관측하고 테스트하기 쉽기 때문입니다
+
+Go가 data modeling을 대신해주지는 않습니다. 하지만 그 모델을 강제하는 control-plane 서비스를 만들기에는 매우 좋은 언어입니다.
+
+## 실전 판단 기준
+
+다음이면 regulated system에서도 event sourcing을 쓸 만합니다.
+
+- immutable log가 대부분 business fact 중심이고
+- 민감 payload가 indirection 뒤에 있으며
+- key ownership이 명시적이고
+- retention / erasure가 1급 workflow이며
+- rebuild / replay가 삭제된 personal data를 조용히 되살리지 않는 경우
+
+다음이면 조심하거나 다른 architecture를 택하는 편이 낫습니다.
+
+- 핵심 business event 자체가 대부분 personal data인 경우
+- downstream 시스템이 raw payload를 사방에 복제하는 경우
+- key destruction boundary를 보장할 수 없는 경우
+- compliance가 canonical history 자체의 in-place rewrite를 요구하는 경우
+
+## 공식 자료
+
+- [GDPR Article 5](https://eur-lex.europa.eu/eli/reg/2016/679/oj/eng)
+- [GDPR Article 17](https://eur-lex.europa.eu/eli/reg/2016/679/oj/eng)
+- [EDPB: Data protection by design and by default](https://www.edpb.europa.eu/sme-data-protection-guide/respect-individuals-rights/data-protection-design-and-default_en)
+- [NIST SP 800-88 Rev. 1](https://csrc.nist.gov/pubs/sp/800/88/r1/final)
+
+## Practical takeaway
+
+프로덕션 답은 "event sourcing이냐 regulation이냐"가 아닙니다.
+
+durable business history는 남기고, revocable personal data는 분리하고, erasure / retention workflow를 explicit하게 만들고, 그 workflow를 코드와 audit trail로 증명하는 것입니다.

--- a/docs/production/index.md
+++ b/docs/production/index.md
@@ -14,6 +14,7 @@ This section is about what changes when the code is no longer a neat example and
 | Topic | Why it matters |
 | --- | --- |
 | [Large-Scale Go Systems](/production/large-scale-go-systems) | Turns runtime knowledge into operating rules for latency, memory, shutdown, and overload |
+| [Regulated Go Systems](/production/regulated-systems) | Explains how event sourcing, cryptographic erase, retention, and audit constraints change Go system design |
 | [Temporal and Durable Execution](/production/temporal-durable-execution) | Shows how a modern workflow engine becomes a Go system of history shards, task queues, and worker polling |
 | [Open-Source Case Studies](/production/open-source-case-studies) | Shows how Kubernetes, etcd, Prometheus, NATS, gRPC-Go, CockroachDB, and go-redis make concurrency policy visible in real source code |
 | [Go Open-Source Histories](/production/go-open-source-histories) | Explains why Go became such a strong fit for infrastructure software and where to read the story in major projects |

--- a/docs/production/regulated-systems.md
+++ b/docs/production/regulated-systems.md
@@ -1,0 +1,355 @@
+---
+title: Regulated Go Systems
+description: Learn how to build Go systems under event sourcing, cryptographic erase, retention, legal hold, and audit constraints.
+---
+
+# Regulated Go Systems
+
+Some of the hardest production Go systems are not just fast or concurrent.
+
+They are regulated.
+
+They have to answer questions like:
+
+- what data is allowed in the canonical event log,
+- how erasure requests work without destroying required business records,
+- how long data must be retained,
+- what happens to backups, caches, and search indexes,
+- how to prove that an erase or purge workflow actually completed.
+
+:::warning Not legal advice
+This page is about engineering patterns for privacy- and audit-sensitive systems. It is not legal advice. Exact retention, disclosure, and erasure obligations depend on your jurisdiction, contract, and domain.
+:::
+
+## Why this topic matters
+
+The tension is real:
+
+- event sourcing wants durable, append-only history,
+- privacy regimes such as GDPR emphasize data minimization, storage limitation, and erasure rights,
+- security guidance such as NIST SP 800-88 recognizes cryptographic erase as a real sanitization technique when key handling is correct.
+
+That means "just store everything forever in immutable events" is not a production design. It is an accident waiting for a compliance review.
+
+## The high-level engineering rule
+
+Do not put revocable personal data directly into the part of the system you want to keep forever.
+
+The safe default shape is:
+
+1. keep the canonical event log focused on business facts,
+2. store sensitive personal data behind a separate boundary,
+3. encrypt that sensitive data with explicit key ownership,
+4. make erasure and retention workflows first-class background jobs,
+5. keep an audit trail of the workflow, not of the erased payload.
+
+## The regulatory pressure in plain English
+
+The official GDPR text matters for system design even if lawyers do the final interpretation:
+
+- Article 5 pushes data minimization and storage limitation,
+- Article 17 creates erasure pressure,
+- Article 25 pushes privacy by design and by default.
+
+Those are architecture concerns, not only policy concerns.
+
+If your Go service stores direct identifiers in immutable streams, hot projections, caches, logs, and object storage all at once, you have already made the erase path much harder than it needed to be.
+
+## The requirement families repeat across regulations
+
+Even when the rule is not literally GDPR, the engineering pressure often looks the same:
+
+- some subject-linked data must be erased or anonymized,
+- some business records must be retained for a defined period,
+- some deletion paths must pause under legal hold or investigation,
+- security review expects a defensible sanitization story,
+- audit and risk teams expect proof that the workflow ran.
+
+That is why the design patterns on this page generalize well to privacy laws, sector retention policies, and internal governance controls.
+
+## A practical architecture shape
+
+```mermaid
+flowchart LR
+    A["Command / API layer"] --> B["Event store<br/>business facts only"]
+    A --> C["PII vault<br/>encrypted subject data"]
+    B --> D["Projection rebuilders"]
+    C --> D
+    B --> E["Audit log"]
+    F["Key management"] --> C
+    G["Erasure workflow"] --> C
+    G --> D
+    G --> E
+    H["Retention / legal hold service"] --> C
+    H --> D
+    H --> E
+```
+
+This shape solves a real problem:
+
+- the event store can preserve business history,
+- the PII vault can be deleted, redacted, or cryptographically erased,
+- projections can be rebuilt without reintroducing deleted subject data,
+- retention and legal hold become explicit workflows instead of tribal knowledge.
+
+## Event sourcing under regulation
+
+Event sourcing is still viable in regulated systems, but only if you are disciplined about boundaries.
+
+### Good event shape
+
+```go
+type OrderPlaced struct {
+	EventID         string
+	AggregateID     string
+	SubjectRef      string
+	PlacedAt        time.Time
+	TotalCents      int64
+	Currency        string
+	ShippingZone    string
+	CustomerTier    string
+	EncryptedPIIRef string
+}
+```
+
+What is important here:
+
+- `SubjectRef` is a stable internal reference, not an email or passport number,
+- `EncryptedPIIRef` points to a different storage boundary,
+- the canonical event still carries enough business meaning to rebuild state.
+
+### Bad event shape
+
+```go
+type OrderPlaced struct {
+	EventID      string
+	AggregateID  string
+	Email        string
+	Phone        string
+	Street       string
+	PassportNo   string
+	CardLastFour string
+}
+```
+
+That is convenient once and expensive forever.
+
+If you write direct personal data into an immutable append-only stream, then every replay, replica, backup, analytics export, and incident dump inherits the cleanup burden.
+
+## Cryptographic erase is the real pattern behind "crypto-shredding"
+
+Teams often say "crypto-shredding." The more formal term is usually cryptographic erase.
+
+The idea is simple:
+
+- encrypt sensitive payloads with a data encryption key,
+- control that key through an explicit key hierarchy,
+- destroy the relevant key material when the payload must become irrecoverable.
+
+In practice, this only works if you are strict about key boundaries.
+
+### Simplified Go sketch
+
+```go
+type PersonalRecord struct {
+	SubjectRef string
+	KeyID      string
+	Ciphertext []byte
+}
+
+type Vault interface {
+	Store(ctx context.Context, r PersonalRecord) error
+	DeleteMetadata(ctx context.Context, subjectRef string) error
+	ListBySubject(ctx context.Context, subjectRef string) ([]PersonalRecord, error)
+}
+
+type KeyManager interface {
+	DestroyKey(ctx context.Context, keyID string) error
+}
+
+func CryptographicallyEraseSubject(ctx context.Context, vault Vault, km KeyManager, subjectRef string) error {
+	records, err := vault.ListBySubject(ctx, subjectRef)
+	if err != nil {
+		return err
+	}
+
+	for _, record := range records {
+		if err := km.DestroyKey(ctx, record.KeyID); err != nil {
+			return err
+		}
+	}
+
+	return vault.DeleteMetadata(ctx, subjectRef)
+}
+```
+
+The code is intentionally small. The important part is not syntax. The important part is that the design has a destroyable key boundary at all.
+
+### When cryptographic erase is weak
+
+It is not enough to say "the data was encrypted."
+
+Cryptographic erase becomes weak or meaningless when:
+
+- one long-lived master key protects too much unrelated data,
+- plaintext copies exist in projections, logs, caches, data lakes, or support dumps,
+- backups still contain the same live keys,
+- operators cannot prove which key protected which subject,
+- the application continues to accept new writes for the subject during erasure.
+
+## Retention and legal hold are workflow problems
+
+Most regulated systems do not only erase data. They also retain some data for explicit periods, suspend deletion under legal hold, and keep an auditable record of which policy fired.
+
+That means retention belongs in a state machine, not in an undocumented cron job.
+
+```go
+type RetentionClass string
+
+const (
+	RetentionCustomerPII RetentionClass = "customer_pii"
+	RetentionInvoice     RetentionClass = "invoice"
+)
+
+type RetentionPolicy struct {
+	Class       RetentionClass
+	KeepFor     time.Duration
+	LegalHold   bool
+	ArchiveOnly bool
+}
+
+func ShouldPurge(now, createdAt time.Time, p RetentionPolicy) bool {
+	if p.LegalHold {
+		return false
+	}
+	return now.Sub(createdAt) >= p.KeepFor
+}
+```
+
+The production rule is straightforward:
+
+- policy must be typed,
+- policy decisions must be inspectable,
+- legal hold must override normal purge,
+- purge must be idempotent and restart-safe.
+
+## Erasure workflow in a Go service
+
+In practice, erasure is rarely a single SQL `DELETE`.
+
+A real Go workflow usually looks more like this:
+
+```go
+func HandleEraseRequest(ctx context.Context, subjectRef string) error {
+	if err := admission.StopNewWrites(ctx, subjectRef); err != nil {
+		return err
+	}
+
+	if err := vault.CryptographicallyErase(ctx, subjectRef); err != nil {
+		return err
+	}
+
+	if err := projections.RedactSubject(ctx, subjectRef); err != nil {
+		return err
+	}
+
+	if err := search.RemoveSubject(ctx, subjectRef); err != nil {
+		return err
+	}
+
+	return audit.Append(ctx, AuditEvent{
+		Kind:       "subject_erasure_completed",
+		SubjectRef: subjectRef,
+		At:         time.Now(),
+	})
+}
+```
+
+Why this shape works:
+
+- it closes the admission boundary first,
+- it treats the vault, projections, and search systems as separate cleanup targets,
+- it records workflow completion without re-storing the sensitive payload.
+
+## Event sourcing vs erasure: the real tradeoff
+
+The right question is not "can event sourcing ever satisfy erasure?"
+
+The right question is:
+
+> Can the immutable history preserve the business truth without preserving revocable personal payloads?
+
+If yes, event sourcing can still be a very strong fit.
+
+If no, you may need one of these:
+
+- a different event model with indirection,
+- a split history where personal payloads live in a redactable side store,
+- a system that is not fully append-only for the affected records,
+- or a different architecture entirely.
+
+## Failure patterns
+
+### Putting emails, addresses, and IDs straight into immutable events
+
+This is the most common structural mistake.
+
+### Treating projections as disposable but ignoring search indexes and caches
+
+The PII rarely lives in only one place.
+
+### Using the same key hierarchy for every tenant or subject
+
+The broader the blast radius of one key, the weaker your erase boundary becomes.
+
+### Making erasure "best effort"
+
+If the workflow cannot be resumed, retried, and audited, it will fail exactly when you need it most.
+
+### Keeping audit logs that reproduce the sensitive payload
+
+The audit trail should prove the workflow happened, not recreate the deleted data.
+
+## Why Go is a good fit here
+
+This problem shape fits Go unusually well:
+
+- explicit request and job lifetimes with `context.Context`,
+- typed policies rather than implicit scripting,
+- background workers for retention, redaction, and reconciliation,
+- clean boundary code around SQL, Kafka, Redis, and object stores,
+- observability and testability for long-running workflows.
+
+Go does **not** remove the need for careful data modeling. But it is a very good language for building the control-plane services that enforce that model.
+
+## A practical decision rule
+
+Use event sourcing in regulated systems when:
+
+- the immutable log can stay mostly about business facts,
+- sensitive payloads can live behind indirection,
+- key ownership is explicit,
+- retention and erasure are first-class workflows,
+- rebuilds and replays do not silently resurrect deleted personal data.
+
+Be cautious or choose a different architecture when:
+
+- the core business event is itself mostly personal data,
+- downstream systems duplicate raw payloads everywhere,
+- you cannot guarantee key destruction boundaries,
+- compliance depends on rewriting canonical history in place.
+
+## Official reading
+
+- [GDPR Article 5](https://eur-lex.europa.eu/eli/reg/2016/679/oj/eng)
+- [GDPR Article 17](https://eur-lex.europa.eu/eli/reg/2016/679/oj/eng)
+- [EDPB Basics on Data Protection by Design and by Default](https://www.edpb.europa.eu/sme-data-protection-guide/respect-individuals-rights/data-protection-design-and-default_en)
+- [NIST SP 800-88 Rev. 1](https://csrc.nist.gov/pubs/sp/800/88/r1/final)
+
+## Practical takeaway
+
+The production-grade answer is not "event sourcing or regulation."
+
+It is:
+
+keep durable business history, isolate revocable personal data, make erasure and retention workflows explicit, and prove those workflows with code and audit trails.


### PR DESCRIPTION
## Summary
- add a new bilingual production chapter for regulated Go systems
- cover event sourcing, PII boundaries, cryptographic erase, retention, legal hold, and auditable erase workflows
- wire the new chapter into production navigation and the home-page entry points

## Testing
- `go test ./...`
- `npm run docs:build`

## Notes
- the chapter is written as engineering guidance, not legal advice
- `crypto-shredding` is framed using the more formal `cryptographic erase` terminology from sanitization guidance

Closes #39.
