### PR TITLE
Add Docker and Kubernetes infrastructure deep dive

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -92,6 +92,7 @@ const enSidebar = [
     items: [
       { text: "Overview", link: "/production/" },
       { text: "Large-Scale Go Systems", link: "/production/large-scale-go-systems" },
+      { text: "Docker, containerd, and Kubernetes", link: "/production/docker-containerd-kubernetes" },
       { text: "Regulated Go Systems", link: "/production/regulated-systems" },
       { text: "Temporal and Durable Execution", link: "/production/temporal-durable-execution" },
       { text: "Open-Source Case Studies", link: "/production/open-source-case-studies" },
@@ -212,6 +213,7 @@ const koSidebar = [
     items: [
       { text: "개요", link: "/ko/production/" },
       { text: "대규모 Go 시스템", link: "/ko/production/large-scale-go-systems" },
+      { text: "Docker, containerd, 그리고 Kubernetes", link: "/ko/production/docker-containerd-kubernetes" },
       { text: "규제 환경의 Go 시스템", link: "/ko/production/regulated-systems" },
       { text: "Temporal과 Durable Execution", link: "/ko/production/temporal-durable-execution" },
       { text: "오픈소스 사례", link: "/ko/production/open-source-case-studies" },

--- a/docs/index.md
+++ b/docs/index.md
@@ -139,6 +139,7 @@ features:
 | How to keep AI-generated Go code from compiling successfully and still shipping bugs | [AI-Assisted Go Safety](/testing/ai-assisted-go-safety) |
 | How to test timeout-heavy code without real sleeps | [Deterministic Tests with synctest](/testing/synctest) |
 | How to keep Postgres, Redis, and container-backed integration tests clean, isolated, and deterministic | [Integration Testing with Testcontainers](/testing/integration-testcontainers) |
+| How Docker, containerd, and Kubernetes divide product UX, runtime lifecycle, and control-plane ownership | [Docker, containerd, and Kubernetes](/production/docker-containerd-kubernetes) |
 | How a durable workflow engine like Temporal becomes a Go system of history, matching, and workers | [Temporal and Durable Execution](/production/temporal-durable-execution) |
 | How to combine event sourcing, erasure, retention, and audit constraints in a real Go system | [Regulated Go Systems](/production/regulated-systems) |
 | Why so many influential infrastructure projects ended up in Go in the first place | [Go Open-Source Histories](/production/go-open-source-histories) |

--- a/docs/ko/index.md
+++ b/docs/ko/index.md
@@ -139,6 +139,7 @@ features:
 | AI가 만든 Go 코드가 컴파일은 되는데 여전히 위험할 때 어떻게 조기 발견하는지 | [AI 보조 Go 안전성](/ko/testing/ai-assisted-go-safety) |
 | timeout-heavy 코드를 실제 sleep 없이 어떻게 테스트하는지 | [synctest로 결정적 테스트](/ko/testing/synctest) |
 | Postgres, Redis, container-backed 통합 테스트를 어떻게 깨끗하고 결정적으로 유지하는지 | [Testcontainers로 통합 테스트하기](/ko/testing/integration-testcontainers) |
+| Docker, containerd, Kubernetes가 product UX, runtime lifecycle, control-plane ownership를 어떻게 나눠 갖는지 | [Docker, containerd, 그리고 Kubernetes](/ko/production/docker-containerd-kubernetes) |
 | Temporal 같은 durable workflow 엔진이 history, matching, worker를 가진 Go 시스템으로 어떻게 구성되는지 | [Temporal과 Durable Execution](/ko/production/temporal-durable-execution) |
 | event sourcing, erasure, retention, audit 제약을 실제 Go 시스템에서 어떻게 함께 풀어야 하는지 | [규제 환경의 Go 시스템](/ko/production/regulated-systems) |
 | 왜 중요한 인프라 오픈소스들이 하필 Go를 많이 택했는지 | [Go 오픈소스 역사 읽기](/ko/production/go-open-source-histories) |

--- a/docs/ko/production/docker-containerd-kubernetes.md
+++ b/docs/ko/production/docker-containerd-kubernetes.md
@@ -1,0 +1,346 @@
+---
+title: Docker, containerd, 그리고 Kubernetes
+description: Docker/Moby, containerd, Kubernetes가 Go daemon과 control loop를 통해 현대 컨테이너 플랫폼이 되는 과정을 설명합니다.
+---
+
+# Docker, containerd, 그리고 Kubernetes
+
+Go가 왜 인프라에서 이렇게 강한 언어가 되었는지 이해하고 싶다면, 이 스택은 가장 좋은 답 중 하나입니다.
+
+Docker, containerd, Kubernetes는 "밑바닥까지 전부 Go"인 시스템이 아닙니다.
+
+이들은 다음 위에 올라간 Go-heavy 시스템입니다.
+
+- Linux namespace와 cgroup
+- overlay / snapshot filesystem
+- OCI image / runtime contract
+- network namespace, iptables, eBPF, storage driver
+
+Go는 이 하위 primitive를 API, daemon, controller, reconciliation loop, 운영 가능한 시스템으로 바꾸는 계층입니다.
+
+:::tip Quick takeaway
+Docker는 user-facing engine/API 계층이고, containerd는 runtime core/lifecycle daemon이며, Kubernetes는 desired state를 향해 cluster를 계속 밀어가는 API-driven control plane입니다.
+:::
+
+## 첫 번째 머릿속 모델
+
+이 스택은 이렇게 보면 가장 깔끔합니다.
+
+- Docker/Moby는 컨테이너 workflow를 제품 형태로 묶은 daemon이고
+- containerd는 image / snapshot / content / task lifecycle을 담당하는 runtime core이며
+- Kubernetes는 container를 node-level execution target 중 하나로 다루는 더 큰 control system입니다
+
+```mermaid
+flowchart TB
+    A["User / CI / kubectl / docker CLI"] --> B["Go APIs and daemons"]
+    B --> C["Docker / Moby"]
+    B --> D["containerd"]
+    B --> E["Kubernetes control plane + kubelet"]
+    C --> D
+    E --> D
+    D --> F["OCI runtime / shim"]
+    F --> G["Linux kernel primitives"]
+```
+
+이 페이지는 이 중에서도 Go가 담당하는 부분, 즉 long-lived process, API boundary, control loop에 집중합니다.
+
+## Docker는 제품 형태의 계층이다
+
+공식 Docker Engine 문서는 Docker를 다음으로 이루어진 client-server application으로 설명합니다.
+
+- server daemon
+- REST API
+- command-line client
+
+Moby 프로젝트는 Docker가 만든 오픈소스 프로젝트로 소개됩니다.
+
+여기서 중요한 점은:
+
+Docker는 단순히 "컨테이너 하나 실행"이 아니라는 것입니다.
+
+Docker는 다음을 묶은 product surface입니다.
+
+- image build와 distribution
+- API exposure
+- networking
+- volume
+- lifecycle UX
+- 하위 runtime stack과의 통합
+
+### 소스 읽기 시작점
+
+- [`cmd/dockerd/main.go`](https://github.com/moby/moby/blob/master/cmd/dockerd/main.go)
+- [`daemon/`](https://github.com/moby/moby/tree/master/daemon)
+- [`api/server/`](https://github.com/moby/moby/tree/master/api/server)
+- [`daemon/cluster/`](https://github.com/moby/moby/tree/master/daemon/cluster)
+
+### Docker가 실제로 소유하는 것
+
+Docker daemon은 다음을 하는 Go server process입니다.
+
+- API를 노출하고
+- image와 config state를 해석하며
+- network / volume 경계를 관리하고
+- user request를 container lifecycle 작업으로 번역하고
+- 더 낮은 runtime stack에 실행을 위임합니다
+
+### 단순화한 mental model
+
+```go
+func RunContainer(req CreateRequest) error {
+	image := imageStore.Resolve(req.ImageRef)
+	rootfs := snapshotter.Prepare(image)
+	spec := ociSpecBuilder.Build(req, rootfs)
+
+	container := runtimeClient.NewContainer(spec)
+	return container.Start()
+}
+```
+
+이 코드는 일부러 압축했습니다. 핵심은 call graph가 아니라 boundary입니다.
+
+- user intent를 해석하고
+- OCI-ish execution state를 만들고
+- runtime 작업을 아래 계층에 넘깁니다
+
+### 중요한 교정 하나
+
+Docker가 커널을 대체한 것이 아닙니다.
+
+Docker는 kernel-backed container를 운영 가능한 제품으로 만든 것입니다.
+
+이건 Go가 특히 잘하는 문제 형태입니다.
+
+- API-heavy
+- process-oriented
+- long-lived
+- operationally observable
+- cross-platform packaging에 강한 구조
+
+## containerd는 runtime core다
+
+공식 containerd README는 containerd를 image transfer/storage, container execution/supervision, low-level storage/network attachment를 포함한 complete container lifecycle을 관리하는 industry-standard container runtime으로 설명합니다.
+
+여기서 스택은 product layer에서 runtime core로 내려갑니다.
+
+### 소스 읽기 시작점
+
+- [`cmd/containerd/main.go`](https://github.com/containerd/containerd/blob/main/cmd/containerd/main.go)
+- [`cmd/containerd/server/`](https://github.com/containerd/containerd/tree/main/cmd/containerd/server)
+- [`core/content/`](https://github.com/containerd/containerd/tree/main/core/content)
+- [`core/metadata/`](https://github.com/containerd/containerd/tree/main/core/metadata)
+- [`core/snapshots/`](https://github.com/containerd/containerd/tree/main/core/snapshots)
+- [`plugins/services/tasks/`](https://github.com/containerd/containerd/tree/main/plugins/services/tasks)
+
+### 아키텍처 아이디어
+
+containerd는 몇 가지 날카로운 책임을 가진 daemon + gRPC surface입니다.
+
+- image/blob용 content store
+- container/image/lease를 위한 metadata
+- root filesystem view를 위한 snapshotter
+- 실행 중인 container를 위한 task service
+- 다른 storage/runtime backend를 위한 plugin boundary
+
+containerd가 좋은 Go 사례인 이유도 여기 있습니다.
+
+이건 단순한 `runc` wrapper가 아닙니다.
+컨테이너 lifecycle을 안전하고, 관측 가능하고, 조합 가능하게 만드는 구조화된 daemon입니다.
+
+### 단순화한 mental model
+
+```go
+func StartTask(req StartTaskRequest) error {
+	container := metadataStore.LoadContainer(req.ContainerID)
+	snapshot := snapshotter.Prepare(container.SnapshotKey)
+	task := taskService.New(container, snapshot)
+	return task.Start()
+}
+```
+
+실제 구현은 더 복잡하지만, 유용한 boundary는 분명합니다.
+
+- metadata와 content는 분리되고
+- execution은 image storage와 같지 않으며
+- plugin surface가 daemon을 확장 가능하게 만듭니다
+
+### 왜 중요한가
+
+사람들이 "Docker가 containerd를 쓴다"라고 할 때 중요한 건 브랜드 관계가 아닙니다.
+
+중요한 건 아키텍처 분리입니다.
+
+- user-facing product concern은 다른 속도로 진화할 수 있고
+- runtime lifecycle은 더 집중된 core로 유지되며
+- Kubernetes 같은 orchestrator는 더 안정적인 runtime core와 연결될 수 있습니다
+
+## Kubernetes는 API-driven control plane이다
+
+공식 Kubernetes components 문서는 control plane을 cluster에 대한 global decision을 내리고, cluster event를 감지하고 대응하는 컴포넌트로 설명합니다.
+
+공식 controller 문서는 controller를 shared state를 watch하고 current state를 desired state 쪽으로 밀어가는 control loop로 설명합니다.
+
+즉 Kubernetes의 핵심은 이것입니다.
+
+Kubernetes는 API server 주변에 모인 거대한 Go control loop 집합입니다.
+
+### 소스 읽기 시작점
+
+- [`cmd/kube-apiserver/`](https://github.com/kubernetes/kubernetes/tree/master/cmd/kube-apiserver)
+- [`pkg/controller/`](https://github.com/kubernetes/kubernetes/tree/master/pkg/controller)
+- [`pkg/scheduler/`](https://github.com/kubernetes/kubernetes/tree/master/pkg/scheduler)
+- [`cmd/kubelet/`](https://github.com/kubernetes/kubernetes/tree/master/cmd/kubelet)
+- [`pkg/kubelet/`](https://github.com/kubernetes/kubernetes/tree/master/pkg/kubelet)
+
+## 정말 중요한 component model
+
+```mermaid
+flowchart LR
+    A["kubectl / operators / controllers"] --> B["kube-apiserver"]
+    B --> C["etcd"]
+    B --> D["kube-controller-manager"]
+    B --> E["kube-scheduler"]
+    B --> F["kubelet"]
+    F --> G["container runtime (containerd)"]
+    G --> H["OCI runtime + kernel"]
+```
+
+이 아키텍처는 "scheduler가 container를 실행한다"가 아닙니다.
+
+정확히는:
+
+- API server가 cluster intent를 저장하고
+- controller가 상위 object를 reconcile하며
+- scheduler가 아직 배치되지 않은 Pod를 node에 할당하고
+- kubelet이 하나의 node에서 Pod state를 reconcile하며
+- container runtime이 그 node에서 실제 container를 실행합니다
+
+### 단순화한 reconciliation 스케치
+
+```go
+func ReconcileDeployment(key string) error {
+	desired := apiServer.GetDeployment(key)
+	current := replicaStore.ListPodsForDeployment(key)
+
+	diff := desired.Replicas - len(current)
+	switch {
+	case diff > 0:
+		return podControl.Create(diff)
+	case diff < 0:
+		return podControl.Delete(-diff)
+	default:
+		return nil
+	}
+}
+```
+
+일부러 generic하게 썼지만, Kubernetes controller logic의 모양은 잘 드러납니다.
+
+- API에서 desired state를 읽고
+- actual state를 관찰하고
+- delta를 계산하고
+- system을 다시 convergence 쪽으로 밀어줍니다
+
+### kubelet이 좋은 Go 예시인 이유
+
+kubelet은 단순히 "node에서 container 시작"이 아닙니다.
+
+이건 다음을 소유하는 long-lived Go process입니다.
+
+- Pod lifecycle reconciliation
+- health checking
+- status reporting
+- node-local storage와 volume plumbing
+- container runtime과의 상호작용
+- node 단위 shutdown / restart resilience
+
+즉 전형적인 Go daemon 구조입니다.
+
+- 무한 루프
+- 명시적인 state transition
+- background worker
+- 많은 I/O와 API edge
+- 분명한 process ownership
+
+## Go가 멈추는 지점
+
+많은 사람이 놓치는 부분이 여기입니다.
+
+이 스택에서 Go는 중요하지만, 전부는 아닙니다.
+
+보통 경계는 이렇게 나뉩니다.
+
+- Go daemon은 API, metadata, reconciliation, orchestration을 소유하고
+- OCI runtime은 low-level process creation과 container spec execution을 소유하며
+- Linux kernel은 namespace, cgroup, mount, networking, process isolation을 소유합니다
+
+이 경계를 놓치면 시스템 전체를 잘못 이해하게 됩니다.
+
+## 왜 Go가 이 생태계에 잘 맞는가
+
+이 프로젝트들은 전형적인 Go형 문제입니다.
+
+- long-lived daemon과 clear owner
+- 많은 networking / API boundary
+- controller loop와 watcher
+- plugin과 extension surface
+- tracing / profiling / metrics 같은 운영 도구
+- practical한 바이너리 배포와 packaging
+
+이건 대부분 SIMD나 수제 memory layout 문제가 아닙니다.
+
+대부분은:
+
+- coordination
+- lifecycle ownership
+- process supervision
+- background work
+- control-plane correctness
+
+입니다.
+
+Go는 역사적으로 이 영역에서 강했습니다.
+
+## 이 시스템을 읽을 때 자주 하는 실수
+
+### Docker와 containerd를 같은 것으로 보는 것
+
+둘은 관련 있지만 abstraction layer가 다릅니다.
+
+### Kubernetes가 container를 직접 실행한다고 생각하는 것
+
+Kubernetes는 주로 API + reconciliation 시스템입니다. node execution은 아래 runtime 계층에 위임됩니다.
+
+### 전부 Go magic이라고 생각하는 것
+
+가장 어려운 경계는 종종 Linux와 OCI interface에 있습니다.
+
+### goroutine 개수만 보고 배우는 것
+
+배워야 할 건 "goroutine을 더 써라"가 아니라, API / loop / runtime handoff 사이 ownership boundary를 더 날카롭게 설계하라는 점입니다.
+
+## 내 시스템에 가져갈 것
+
+- user-facing API concern과 runtime-core concern을 분리하고
+- 각 계층의 state ownership을 명확히 하며
+- reconciliation을 1급 control loop로 취급하고
+- ad hoc imperative script보다 API-driven convergence를 선호하고
+- node-local execution과 cluster-global control을 분리하십시오
+
+## Official reading
+
+- [Docker Engine overview](https://docs.docker.com/engine/)
+- [Moby README](https://github.com/moby/moby/blob/master/README.md)
+- [containerd README](https://github.com/containerd/containerd/blob/main/README.md)
+- [Kubernetes Components](https://kubernetes.io/docs/concepts/overview/components/)
+- [Kubernetes Controllers](https://kubernetes.io/docs/concepts/architecture/controller/)
+
+## Practical takeaway
+
+Docker, containerd, Kubernetes는 같은 Go 강점을 서로 다른 계층에서 보여줍니다.
+
+- product daemon
+- runtime core
+- distributed control plane
+
+그래서 Go는 인프라에서 유독 끈적하게 살아남았습니다. 운영체제와 네트워크 primitive를 이해 가능하고 디버그 가능한 long-lived system으로 바꾸는 데 강하기 때문입니다.

--- a/docs/ko/production/index.md
+++ b/docs/ko/production/index.md
@@ -14,6 +14,7 @@ description: Go 코드가 실제 대규모 트래픽을 받을 때 중요해지�
 | 주제 | 왜 중요한가 |
 | --- | --- |
 | [대규모 Go 시스템](/ko/production/large-scale-go-systems) | 런타임 지식을 실제 latency, memory, overload, shutdown 규칙으로 바꿉니다 |
+| [Docker, containerd, 그리고 Kubernetes](/ko/production/docker-containerd-kubernetes) | Go daemon, runtime core, controller loop가 현대 컨테이너 플랫폼을 어떻게 이루는지 설명합니다 |
 | [규제 환경의 Go 시스템](/ko/production/regulated-systems) | event sourcing, cryptographic erase, retention, audit 제약이 Go 시스템 설계를 어떻게 바꾸는지 설명합니다 |
 | [Temporal과 Durable Execution](/ko/production/temporal-durable-execution) | 현대 workflow 엔진이 history shard, task queue, worker polling을 가진 Go 시스템으로 어떻게 구성되는지 보여줍니다 |
 | [오픈소스 사례](/ko/production/open-source-case-studies) | Kubernetes, etcd, Prometheus, NATS, gRPC-Go, CockroachDB, go-redis가 concurrency policy를 어떻게 코드에 드러내는지 봅니다 |

--- a/docs/production/docker-containerd-kubernetes.md
+++ b/docs/production/docker-containerd-kubernetes.md
@@ -1,0 +1,345 @@
+---
+title: Docker, containerd, and Kubernetes
+description: Learn how Docker/Moby, containerd, and Kubernetes turn Go daemons and control loops into a modern container platform.
+---
+
+# Docker, containerd, and Kubernetes
+
+If you want to understand why Go became such a dominant language in infrastructure, this stack is one of the clearest answers.
+
+Docker, containerd, and Kubernetes are not "Go all the way down."
+
+They are Go-heavy systems that sit on top of:
+
+- Linux namespaces and cgroups,
+- overlay and snapshot filesystems,
+- OCI image and runtime contracts,
+- network namespaces, iptables, eBPF, and storage drivers.
+
+Go is what turns those lower-level primitives into APIs, daemons, controllers, reconciliation loops, and user-facing operational systems.
+
+:::tip Quick takeaway
+Docker is the user-facing engine and API layer, containerd is the runtime core and lifecycle daemon, and Kubernetes is the API-driven control plane that keeps cluster state moving toward the desired state.
+:::
+
+## The first mental model
+
+The cleanest way to think about this stack is:
+
+- Docker/Moby packages a product and daemon around container workflows,
+- containerd owns image, snapshot, content, and task lifecycle concerns,
+- Kubernetes treats containers as one node-level execution target inside a much larger control system.
+
+```mermaid
+flowchart TB
+    A["User / CI / kubectl / docker CLI"] --> B["Go APIs and daemons"]
+    B --> C["Docker / Moby"]
+    B --> D["containerd"]
+    B --> E["Kubernetes control plane + kubelet"]
+    C --> D
+    E --> D
+    D --> F["OCI runtime / shim"]
+    F --> G["Linux kernel primitives"]
+```
+
+This page is about the Go part of that stack: the long-lived processes, API boundaries, and controller loops.
+
+## Docker is the product-shaped layer
+
+The official Docker Engine docs describe Docker as a client-server application with:
+
+- a server daemon,
+- REST APIs,
+- command-line clients.
+
+The Moby project describes itself as the open-source project created by Docker to enable and accelerate containerized software.
+
+That already tells you something important:
+
+Docker is not only "run a container."
+It is a product surface around:
+
+- image build and distribution,
+- API exposure,
+- networking,
+- volumes,
+- lifecycle UX,
+- and integration with the lower runtime stack.
+
+### A useful source-reading path
+
+- [`cmd/dockerd/main.go`](https://github.com/moby/moby/blob/master/cmd/dockerd/main.go)
+- [`daemon/`](https://github.com/moby/moby/tree/master/daemon)
+- [`api/server/`](https://github.com/moby/moby/tree/master/api/server)
+- [`daemon/cluster/`](https://github.com/moby/moby/tree/master/daemon/cluster)
+
+### What Docker actually owns
+
+The Docker daemon is a Go server process that:
+
+- exposes APIs,
+- resolves image and config state,
+- manages network and volume concerns,
+- translates user requests into container lifecycle work,
+- delegates lower execution concerns to the runtime stack below it.
+
+### Simplified mental model
+
+```go
+func RunContainer(req CreateRequest) error {
+	image := imageStore.Resolve(req.ImageRef)
+	rootfs := snapshotter.Prepare(image)
+	spec := ociSpecBuilder.Build(req, rootfs)
+
+	container := runtimeClient.NewContainer(spec)
+	return container.Start()
+}
+```
+
+That code is intentionally compressed. The lesson is not the exact call graph. The lesson is that Docker is glue with opinionated product boundaries:
+
+- resolve user intent,
+- build OCI-ish execution state,
+- hand off runtime work.
+
+### The key correction
+
+Docker did not replace the kernel.
+It made kernel-backed containers operationally usable.
+
+That is exactly the kind of system Go is good at:
+
+- API-heavy,
+- process-oriented,
+- long-lived,
+- operationally observable,
+- cross-platform enough to matter.
+
+## containerd is the runtime core
+
+The official containerd README describes containerd as an industry-standard container runtime that manages the complete container lifecycle:
+
+- image transfer and storage,
+- container execution and supervision,
+- low-level storage and network attachments.
+
+This is where the stack becomes less "developer product" and more "runtime core."
+
+### A useful source-reading path
+
+- [`cmd/containerd/main.go`](https://github.com/containerd/containerd/blob/main/cmd/containerd/main.go)
+- [`cmd/containerd/server/`](https://github.com/containerd/containerd/tree/main/cmd/containerd/server)
+- [`core/content/`](https://github.com/containerd/containerd/tree/main/core/content)
+- [`core/metadata/`](https://github.com/containerd/containerd/tree/main/core/metadata)
+- [`core/snapshots/`](https://github.com/containerd/containerd/tree/main/core/snapshots)
+- [`plugins/services/tasks/`](https://github.com/containerd/containerd/tree/main/plugins/services/tasks)
+
+### The architectural idea
+
+containerd is a daemon and gRPC surface around a few sharp responsibilities:
+
+- content store for images and blobs,
+- metadata for containers, images, and leases,
+- snapshotters for root filesystem views,
+- task services for running containers,
+- plugin boundaries for different storage and runtime backends.
+
+This is why containerd is such an important Go case study:
+
+it is not a toy wrapper over `runc`.
+It is a structured, long-lived daemon whose job is to make container lifecycle safe, observable, and composable.
+
+### Simplified mental model
+
+```go
+func StartTask(req StartTaskRequest) error {
+	container := metadataStore.LoadContainer(req.ContainerID)
+	snapshot := snapshotter.Prepare(container.SnapshotKey)
+	task := taskService.New(container, snapshot)
+	return task.Start()
+}
+```
+
+Again, the exact implementation is richer than this, but the useful boundary is clear:
+
+- metadata and content are stored separately,
+- execution is not the same thing as image storage,
+- plugin surfaces keep the daemon extensible.
+
+### Why this matters
+
+When people say "Docker uses containerd," the important point is not the brand hierarchy.
+
+The important point is architectural separation:
+
+- user-facing product concerns can move at a different speed,
+- runtime lifecycle can stay focused,
+- orchestrators like Kubernetes can speak to a more stable runtime core.
+
+## Kubernetes is the API-driven control plane
+
+The official Kubernetes components docs describe the control plane as the components that make global decisions about the cluster and detect and respond to cluster events.
+
+The controller docs describe a controller as a control loop that watches shared state and makes changes attempting to move the current state toward the desired state.
+
+That is the Kubernetes core idea in one sentence:
+
+Kubernetes is a giant collection of Go control loops around an API server.
+
+### A useful source-reading path
+
+- [`cmd/kube-apiserver/`](https://github.com/kubernetes/kubernetes/tree/master/cmd/kube-apiserver)
+- [`pkg/controller/`](https://github.com/kubernetes/kubernetes/tree/master/pkg/controller)
+- [`pkg/scheduler/`](https://github.com/kubernetes/kubernetes/tree/master/pkg/scheduler)
+- [`cmd/kubelet/`](https://github.com/kubernetes/kubernetes/tree/master/cmd/kubelet)
+- [`pkg/kubelet/`](https://github.com/kubernetes/kubernetes/tree/master/pkg/kubelet)
+
+## The component model that matters
+
+```mermaid
+flowchart LR
+    A["kubectl / operators / controllers"] --> B["kube-apiserver"]
+    B --> C["etcd"]
+    B --> D["kube-controller-manager"]
+    B --> E["kube-scheduler"]
+    B --> F["kubelet"]
+    F --> G["container runtime (containerd)"]
+    G --> H["OCI runtime + kernel"]
+```
+
+The architecture is not "the scheduler runs containers."
+
+It is:
+
+- the API server stores cluster intent,
+- controllers reconcile higher-level objects,
+- the scheduler assigns unscheduled Pods to nodes,
+- the kubelet reconciles Pod state on one node,
+- the container runtime executes containers on that node.
+
+### Simplified reconciliation sketch
+
+```go
+func ReconcileDeployment(key string) error {
+	desired := apiServer.GetDeployment(key)
+	current := replicaStore.ListPodsForDeployment(key)
+
+	diff := desired.Replicas - len(current)
+	switch {
+	case diff > 0:
+		return podControl.Create(diff)
+	case diff < 0:
+		return podControl.Delete(-diff)
+	default:
+		return nil
+	}
+}
+```
+
+That sketch is intentionally generic, but it captures the shape of Kubernetes controller logic:
+
+- read desired state from the API,
+- observe actual state,
+- compute a delta,
+- push the system back toward convergence.
+
+### Why the kubelet is a great Go example
+
+The kubelet is not just "start containers on the node."
+
+It is a long-lived Go process that owns:
+
+- Pod lifecycle reconciliation,
+- health checking,
+- status reporting,
+- node-local storage and volume plumbing,
+- interaction with the container runtime,
+- and shutdown / restart resilience on one machine.
+
+That is a classic Go daemon shape:
+
+- infinite loops,
+- explicit state transitions,
+- background workers,
+- lots of I/O and API edges,
+- and clear process ownership.
+
+## Where Go stops
+
+This is the part many readers miss.
+
+Go is crucial in this stack, but Go is not the whole stack.
+
+The boundary usually looks like this:
+
+- Go daemons own APIs, metadata, reconciliation, and orchestration,
+- OCI runtimes own low-level process creation and container spec execution,
+- the Linux kernel owns namespaces, cgroups, mounts, networking, and process isolation.
+
+If you ignore that boundary, you end up with a misleading mental model of how these systems work.
+
+## Why Go fits this ecosystem so well
+
+These projects are ideal Go-shaped problems:
+
+- long-lived daemons with clear owners,
+- lots of networking and API boundaries,
+- controller loops and watchers,
+- plugin and extension surfaces,
+- operational tooling, tracing, profiling, and metrics,
+- practical cross-platform binaries and packaging.
+
+This is not mostly SIMD work or handwritten memory layout work.
+It is mostly:
+
+- coordination,
+- lifecycle ownership,
+- process supervision,
+- background work,
+- and control-plane correctness.
+
+Go has historically been very strong there.
+
+## Failure patterns when reading these systems
+
+### Thinking Docker and containerd are interchangeable
+
+They are related, but they sit at different abstraction layers.
+
+### Thinking Kubernetes "runs containers directly"
+
+Kubernetes is mostly an API and reconciliation system. Node execution is delegated downward.
+
+### Thinking this is all pure Go magic
+
+The hardest boundaries often sit at the Linux and OCI interfaces.
+
+### Copying goroutine counts instead of control boundaries
+
+The lesson is not "use more goroutines." The lesson is "design sharper ownership between APIs, loops, and runtime handoffs."
+
+## What to steal for your own systems
+
+- separate user-facing API concerns from runtime-core concerns,
+- keep state ownership explicit at each layer,
+- treat reconciliation as a first-class control loop,
+- prefer API-driven convergence over ad hoc imperative scripts,
+- keep node-local execution responsibilities separate from cluster-global control.
+
+## Official reading
+
+- [Docker Engine overview](https://docs.docker.com/engine/)
+- [Moby README](https://github.com/moby/moby/blob/master/README.md)
+- [containerd README](https://github.com/containerd/containerd/blob/main/README.md)
+- [Kubernetes Components](https://kubernetes.io/docs/concepts/overview/components/)
+- [Kubernetes Controllers](https://kubernetes.io/docs/concepts/architecture/controller/)
+
+## Practical takeaway
+
+Docker, containerd, and Kubernetes show the same Go strength at three different layers:
+
+- product daemon,
+- runtime core,
+- distributed control plane.
+
+That is why Go became so sticky in infrastructure. It turns operating-system and network primitives into understandable, debuggable, long-lived systems.

--- a/docs/production/index.md
+++ b/docs/production/index.md
@@ -14,6 +14,7 @@ This section is about what changes when the code is no longer a neat example and
 | Topic | Why it matters |
 | --- | --- |
 | [Large-Scale Go Systems](/production/large-scale-go-systems) | Turns runtime knowledge into operating rules for latency, memory, shutdown, and overload |
+| [Docker, containerd, and Kubernetes](/production/docker-containerd-kubernetes) | Explains how Go daemons, runtime cores, and controller loops form a modern container platform |
 | [Regulated Go Systems](/production/regulated-systems) | Explains how event sourcing, cryptographic erase, retention, and audit constraints change Go system design |
 | [Temporal and Durable Execution](/production/temporal-durable-execution) | Shows how a modern workflow engine becomes a Go system of history shards, task queues, and worker polling |
 | [Open-Source Case Studies](/production/open-source-case-studies) | Shows how Kubernetes, etcd, Prometheus, NATS, gRPC-Go, CockroachDB, and go-redis make concurrency policy visible in real source code |


### PR DESCRIPTION
## Summary
- add a new bilingual production deep dive for Docker/Moby, containerd, and Kubernetes
- explain how Go is used at the product daemon, runtime core, and control-plane layers
- wire the new page into production navigation and home-page entry points

## Testing
- `go test ./...`
- `npm run docs:build`

## Notes
- the page explicitly separates Go daemon logic from OCI runtime and Linux kernel boundaries
- source pointers are based on official docs and primary repositories

Closes #43.
