### PR TITLE
Add basic Go service best-practices guide

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -6,6 +6,7 @@ const enSidebar = [
     items: [
       { text: "Getting Started", link: "/guide/getting-started" },
       { text: "How to Read the Examples", link: "/guide/how-to-read" },
+      { text: "Clean Go Service Basics", link: "/guide/clean-go-service-basics" },
     ],
   },
   {
@@ -135,6 +136,7 @@ const koSidebar = [
     items: [
       { text: "시작하기", link: "/ko/guide/getting-started" },
       { text: "예제 읽는 법", link: "/ko/guide/how-to-read" },
+      { text: "깔끔한 Go 서비스 기본기", link: "/ko/guide/clean-go-service-basics" },
     ],
   },
   {

--- a/docs/guide/clean-go-service-basics.md
+++ b/docs/guide/clean-go-service-basics.md
@@ -1,0 +1,242 @@
+---
+title: Clean Go Service Basics
+description: Interview-friendly Go backend best practices for DTOs, service boundaries, graceful shutdown, channel direction, and clean package design.
+---
+
+# Clean Go Service Basics
+
+If you are coming from FastAPI, Spring, or NestJS, the cleanest Go backend style is not “find the closest big framework and copy its magic.”
+
+The cleanest style is usually:
+
+- explicit wiring,
+- small interfaces near their consumer,
+- DTOs only at the transport edge,
+- plain services with ordinary Go types,
+- graceful shutdown as part of the main program, not an afterthought.
+
+:::tip Quick takeaway
+For interviews, a strong default answer is: `handler -> service -> store`, DTOs at the edge, `context.Context` through the call chain, one owner per channel, and `http.Server.Shutdown` for graceful exit.
+:::
+
+## Mental model
+
+```mermaid
+flowchart LR
+    A["HTTP request DTO"] --> B["handler"]
+    B --> C["service"]
+    C --> D["store interface"]
+    C --> E["send-only audit channel"]
+    E --> F["background worker"]
+    C --> G["response DTO"]
+```
+
+If you want a concrete version of this shape, see [`examples/cleanservice`](https://github.com/jaeyoung0509/golang-handbook/tree/develop/examples/cleanservice).
+
+## 1. Keep DTOs at the transport edge
+
+One of the most common design mistakes is passing HTTP or JSON-shaped structs through the entire application.
+
+Cleaner boundary:
+
+- request DTO in the handler,
+- domain or service input inside the service,
+- response DTO back at the edge.
+
+```go
+type CreatePaymentRequest struct {
+	PartnerID string `json:"partner_id"`
+	Amount    int    `json:"amount"`
+	Currency  string `json:"currency"`
+}
+
+type Payment struct {
+	ID        string
+	PartnerID string
+	Amount    int
+	Currency  string
+	CreatedAt time.Time
+}
+```
+
+Why this is better:
+
+- transport concerns stay at the edge,
+- service code stops depending on JSON tags,
+- tests get simpler because they use plain types.
+
+## 2. Place interfaces near the consumer
+
+In Go, you usually define the interface where it is consumed, not where it is implemented.
+
+```go
+type PaymentStore interface {
+	Save(context.Context, Payment) error
+}
+
+type Service struct {
+	store PaymentStore
+}
+```
+
+This is more idiomatic than creating a giant shared `repository` package full of speculative interfaces.
+
+Interview answer worth remembering:
+
+“In Go, small interfaces usually belong to the consumer package because the consumer owns the dependency shape.”
+
+## 3. Pass `context.Context` through the call chain
+
+The clean default is:
+
+- request handler gets `r.Context()`,
+- service accepts `ctx` as its first parameter,
+- store and outbound calls receive that same context.
+
+```go
+func (s Service) CreatePayment(ctx context.Context, req CreatePaymentRequest) (PaymentResponse, error) {
+	// validation
+	// store.Save(ctx, ...)
+	// outbound calls with ctx
+}
+```
+
+Do not hide request lifetime behind globals or `context.Background()` in request-scoped code.
+
+## 4. Use channel direction to show ownership
+
+Channel direction is small, but it makes APIs easier to reason about.
+
+```go
+type Service struct {
+	audit chan<- AuditEvent
+}
+
+func drainAudit(events <-chan AuditEvent, sink AuditSink) {
+	for event := range events {
+		_ = sink.Write(context.Background(), event)
+	}
+}
+```
+
+This communicates intent immediately:
+
+- the service may only send,
+- the worker may only receive.
+
+That is much cleaner than passing `chan AuditEvent` everywhere and hoping ownership remains obvious.
+
+## 5. Keep handlers thin
+
+HTTP handlers should mostly do four things:
+
+1. decode and validate the request DTO,
+2. call the service,
+3. map service errors to HTTP status,
+4. encode the response DTO.
+
+That is enough.
+
+If the handler also performs business branching, persistence logic, retries, and background coordination, the boundary is already too wide.
+
+## 6. Graceful shutdown belongs in the app boundary
+
+Graceful shutdown is usually not the service layer's job. It is the application's job.
+
+The clean shape is:
+
+```go
+ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+defer stop()
+
+go func() {
+	<-ctx.Done()
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	_ = server.Shutdown(shutdownCtx)
+}()
+```
+
+In the [`examples/cleanservice`](https://github.com/jaeyoung0509/golang-handbook/tree/develop/examples/cleanservice) package, shutdown also drains an audit worker after the HTTP server stops accepting new work.
+
+Read [Graceful Shutdown](/patterns/graceful-shutdown) next if you want the deeper concurrency version.
+
+## 7. Validate early, map errors at the edge
+
+Good Go service code usually validates near the boundary and returns ordinary errors upward.
+
+```go
+var ErrPartnerIDRequired = errors.New("partner_id is required")
+
+switch {
+case errors.Is(err, ErrPartnerIDRequired):
+	writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+default:
+	writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
+}
+```
+
+That gives you:
+
+- readable business errors in the service,
+- clean protocol mapping in the handler,
+- less framework-style hidden behavior.
+
+## 8. Prefer explicit construction over framework magic
+
+Go services stay clean when dependencies are visible:
+
+```go
+app := NewApp(":8080", Dependencies{
+	Store:     store,
+	IDs:       ids,
+	AuditSink: auditSink,
+	Now:       time.Now,
+})
+```
+
+This is one reason Go services often feel “lighter” than framework-heavy systems. Construction is boring and obvious, which is usually a feature.
+
+## Suggested package shape
+
+For a modest API service, a simple shape is enough:
+
+```text
+internal/
+  payments/
+    service.go
+    handler.go
+    dto.go
+    store.go
+cmd/api/
+  main.go
+```
+
+You do not need a huge hexagonal folder tree on day one.
+
+You need:
+
+- a clear edge,
+- a clear service boundary,
+- explicit dependency wiring,
+- tests that prove the important behavior.
+
+## Interview checklist
+
+If someone asks how you structure a Go backend service, a strong answer is:
+
+- DTOs live at the HTTP or message boundary.
+- Business logic lives in a service layer with plain Go types.
+- Interfaces are small and defined near the consumer.
+- `context.Context` is passed through every request-scoped dependency.
+- Channels use direction when ownership matters.
+- Graceful shutdown uses `http.Server.Shutdown` with a deadline.
+- Errors are wrapped in the service and mapped to protocol status at the edge.
+
+## Practical takeaway
+
+You do not need a Go equivalent of FastAPI magic to make a service feel clean.
+
+You need sharper boundaries, smaller interfaces, and explicit lifecycle ownership.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -33,6 +33,7 @@ That split matters because the site explains the patterns, but the Go packages p
 │   └── ko/
 ├── examples/
 │   ├── actor/
+│   ├── cleanservice/
 │   ├── contexttimeout/
 │   ├── errgroupbatch/
 │   ├── fanoutfanin/
@@ -66,10 +67,11 @@ Use the commands above before pushing changes. The first validates the static si
 ## Fast path for first-time readers
 
 1. Read [Fundamentals Overview](/fundamentals/).
-2. Move through [Patterns Overview](/patterns/) with the matching package under `examples/`.
-3. Read [Testing Overview](/testing/) before trusting any timeout or shutdown path.
-4. Read [Production Overview](/production/) once you care about operating rules and large-scale system tradeoffs.
-5. Only then move into [Advanced Overview](/advanced/) and [Extras Overview](/extras/).
+2. If you are preparing for interviews or basic backend service design, read [Clean Go Service Basics](/guide/clean-go-service-basics).
+3. Move through [Patterns Overview](/patterns/) with the matching package under `examples/`.
+4. Read [Testing Overview](/testing/) before trusting any timeout or shutdown path.
+5. Read [Production Overview](/production/) once you care about operating rules and large-scale system tradeoffs.
+6. Only then move into [Advanced Overview](/advanced/) and [Extras Overview](/extras/).
 
 ## What is inside each example
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -115,6 +115,7 @@ features:
 | If you need to understand... | Start with |
 | --- | --- |
 | Why goroutines are cheap and how the scheduler actually runs them | [Go Runtime and Scheduler](/fundamentals/go-runtime-scheduler) |
+| How to structure a clean Go API service for interviews and day-to-day backend work | [Clean Go Service Basics](/guide/clean-go-service-basics) |
 | Why a local value still ends up on the heap | [Compiler and Toolchain](/internals/compiler-and-toolchain) |
 | Why one allocation pattern hurts GC more than another | [Allocator and Hybrid Write Barrier](/internals/allocator-and-write-barrier) |
 | How request-scoped cancellation actually propagates | [context Package Internals](/stdlib/context-internals) |

--- a/docs/ko/guide/clean-go-service-basics.md
+++ b/docs/ko/guide/clean-go-service-basics.md
@@ -1,0 +1,244 @@
+---
+title: 깔끔한 Go 서비스 기본기
+description: DTO, 서비스 경계, graceful shutdown, channel direction, 패키지 설계를 인터뷰 관점에서 정리한 Go 백엔드 베스트 프랙티스 가이드입니다.
+---
+
+# 깔끔한 Go 서비스 기본기
+
+FastAPI, Spring, NestJS 쪽에 익숙하다면 Go에서도 가장 깔끔한 스타일은 “비슷한 큰 프레임워크를 찾아서 마법처럼 쓰는 것”이라고 생각하기 쉽습니다.
+
+하지만 보통 Go에서 더 깔끔한 스타일은 다음입니다.
+
+- explicit wiring
+- consumer 가까이에 둔 작은 interface
+- transport edge에만 있는 DTO
+- plain Go type 중심의 service
+- 메인 프로그램에 포함된 graceful shutdown
+
+:::tip Quick takeaway
+인터뷰 답변용으로는 `handler -> service -> store`, edge DTO, 전체 call chain의 `context.Context`, channel direction으로 드러나는 ownership, `http.Server.Shutdown` 기반 graceful exit를 기본 답으로 가져가면 좋습니다.
+:::
+
+## Mental model
+
+```mermaid
+flowchart LR
+    A["HTTP request DTO"] --> B["handler"]
+    B --> C["service"]
+    C --> D["store interface"]
+    C --> E["send-only audit channel"]
+    E --> F["background worker"]
+    C --> G["response DTO"]
+```
+
+이 구조의 구체적인 예시는 [`examples/cleanservice`](https://github.com/jaeyoung0509/golang-handbook/tree/develop/examples/cleanservice)에서 볼 수 있습니다.
+
+## 1. DTO는 transport edge에 둔다
+
+가장 흔한 설계 실수 중 하나는 HTTP/JSON 모양의 struct를 애플리케이션 전체로 끌고 다니는 것입니다.
+
+더 깔끔한 경계는 이렇습니다.
+
+- handler에 request DTO
+- service 내부에는 domain 혹은 service input
+- 응답 직전에 response DTO
+
+```go
+type CreatePaymentRequest struct {
+	PartnerID string `json:"partner_id"`
+	Amount    int    `json:"amount"`
+	Currency  string `json:"currency"`
+}
+
+type Payment struct {
+	ID        string
+	PartnerID string
+	Amount    int
+	Currency  string
+	CreatedAt time.Time
+}
+```
+
+이 방식이 더 나은 이유:
+
+- transport concern이 edge에만 남고
+- service code가 JSON tag에 의존하지 않으며
+- 테스트가 plain type 중심으로 단순해집니다
+
+## 2. interface는 consumer 가까이에 둔다
+
+Go에서는 보통 interface를 구현체 쪽이 아니라 소비하는 쪽에 둡니다.
+
+```go
+type PaymentStore interface {
+	Save(context.Context, Payment) error
+}
+
+type Service struct {
+	store PaymentStore
+}
+```
+
+미리 큰 `repository` 패키지를 만들어 speculative interface를 쌓는 것보다 이 편이 더 Go답습니다.
+
+인터뷰에서 기억할 답:
+
+“Go에서는 작은 interface를 보통 consumer package에 둡니다. dependency shape를 실제로 소유하는 쪽이 consumer이기 때문입니다.”
+
+## 3. `context.Context`는 call chain 전체에 흘린다
+
+기본 규칙은 이렇습니다.
+
+- handler는 `r.Context()`를 받고
+- service는 첫 번째 인자로 `ctx`를 받으며
+- store와 outbound call도 같은 context를 받습니다
+
+```go
+func (s Service) CreatePayment(ctx context.Context, req CreatePaymentRequest) (PaymentResponse, error) {
+	// validation
+	// store.Save(ctx, ...)
+	// outbound calls with ctx
+}
+```
+
+request-scoped code에서 `context.Background()`나 global lifetime을 몰래 쓰지 않는 것이 기본입니다.
+
+## 4. channel direction으로 ownership을 드러낸다
+
+작은 문법이지만 API를 훨씬 읽기 좋게 만듭니다.
+
+```go
+type Service struct {
+	audit chan<- AuditEvent
+}
+
+func drainAudit(events <-chan AuditEvent, sink AuditSink) {
+	for event := range events {
+		_ = sink.Write(context.Background(), event)
+	}
+}
+```
+
+이렇게 쓰면 의도가 바로 드러납니다.
+
+- service는 send만 할 수 있고
+- worker는 receive만 할 수 있습니다
+
+`chan AuditEvent`를 여기저기 넘기며 ownership을 추측하게 만드는 것보다 훨씬 낫습니다.
+
+## 5. handler는 얇게 유지한다
+
+HTTP handler는 보통 네 가지만 하면 됩니다.
+
+1. request DTO decode/validate
+2. service 호출
+3. service error를 HTTP status로 매핑
+4. response DTO encode
+
+그 정도면 충분합니다.
+
+handler가 business branching, persistence logic, retry, background coordination까지 다 해버리면 경계가 이미 너무 넓어진 것입니다.
+
+## 6. graceful shutdown은 app boundary 책임이다
+
+graceful shutdown은 대개 service layer 책임이 아니라 application 책임입니다.
+
+깔끔한 형태는 대략 이렇습니다.
+
+```go
+ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+defer stop()
+
+go func() {
+	<-ctx.Done()
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	_ = server.Shutdown(shutdownCtx)
+}()
+```
+
+[`examples/cleanservice`](https://github.com/jaeyoung0509/golang-handbook/tree/develop/examples/cleanservice) 예제는 여기서 한 단계 더 가서, HTTP 서버가 새 요청을 멈춘 뒤 audit worker까지 drain합니다.
+
+동시성 패턴 관점에서 더 깊게 보려면 [Graceful Shutdown](/ko/patterns/graceful-shutdown) 문서를 같이 읽으면 됩니다.
+
+## 7. validation은 일찍, error mapping은 edge에서
+
+좋은 Go 서비스 코드는 보통 boundary 가까이에서 validation을 하고, 위로는 ordinary error를 반환합니다.
+
+```go
+var ErrPartnerIDRequired = errors.New("partner_id is required")
+
+switch {
+case errors.Is(err, ErrPartnerIDRequired):
+	writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+default:
+	writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
+}
+```
+
+이 패턴의 장점은:
+
+- service 안에서는 business error가 읽기 쉽고
+- handler에서는 protocol mapping이 명확하며
+- 프레임워크성 hidden behavior가 줄어든다는 점입니다
+
+## 8. framework magic보다 explicit construction
+
+Go 서비스는 dependency가 눈에 보일수록 깔끔해집니다.
+
+```go
+app := NewApp(":8080", Dependencies{
+	Store:     store,
+	IDs:       ids,
+	AuditSink: auditSink,
+	Now:       time.Now,
+})
+```
+
+이게 Go 서비스가 프레임워크 중심 시스템보다 “가볍게” 느껴지는 이유 중 하나입니다. construction이 지루할 만큼 명시적이라는 건 보통 장점입니다.
+
+## 추천 패키지 구조
+
+적당한 크기의 API 서비스라면 이 정도면 충분합니다.
+
+```text
+internal/
+  payments/
+    service.go
+    handler.go
+    dto.go
+    store.go
+cmd/api/
+  main.go
+```
+
+처음부터 거대한 hexagonal folder tree가 필요한 건 아닙니다.
+
+정말 필요한 것은:
+
+- 분명한 edge
+- 분명한 service boundary
+- explicit dependency wiring
+- 중요한 동작을 증명하는 테스트
+
+입니다.
+
+## 인터뷰 체크리스트
+
+“Go 백엔드 서비스를 어떻게 구조화하나요?”라는 질문에는 이렇게 답하면 강합니다.
+
+- DTO는 HTTP 혹은 message boundary에 둡니다.
+- 비즈니스 로직은 plain Go type 중심의 service layer에 둡니다.
+- interface는 작게 만들고 consumer 가까이에 둡니다.
+- `context.Context`는 request-scoped dependency 전체로 전달합니다.
+- ownership이 중요하면 channel direction을 사용합니다.
+- graceful shutdown은 deadline을 둔 `http.Server.Shutdown`으로 처리합니다.
+- error는 service에서 wrap하고, protocol status 매핑은 edge에서 합니다.
+
+## Practical takeaway
+
+FastAPI 같은 마법이 없어도 Go 서비스는 충분히 깔끔해질 수 있습니다.
+
+필요한 것은 더 날카로운 경계, 더 작은 interface, 더 명시적인 lifecycle ownership입니다.

--- a/docs/ko/guide/getting-started.md
+++ b/docs/ko/guide/getting-started.md
@@ -33,6 +33,7 @@ description: VitePress 기반 Go 동시성 문서 저장소의 구조와 실행 
 │   └── ko/
 ├── examples/
 │   ├── actor/
+│   ├── cleanservice/
 │   ├── contexttimeout/
 │   ├── errgroupbatch/
 │   ├── fanoutfanin/
@@ -67,10 +68,11 @@ go test ./...
 ## 처음 읽는 사람을 위한 빠른 경로
 
 1. [기초 원리 개요](/ko/fundamentals/)부터 읽습니다.
-2. [패턴 개요](/ko/patterns/)와 `examples/` 대응 패키지를 같이 읽습니다.
-3. timeout과 shutdown 경로를 믿기 전에 [테스트 개요](/ko/testing/)를 읽습니다.
-4. 운영 규칙과 대규모 시스템 tradeoff가 중요해지면 [프로덕션 개요](/ko/production/)를 읽습니다.
-5. 그 다음에 [고급 주제 개요](/ko/advanced/), [비교 / 확장 개요](/ko/extras/)로 넘어갑니다.
+2. 인터뷰나 기본 백엔드 서비스 설계가 급하면 [깔끔한 Go 서비스 기본기](/ko/guide/clean-go-service-basics)를 먼저 읽습니다.
+3. [패턴 개요](/ko/patterns/)와 `examples/` 대응 패키지를 같이 읽습니다.
+4. timeout과 shutdown 경로를 믿기 전에 [테스트 개요](/ko/testing/)를 읽습니다.
+5. 운영 규칙과 대규모 시스템 tradeoff가 중요해지면 [프로덕션 개요](/ko/production/)를 읽습니다.
+6. 그 다음에 [고급 주제 개요](/ko/advanced/), [비교 / 확장 개요](/ko/extras/)로 넘어갑니다.
 
 ## 예제 패키지 구성 원칙
 

--- a/docs/ko/index.md
+++ b/docs/ko/index.md
@@ -115,6 +115,7 @@ features:
 | 이런 게 궁금하면 | 여기부터 읽기 |
 | --- | --- |
 | 고루틴이 왜 싸고, 스케줄러가 실제로 뭘 하는지 | [Go 런타임과 스케줄러](/ko/fundamentals/go-runtime-scheduler) |
+| 인터뷰와 실무에서 깔끔한 Go API 서비스를 어떻게 구조화하는지 | [깔끔한 Go 서비스 기본기](/ko/guide/clean-go-service-basics) |
 | 지역 값이 왜 여전히 힙으로 가는지 | [컴파일러와 툴체인](/ko/internals/compiler-and-toolchain) |
 | 어떤 allocation 패턴이 왜 GC를 더 힘들게 하는지 | [할당기와 하이브리드 write barrier](/ko/internals/allocator-and-write-barrier) |
 | request-scoped cancellation이 실제로 어떻게 전파되는지 | [context 패키지 내부](/ko/stdlib/context-internals) |

--- a/examples/cleanservice/cleanservice.go
+++ b/examples/cleanservice/cleanservice.go
@@ -1,0 +1,235 @@
+package cleanservice
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+)
+
+var (
+	ErrPartnerIDRequired     = errors.New("partner_id is required")
+	ErrAmountMustBeAboveZero = errors.New("amount must be above zero")
+)
+
+type CreatePaymentRequest struct {
+	PartnerID string `json:"partner_id"`
+	Amount    int    `json:"amount"`
+	Currency  string `json:"currency"`
+}
+
+type PaymentResponse struct {
+	ID        string `json:"id"`
+	PartnerID string `json:"partner_id"`
+	Amount    int    `json:"amount"`
+	Currency  string `json:"currency"`
+	CreatedAt string `json:"created_at"`
+}
+
+type Payment struct {
+	ID        string
+	PartnerID string
+	Amount    int
+	Currency  string
+	CreatedAt time.Time
+}
+
+type AuditEvent struct {
+	PaymentID string
+	PartnerID string
+	EventType string
+}
+
+type PaymentStore interface {
+	Save(context.Context, Payment) error
+}
+
+type IDGenerator interface {
+	Next() string
+}
+
+type AuditSink interface {
+	Write(context.Context, AuditEvent) error
+}
+
+type Service struct {
+	store PaymentStore
+	ids   IDGenerator
+	now   func() time.Time
+	audit chan<- AuditEvent
+}
+
+func NewService(store PaymentStore, ids IDGenerator, now func() time.Time, audit chan<- AuditEvent) Service {
+	if now == nil {
+		now = time.Now
+	}
+
+	return Service{
+		store: store,
+		ids:   ids,
+		now:   now,
+		audit: audit,
+	}
+}
+
+func (s Service) CreatePayment(ctx context.Context, req CreatePaymentRequest) (PaymentResponse, error) {
+	if req.PartnerID == "" {
+		return PaymentResponse{}, ErrPartnerIDRequired
+	}
+	if req.Amount <= 0 {
+		return PaymentResponse{}, ErrAmountMustBeAboveZero
+	}
+
+	payment := Payment{
+		ID:        s.ids.Next(),
+		PartnerID: req.PartnerID,
+		Amount:    req.Amount,
+		Currency:  req.Currency,
+		CreatedAt: s.now().UTC(),
+	}
+
+	if err := s.store.Save(ctx, payment); err != nil {
+		return PaymentResponse{}, err
+	}
+
+	select {
+	case s.audit <- AuditEvent{
+		PaymentID: payment.ID,
+		PartnerID: payment.PartnerID,
+		EventType: "payment.created",
+	}:
+	case <-ctx.Done():
+		return PaymentResponse{}, ctx.Err()
+	}
+
+	return toPaymentResponse(payment), nil
+}
+
+type Handler struct {
+	service Service
+}
+
+func NewHandler(service Service) Handler {
+	return Handler{service: service}
+}
+
+func (h Handler) Register(mux *http.ServeMux) {
+	mux.HandleFunc("POST /payments", h.createPayment)
+}
+
+func (h Handler) createPayment(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+
+	var req CreatePaymentRequest
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+
+	resp, err := h.service.CreatePayment(r.Context(), req)
+	if err != nil {
+		switch {
+		case errors.Is(err, ErrPartnerIDRequired), errors.Is(err, ErrAmountMustBeAboveZero):
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		default:
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
+		}
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, resp)
+}
+
+type Dependencies struct {
+	Store     PaymentStore
+	IDs       IDGenerator
+	AuditSink AuditSink
+	Now       func() time.Time
+}
+
+type App struct {
+	server    *http.Server
+	auditCh   chan AuditEvent
+	auditWg   sync.WaitGroup
+	auditSink AuditSink
+}
+
+func NewApp(addr string, deps Dependencies) *App {
+	auditCh := make(chan AuditEvent, 16)
+	service := NewService(deps.Store, deps.IDs, deps.Now, auditCh)
+	mux := http.NewServeMux()
+	NewHandler(service).Register(mux)
+
+	app := &App{
+		server: &http.Server{
+			Addr:              addr,
+			Handler:           mux,
+			ReadHeaderTimeout: 2 * time.Second,
+			IdleTimeout:       30 * time.Second,
+		},
+		auditCh:   auditCh,
+		auditSink: deps.AuditSink,
+	}
+
+	app.auditWg.Add(1)
+	go app.runAuditWorker()
+
+	return app
+}
+
+func (a *App) Serve(listener net.Listener) error {
+	return a.server.Serve(listener)
+}
+
+func (a *App) Shutdown(ctx context.Context) error {
+	if err := a.server.Shutdown(ctx); err != nil {
+		return err
+	}
+
+	close(a.auditCh)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		a.auditWg.Wait()
+	}()
+
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (a *App) runAuditWorker() {
+	defer a.auditWg.Done()
+
+	for event := range a.auditCh {
+		if a.auditSink == nil {
+			continue
+		}
+		_ = a.auditSink.Write(context.Background(), event)
+	}
+}
+
+func toPaymentResponse(payment Payment) PaymentResponse {
+	return PaymentResponse{
+		ID:        payment.ID,
+		PartnerID: payment.PartnerID,
+		Amount:    payment.Amount,
+		Currency:  payment.Currency,
+		CreatedAt: payment.CreatedAt.Format(time.RFC3339),
+	}
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(payload)
+}

--- a/examples/cleanservice/cleanservice_test.go
+++ b/examples/cleanservice/cleanservice_test.go
@@ -1,0 +1,204 @@
+package cleanservice
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestServiceCreatePaymentMapsDTOAndEmitsAudit(t *testing.T) {
+	store := &memoryStore{}
+	auditCh := make(chan AuditEvent, 1)
+	now := func() time.Time {
+		return time.Date(2026, time.March, 22, 10, 30, 0, 0, time.UTC)
+	}
+
+	service := NewService(store, staticIDs{id: "pay_123"}, now, auditCh)
+
+	resp, err := service.CreatePayment(context.Background(), CreatePaymentRequest{
+		PartnerID: "partner_42",
+		Amount:    1999,
+		Currency:  "GBP",
+	})
+	if err != nil {
+		t.Fatalf("CreatePayment returned error: %v", err)
+	}
+
+	if resp.ID != "pay_123" {
+		t.Fatalf("response ID = %q, want pay_123", resp.ID)
+	}
+	if resp.CreatedAt != "2026-03-22T10:30:00Z" {
+		t.Fatalf("response CreatedAt = %q, want RFC3339 value", resp.CreatedAt)
+	}
+
+	saved := store.Last()
+	if saved.PartnerID != "partner_42" || saved.Amount != 1999 {
+		t.Fatalf("saved payment = %+v, want persisted request values", saved)
+	}
+
+	select {
+	case event := <-auditCh:
+		if event.PaymentID != "pay_123" || event.EventType != "payment.created" {
+			t.Fatalf("audit event = %+v, want created event", event)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("expected audit event")
+	}
+}
+
+func TestHandlerRejectsInvalidDTO(t *testing.T) {
+	service := NewService(&memoryStore{}, staticIDs{id: "pay_123"}, time.Now, make(chan AuditEvent, 1))
+	handler := NewHandler(service)
+	mux := http.NewServeMux()
+	handler.Register(mux)
+
+	reqBody := []byte(`{"partner_id":"partner_42","amount":0,"currency":"GBP","unexpected":true}`)
+	req := httptestRequest(t, http.MethodPost, "/payments", reqBody)
+	recorder := httptestRecorder()
+
+	mux.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", recorder.Code)
+	}
+}
+
+func TestAppShutdownDrainsAuditAndStopsServer(t *testing.T) {
+	store := &memoryStore{}
+	sink := &recordingSink{}
+	app := NewApp("127.0.0.1:0", Dependencies{
+		Store:     store,
+		IDs:       staticIDs{id: "pay_789"},
+		AuditSink: sink,
+		Now: func() time.Time {
+			return time.Date(2026, time.March, 22, 12, 0, 0, 0, time.UTC)
+		},
+	})
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.Listen returned error: %v", err)
+	}
+
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- app.Serve(listener)
+	}()
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	payload, _ := json.Marshal(CreatePaymentRequest{
+		PartnerID: "partner_77",
+		Amount:    4500,
+		Currency:  "GBP",
+	})
+
+	resp, err := client.Post("http://"+listener.Addr().String()+"/payments", "application/json", bytes.NewReader(payload))
+	if err != nil {
+		t.Fatalf("POST returned error: %v", err)
+	}
+	resp.Body.Close()
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	if err := app.Shutdown(shutdownCtx); err != nil {
+		t.Fatalf("Shutdown returned error: %v", err)
+	}
+
+	if err := <-serveErr; !errors.Is(err, http.ErrServerClosed) {
+		t.Fatalf("Serve error = %v, want http.ErrServerClosed", err)
+	}
+
+	if got := sink.Events(); len(got) != 1 || got[0].PaymentID != "pay_789" {
+		t.Fatalf("audit events = %+v, want one drained event", got)
+	}
+
+	_, err = client.Post("http://"+listener.Addr().String()+"/payments", "application/json", bytes.NewReader(payload))
+	if err == nil {
+		t.Fatalf("POST after shutdown error = nil, want connection failure")
+	}
+}
+
+type memoryStore struct {
+	mu       sync.Mutex
+	payments []Payment
+}
+
+func (s *memoryStore) Save(_ context.Context, payment Payment) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.payments = append(s.payments, payment)
+	return nil
+}
+
+func (s *memoryStore) Last() Payment {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.payments[len(s.payments)-1]
+}
+
+type staticIDs struct {
+	id string
+}
+
+func (s staticIDs) Next() string {
+	return s.id
+}
+
+type recordingSink struct {
+	mu     sync.Mutex
+	events []AuditEvent
+}
+
+func (s *recordingSink) Write(_ context.Context, event AuditEvent) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, event)
+	return nil
+}
+
+func (s *recordingSink) Events() []AuditEvent {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cloned := make([]AuditEvent, len(s.events))
+	copy(cloned, s.events)
+	return cloned
+}
+
+type responseRecorder struct {
+	header http.Header
+	body   bytes.Buffer
+	Code   int
+}
+
+func httptestRecorder() *responseRecorder {
+	return &responseRecorder{header: make(http.Header)}
+}
+
+func (r *responseRecorder) Header() http.Header {
+	return r.header
+}
+
+func (r *responseRecorder) Write(p []byte) (int, error) {
+	return r.body.Write(p)
+}
+
+func (r *responseRecorder) WriteHeader(statusCode int) {
+	r.Code = statusCode
+}
+
+func httptestRequest(t *testing.T, method, target string, body []byte) *http.Request {
+	t.Helper()
+
+	req, err := http.NewRequest(method, target, bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("http.NewRequest returned error: %v", err)
+	}
+	return req
+}


### PR DESCRIPTION
## Summary
- add a bilingual guide page for clean Go service basics focused on interview prep and practical backend structure
- add a runnable `cleanservice` example that demonstrates DTO boundaries, consumer-side interfaces, channel direction, and graceful shutdown
- link the new guide from Guide navigation, Getting Started, and the home-page quick-start table

## Testing
- go test ./...
- npm run docs:build

Closes #55
