### PR TITLE
Refresh top-level handbook branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Go Concurrency Patterns
+# Go Handbook
 
-Expert-level Go concurrency fundamentals, standard library deep dives, practical patterns, testing guidance, and bilingual English/Korean documentation built with VitePress.
+Expert-level Go fundamentals, runtime and compiler internals, standard library deep dives, practical patterns, testing guidance, production systems, and bilingual English/Korean documentation built with VitePress.
 
 ## Where to view it
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -247,8 +247,8 @@ const koSidebar = [
 ] as const;
 
 export default defineConfig({
-  title: "Go Concurrency Patterns",
-  description: "Detailed, practical Go concurrency patterns with tests and Mermaid diagrams.",
+  title: "Go Handbook",
+  description: "Deep, practical Go handbook covering internals, standard library, patterns, testing, and production systems.",
   base: "/golang-handbook/",
   cleanUrls: true,
   lastUpdated: true,
@@ -289,8 +289,8 @@ export default defineConfig({
     root: {
       label: "English",
       lang: "en-US",
-      title: "Go Concurrency Patterns",
-      description: "Detailed, practical Go concurrency patterns with tests and Mermaid diagrams.",
+      title: "Go Handbook",
+      description: "Deep, practical Go handbook covering internals, standard library, patterns, testing, and production systems.",
       themeConfig: {
         nav: [
           { text: "Start", link: "/guide/getting-started" },
@@ -338,8 +338,8 @@ export default defineConfig({
       label: "한국어",
       lang: "ko-KR",
       link: "/ko/",
-      title: "Go Concurrency Patterns",
-      description: "테스트와 Mermaid 다이어그램까지 포함한 실전 Go 동시성 패턴 문서.",
+      title: "Go Handbook",
+      description: "기초 원리, 내부 구조, 표준 라이브러리, 패턴, 테스트, 프로덕션 시스템까지 다루는 실전 Go 핸드북.",
       themeConfig: {
         nav: [
           { text: "시작", link: "/ko/guide/getting-started" },

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,9 +2,9 @@
 layout: home
 
 hero:
-  name: Go Concurrency Patterns
-  text: From compiler internals to production-safe concurrency
-  tagline: Learn Go through deep fundamentals, systems internals, tested examples, decision guides, and bilingual English/Korean docs.
+  name: Go Handbook
+  text: From compiler internals to production systems
+  tagline: Learn Go through runtime fundamentals, systems internals, standard library deep dives, tested examples, decision guides, and bilingual English/Korean docs.
   actions:
     - theme: brand
       text: Start With Fundamentals
@@ -57,8 +57,8 @@ features:
 
 <div class="lead-panel">
   <p>
-    This site is built for engineers who want to do more than memorize goroutines and channels.
-    The goal is to understand <strong>why Go concurrency works, when each pattern is the right fit, and how to keep it safe in production</strong>.
+    This site is built for engineers who want to do more than memorize syntax, goroutines, and package names.
+    The goal is to understand <strong>how Go works, how its runtime and libraries shape production systems, and how to use it safely at scale</strong>.
   </p>
 </div>
 

--- a/docs/ko/index.md
+++ b/docs/ko/index.md
@@ -2,9 +2,9 @@
 layout: home
 
 hero:
-  name: Go Concurrency Patterns
-  text: 컴파일러 내부부터 실전 동시성 패턴까지
-  tagline: Go를 기초 원리, 시스템 내부 구조, 테스트된 예제, 패턴 선택 가이드, 영문/국문 동시 문서로 깊게 학습합니다.
+  name: Go Handbook
+  text: 컴파일러 내부부터 프로덕션 시스템까지
+  tagline: Go를 기초 원리, 시스템 내부 구조, 표준 라이브러리, 실전 패턴, 운영 가이드, 영문/국문 동시 문서로 깊게 학습합니다.
   actions:
     - theme: brand
       text: 기초 원리부터 시작
@@ -57,8 +57,8 @@ features:
 
 <div class="lead-panel">
   <p>
-    이 사이트는 goroutine과 channel 문법을 외우는 곳이 아니라,
-    <strong>왜 이런 패턴이 가능한지, 언제 어떤 패턴을 써야 하는지, 운영에서 어떻게 안전하게 유지할지</strong>를 배우는 곳입니다.
+    이 사이트는 Go 문법이나 goroutine/channel만 외우는 곳이 아니라,
+    <strong>Go가 왜 이런 식으로 동작하는지, 런타임과 표준 라이브러리가 실제 시스템을 어떻게 만들게 하는지, 운영에서 어떻게 안전하게 쓰는지</strong>를 배우는 곳입니다.
   </p>
 </div>
 


### PR DESCRIPTION
## Summary
- rename the top-level site branding from "Go Concurrency Patterns" to "Go Handbook"
- broaden homepage hero copy in both locales so it reflects the full handbook scope, not just concurrency
- update README and VitePress global metadata to match the broader handbook positioning

## Verification
- npm run docs:build
- go test ./...

Closes #51