### PR TITLE
Simplify the sidebar toggle UI

### DIFF
--- a/docs/.vitepress/theme/components/SidebarToggle.vue
+++ b/docs/.vitepress/theme/components/SidebarToggle.vue
@@ -9,9 +9,8 @@ const { lang, frontmatter } = useData();
 const isCollapsed = ref(false);
 const isMounted = ref(false);
 
-const isKorean = computed(() => lang.value.startsWith("ko"));
 const buttonLabel = computed(() =>
-  isKorean.value
+  lang.value.startsWith("ko")
     ? isCollapsed.value
       ? "사이드바 펼치기"
       : "사이드바 접기"
@@ -19,10 +18,7 @@ const buttonLabel = computed(() =>
       ? "Show sidebar"
       : "Hide sidebar"
 );
-
-const helperText = computed(() =>
-  isKorean.value ? "읽기 집중 모드" : "Focus mode"
-);
+const icon = computed(() => (isCollapsed.value ? ">" : "<"));
 
 const showToggle = computed(() => frontmatter.value.layout !== "home");
 
@@ -57,20 +53,17 @@ watch(isCollapsed, (value) => {
 </script>
 
 <template>
-  <div
-    v-if="showToggle"
-    class="sidebar-toggle-shell"
-    :class="{ 'is-collapsed': isCollapsed }"
-  >
+  <div v-if="showToggle" class="sidebar-toggle-shell">
     <button
       type="button"
       class="sidebar-toggle-button"
       :aria-label="buttonLabel"
       :aria-pressed="isCollapsed"
+      :title="buttonLabel"
       @click="toggleSidebar"
     >
-      <span class="sidebar-toggle-kicker">{{ helperText }}</span>
-      <span class="sidebar-toggle-label">{{ buttonLabel }}</span>
+      <span class="sidebar-toggle-icon" aria-hidden="true">{{ icon }}</span>
+      <span class="sidebar-toggle-text">{{ buttonLabel }}</span>
     </button>
   </div>
 </template>

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -217,56 +217,60 @@
 
 @media (min-width: 960px) {
   .sidebar-toggle-shell {
-    position: sticky;
-    top: calc(var(--vp-nav-height) + 12px);
-    z-index: 12;
-    display: flex;
-    justify-content: flex-start;
-    margin: 0 0 1.1rem;
+    position: fixed;
+    top: calc(var(--vp-nav-height) + 18px);
+    left: calc(var(--vp-sidebar-width) - 16px);
+    z-index: 24;
+    display: block;
     pointer-events: none;
   }
 
-  .sidebar-toggle-shell.is-collapsed {
-    margin-bottom: 1.35rem;
+  .sidebar-collapsed .sidebar-toggle-shell {
+    left: 12px;
   }
 
   .sidebar-toggle-button {
     pointer-events: auto;
     display: inline-flex;
-    flex-direction: column;
-    gap: 0.15rem;
-    padding: 0.7rem 0.85rem;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    padding: 0;
     border: 1px solid var(--vp-c-divider);
     border-radius: 999px;
-    background:
-      radial-gradient(circle at top right, rgba(15, 118, 110, 0.14), transparent 42%),
-      var(--vp-c-bg-soft);
-    box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
+    background: color-mix(in srgb, var(--vp-c-bg-soft) 92%, white 8%);
+    box-shadow: 0 8px 20px rgba(15, 23, 42, 0.08);
     color: var(--vp-c-text-1);
-    line-height: 1.1;
     transition:
       transform 0.18s ease,
       border-color 0.18s ease,
-      box-shadow 0.18s ease;
+      box-shadow 0.18s ease,
+      background-color 0.18s ease;
   }
 
   .sidebar-toggle-button:hover {
     border-color: rgba(15, 118, 110, 0.45);
     transform: translateY(-1px);
-    box-shadow: 0 16px 36px rgba(15, 23, 42, 0.11);
+    box-shadow: 0 10px 24px rgba(15, 23, 42, 0.12);
   }
 
-  .sidebar-toggle-kicker {
-    color: var(--vp-c-text-2);
-    font-size: 0.73rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-  }
-
-  .sidebar-toggle-label {
-    font-size: 0.92rem;
+  .sidebar-toggle-icon {
+    font-size: 14px;
     font-weight: 700;
+    line-height: 1;
+  }
+
+  .sidebar-toggle-text {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
   }
 }
 


### PR DESCRIPTION
## Summary
- replace the current large pill-style sidebar toggle with a smaller icon-only control
- keep sidebar collapse/expand behavior and localStorage persistence
- move the control out of the document flow so it no longer pushes content down or dominates the reading area

## Testing
- `npm run docs:build`

Closes #41.
