### PR TITLE
Expand clean Go service basics guide

### DIFF
--- a/docs/guide/clean-go-service-basics.md
+++ b/docs/guide/clean-go-service-basics.md
@@ -5,25 +5,29 @@ description: Interview-friendly Go backend best practices for DTOs, service boun
 
 # Clean Go Service Basics
 
-If you are coming from FastAPI, Spring, or NestJS, the cleanest Go backend style is not “find the closest big framework and copy its magic.”
+If you are coming from FastAPI, Spring, or NestJS, the cleanest Go backend style is usually not “find a huge framework and hide everything.”
 
-The cleanest style is usually:
+The cleaner default is:
 
 - explicit wiring,
+- DTOs only at the edge,
+- thin handlers,
+- plain services,
 - small interfaces near their consumer,
-- DTOs only at the transport edge,
-- plain services with ordinary Go types,
-- graceful shutdown as part of the main program, not an afterthought.
+- graceful shutdown in the app boundary,
+- channels with obvious ownership.
 
 :::tip Quick takeaway
 For interviews, a strong default answer is: `handler -> service -> store`, DTOs at the edge, `context.Context` through the call chain, one owner per channel, and `http.Server.Shutdown` for graceful exit.
 :::
 
-## Mental model
+If you want a concrete version of this shape, see [`examples/cleanservice`](https://github.com/jaeyoung0509/golang-handbook/tree/develop/examples/cleanservice).
+
+## The default shape to memorize
 
 ```mermaid
 flowchart LR
-    A["HTTP request DTO"] --> B["handler"]
+    A["request DTO"] --> B["handler"]
     B --> C["service"]
     C --> D["store interface"]
     C --> E["send-only audit channel"]
@@ -31,17 +35,26 @@ flowchart LR
     C --> G["response DTO"]
 ```
 
-If you want a concrete version of this shape, see [`examples/cleanservice`](https://github.com/jaeyoung0509/golang-handbook/tree/develop/examples/cleanservice).
+If an interviewer asks, “How would you structure a Go API?”, this is already a good start.
 
 ## 1. Keep DTOs at the transport edge
 
-One of the most common design mistakes is passing HTTP or JSON-shaped structs through the entire application.
+Bad default:
 
-Cleaner boundary:
+```go
+type Payment struct {
+	PartnerID string `json:"partner_id"`
+	Amount    int    `json:"amount"`
+	Currency  string `json:"currency"`
+}
 
-- request DTO in the handler,
-- domain or service input inside the service,
-- response DTO back at the edge.
+func (s Service) CreatePayment(ctx context.Context, payment Payment) error {
+	// now JSON concerns leaked into the service
+	return nil
+}
+```
+
+Better:
 
 ```go
 type CreatePaymentRequest struct {
@@ -57,17 +70,47 @@ type Payment struct {
 	Currency  string
 	CreatedAt time.Time
 }
+
+type PaymentResponse struct {
+	ID        string `json:"id"`
+	PartnerID string `json:"partner_id"`
+	Amount    int    `json:"amount"`
+	Currency  string `json:"currency"`
+	CreatedAt string `json:"created_at"`
+}
 ```
 
-Why this is better:
+The handler owns `CreatePaymentRequest` and `PaymentResponse`.
 
-- transport concerns stay at the edge,
-- service code stops depending on JSON tags,
-- tests get simpler because they use plain types.
+The service owns `Payment`.
 
-## 2. Place interfaces near the consumer
+That separation keeps transport concerns from infecting the rest of the program.
 
-In Go, you usually define the interface where it is consumed, not where it is implemented.
+## 2. Map DTOs explicitly
+
+Do not be embarrassed by small mapping functions. They are one of the cleanest parts of Go service code.
+
+```go
+func toPaymentResponse(payment Payment) PaymentResponse {
+	return PaymentResponse{
+		ID:        payment.ID,
+		PartnerID: payment.PartnerID,
+		Amount:    payment.Amount,
+		Currency:  payment.Currency,
+		CreatedAt: payment.CreatedAt.Format(time.RFC3339),
+	}
+}
+```
+
+That is clearer than:
+
+- passing DB models directly to JSON,
+- leaking persistence fields into responses,
+- or hiding everything behind reflection magic.
+
+## 3. Place interfaces near the consumer
+
+In Go, interfaces usually belong to the package that consumes the dependency shape.
 
 ```go
 type PaymentStore interface {
@@ -79,54 +122,122 @@ type Service struct {
 }
 ```
 
-This is more idiomatic than creating a giant shared `repository` package full of speculative interfaces.
+This is cleaner than a giant shared `repository` package full of speculative interfaces.
 
-Interview answer worth remembering:
+Good interview sentence:
 
-“In Go, small interfaces usually belong to the consumer package because the consumer owns the dependency shape.”
+“In Go, I define small interfaces close to the consumer because the consumer owns the dependency contract.”
 
-## 3. Pass `context.Context` through the call chain
+## 4. Pass `context.Context` through the whole request path
 
 The clean default is:
 
-- request handler gets `r.Context()`,
-- service accepts `ctx` as its first parameter,
+- handler uses `r.Context()`,
+- service accepts `ctx` as the first parameter,
 - store and outbound calls receive that same context.
 
 ```go
+func (h Handler) createPayment(w http.ResponseWriter, r *http.Request) {
+	resp, err := h.service.CreatePayment(r.Context(), req)
+	_ = resp
+	_ = err
+}
+
 func (s Service) CreatePayment(ctx context.Context, req CreatePaymentRequest) (PaymentResponse, error) {
-	// validation
-	// store.Save(ctx, ...)
-	// outbound calls with ctx
+	if err := s.store.Save(ctx, payment); err != nil {
+		return PaymentResponse{}, err
+	}
+	return toPaymentResponse(payment), nil
 }
 ```
 
-Do not hide request lifetime behind globals or `context.Background()` in request-scoped code.
-
-## 4. Use channel direction to show ownership
-
-Channel direction is small, but it makes APIs easier to reason about.
+Avoid this in request-scoped code:
 
 ```go
-type Service struct {
-	audit chan<- AuditEvent
+func (s Service) CreatePayment(_ context.Context, req CreatePaymentRequest) error {
+	return s.store.Save(context.Background(), payment) // bad
+}
+```
+
+That throws away the caller's timeout and cancellation.
+
+## 5. Channel direction cheat sheet
+
+This is where many people stay confused longer than they should.
+
+### The three forms
+
+| Type | Meaning | What this side can do |
+| --- | --- | --- |
+| `chan T` | bidirectional | send and receive |
+| `chan<- T` | send-only | send only |
+| `<-chan T` | receive-only | receive only |
+
+### The easy memory trick
+
+- `chan<- T`: you push `T` values into it
+- `<-chan T`: you pull `T` values out of it
+
+### Minimal examples
+
+```go
+func producer(out chan<- int) {
+	out <- 1
 }
 
-func drainAudit(events <-chan AuditEvent, sink AuditSink) {
+func consumer(in <-chan int) int {
+	return <-in
+}
+
+func pipe() <-chan int {
+	out := make(chan int, 1)
+	out <- 42
+	close(out)
+	return out
+}
+```
+
+### Why this is useful
+
+Bad:
+
+```go
+func drainAudit(events chan AuditEvent) {
 	for event := range events {
-		_ = sink.Write(context.Background(), event)
+		_ = event
 	}
 }
 ```
 
-This communicates intent immediately:
+The reader cannot tell whether `drainAudit` is allowed to send, receive, or close.
 
-- the service may only send,
-- the worker may only receive.
+Better:
 
-That is much cleaner than passing `chan AuditEvent` everywhere and hoping ownership remains obvious.
+```go
+func drainAudit(events <-chan AuditEvent) {
+	for event := range events {
+		_ = event
+	}
+}
+```
 
-## 5. Keep handlers thin
+Now the API itself says:
+
+- this function only reads,
+- it should not write,
+- it should not own the sending side.
+
+### Practical rule
+
+Use channel direction in:
+
+- function parameters,
+- struct fields that express ownership,
+- return types for producer-style APIs.
+
+You do not need to force it onto every local variable.
+
+## 6. Keep handlers thin
 
 HTTP handlers should mostly do four things:
 
@@ -135,15 +246,96 @@ HTTP handlers should mostly do four things:
 3. map service errors to HTTP status,
 4. encode the response DTO.
 
-That is enough.
+Good shape:
 
-If the handler also performs business branching, persistence logic, retries, and background coordination, the boundary is already too wide.
+```go
+func (h Handler) createPayment(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
 
-## 6. Graceful shutdown belongs in the app boundary
+	var req CreatePaymentRequest
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
 
-Graceful shutdown is usually not the service layer's job. It is the application's job.
+	resp, err := h.service.CreatePayment(r.Context(), req)
+	if err != nil {
+		writeServiceError(w, err)
+		return
+	}
 
-The clean shape is:
+	writeJSON(w, http.StatusCreated, resp)
+}
+```
+
+Bad shape:
+
+```go
+func createPayment(w http.ResponseWriter, r *http.Request) {
+	// decode JSON
+	// validate business rules
+	// build SQL
+	// call external API
+	// enqueue audit event
+	// map status codes
+}
+```
+
+That boundary is too wide.
+
+## 7. Validate early, map errors at the edge
+
+The service should return ordinary Go errors.
+
+The handler should translate them into protocol behavior.
+
+```go
+var ErrPartnerIDRequired = errors.New("partner_id is required")
+
+func writeServiceError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, ErrPartnerIDRequired):
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+	default:
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
+	}
+}
+```
+
+This gives you:
+
+- readable service logic,
+- clear HTTP mapping,
+- less hidden framework behavior.
+
+## 8. Prefer explicit construction over framework magic
+
+Go services stay cleaner when dependencies are visible.
+
+```go
+app := NewApp(":8080", Dependencies{
+	Store:     store,
+	IDs:       ids,
+	AuditSink: auditSink,
+	Now:       time.Now,
+})
+```
+
+That is boring, and boring is good here.
+
+The reader can see:
+
+- what the app depends on,
+- what is injectable in tests,
+- where the wiring happens.
+
+## 9. Graceful shutdown belongs in the app boundary
+
+Graceful shutdown is usually not the service layer's job.
+
+It is the application's job:
 
 ```go
 ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
@@ -159,73 +351,115 @@ go func() {
 }()
 ```
 
-In the [`examples/cleanservice`](https://github.com/jaeyoung0509/golang-handbook/tree/develop/examples/cleanservice) package, shutdown also drains an audit worker after the HTTP server stops accepting new work.
-
-Read [Graceful Shutdown](/patterns/graceful-shutdown) next if you want the deeper concurrency version.
-
-## 7. Validate early, map errors at the edge
-
-Good Go service code usually validates near the boundary and returns ordinary errors upward.
+If you also own background workers, drain them after the server stops admitting new work:
 
 ```go
-var ErrPartnerIDRequired = errors.New("partner_id is required")
+func (a *App) Shutdown(ctx context.Context) error {
+	if err := a.server.Shutdown(ctx); err != nil {
+		return err
+	}
 
-switch {
-case errors.Is(err, ErrPartnerIDRequired):
-	writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
-default:
-	writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
+	close(a.auditCh)
+	a.auditWg.Wait()
+	return nil
 }
 ```
 
-That gives you:
+Read [Graceful Shutdown](/patterns/graceful-shutdown) next if you want the deeper concurrency treatment.
 
-- readable business errors in the service,
-- clean protocol mapping in the handler,
-- less framework-style hidden behavior.
+## 10. Suggested package shape
 
-## 8. Prefer explicit construction over framework magic
-
-Go services stay clean when dependencies are visible:
-
-```go
-app := NewApp(":8080", Dependencies{
-	Store:     store,
-	IDs:       ids,
-	AuditSink: auditSink,
-	Now:       time.Now,
-})
-```
-
-This is one reason Go services often feel “lighter” than framework-heavy systems. Construction is boring and obvious, which is usually a feature.
-
-## Suggested package shape
-
-For a modest API service, a simple shape is enough:
+For a modest API service, this is already enough:
 
 ```text
 internal/
   payments/
-    service.go
-    handler.go
     dto.go
+    handler.go
+    service.go
     store.go
 cmd/api/
   main.go
 ```
 
-You do not need a huge hexagonal folder tree on day one.
+You do not need a giant folder taxonomy on day one.
 
 You need:
 
 - a clear edge,
 - a clear service boundary,
-- explicit dependency wiring,
+- explicit wiring,
 - tests that prove the important behavior.
 
-## Interview checklist
+## 11. Common basic mistakes
 
-If someone asks how you structure a Go backend service, a strong answer is:
+### Mistake: using `context.Background()` in request work
+
+```go
+func (s Service) CreatePayment(ctx context.Context, req CreatePaymentRequest) error {
+	return s.store.Save(context.Background(), payment) // bad
+}
+```
+
+Better:
+
+```go
+func (s Service) CreatePayment(ctx context.Context, req CreatePaymentRequest) error {
+	return s.store.Save(ctx, payment)
+}
+```
+
+### Mistake: giant bidirectional channels everywhere
+
+```go
+func startAudit(ch chan AuditEvent) { ... } // vague ownership
+```
+
+Better:
+
+```go
+func startAudit(in <-chan AuditEvent) { ... }
+func emitAudit(out chan<- AuditEvent, event AuditEvent) { out <- event }
+```
+
+### Mistake: DTOs leaking into business code
+
+```go
+func (s Service) CreatePayment(ctx context.Context, req http.Request) error { ... }
+```
+
+Better:
+
+```go
+func (s Service) CreatePayment(ctx context.Context, req CreatePaymentRequest) (PaymentResponse, error) { ... }
+```
+
+### Mistake: hidden globals for time and IDs
+
+```go
+func CreatePayment(...) Payment {
+	return Payment{ID: uuid.NewString(), CreatedAt: time.Now()}
+}
+```
+
+Better:
+
+```go
+type IDGenerator interface {
+	Next() string
+}
+
+type Service struct {
+	ids IDGenerator
+	now func() time.Time
+}
+```
+
+This is much easier to test.
+
+## 12. Interview checklist
+
+If someone asks how you would structure a Go backend service, a strong answer is:
 
 - DTOs live at the HTTP or message boundary.
 - Business logic lives in a service layer with plain Go types.
@@ -233,10 +467,11 @@ If someone asks how you structure a Go backend service, a strong answer is:
 - `context.Context` is passed through every request-scoped dependency.
 - Channels use direction when ownership matters.
 - Graceful shutdown uses `http.Server.Shutdown` with a deadline.
-- Errors are wrapped in the service and mapped to protocol status at the edge.
+- Errors are returned from the service and mapped to protocol status at the edge.
+- Constructors wire dependencies explicitly instead of hiding them in global state.
 
 ## Practical takeaway
 
 You do not need a Go equivalent of FastAPI magic to make a service feel clean.
 
-You need sharper boundaries, smaller interfaces, and explicit lifecycle ownership.
+You need sharper boundaries, smaller interfaces, explicit lifecycle ownership, and enough small code snippets that the design stays obvious under pressure.

--- a/docs/ko/guide/clean-go-service-basics.md
+++ b/docs/ko/guide/clean-go-service-basics.md
@@ -5,25 +5,29 @@ description: DTO, 서비스 경계, graceful shutdown, channel direction, 패키
 
 # 깔끔한 Go 서비스 기본기
 
-FastAPI, Spring, NestJS 쪽에 익숙하다면 Go에서도 가장 깔끔한 스타일은 “비슷한 큰 프레임워크를 찾아서 마법처럼 쓰는 것”이라고 생각하기 쉽습니다.
+FastAPI, Spring, NestJS 쪽에 익숙하다면 Go에서도 “큰 프레임워크를 붙이면 깔끔해질 것”이라고 생각하기 쉽습니다.
 
-하지만 보통 Go에서 더 깔끔한 스타일은 다음입니다.
+하지만 보통 Go에서 더 깔끔한 기본값은 다음입니다.
 
 - explicit wiring
+- edge에만 있는 DTO
+- 얇은 handler
+- plain service
 - consumer 가까이에 둔 작은 interface
-- transport edge에만 있는 DTO
-- plain Go type 중심의 service
-- 메인 프로그램에 포함된 graceful shutdown
+- app boundary에 둔 graceful shutdown
+- ownership이 드러나는 channel
 
 :::tip Quick takeaway
-인터뷰 답변용으로는 `handler -> service -> store`, edge DTO, 전체 call chain의 `context.Context`, channel direction으로 드러나는 ownership, `http.Server.Shutdown` 기반 graceful exit를 기본 답으로 가져가면 좋습니다.
+인터뷰 답변용 기본 구조는 `handler -> service -> store`, edge DTO, call chain 전체에 흐르는 `context.Context`, ownership이 보이는 channel, `http.Server.Shutdown` 기반 graceful exit입니다.
 :::
 
-## Mental model
+이 구조의 실제 예시는 [`examples/cleanservice`](https://github.com/jaeyoung0509/golang-handbook/tree/develop/examples/cleanservice)에서 볼 수 있습니다.
+
+## 먼저 외울 기본 구조
 
 ```mermaid
 flowchart LR
-    A["HTTP request DTO"] --> B["handler"]
+    A["request DTO"] --> B["handler"]
     B --> C["service"]
     C --> D["store interface"]
     C --> E["send-only audit channel"]
@@ -31,17 +35,26 @@ flowchart LR
     C --> G["response DTO"]
 ```
 
-이 구조의 구체적인 예시는 [`examples/cleanservice`](https://github.com/jaeyoung0509/golang-handbook/tree/develop/examples/cleanservice)에서 볼 수 있습니다.
+면접에서 “Go API를 어떻게 구조화하나요?”라는 질문을 받으면, 이 그림만 제대로 설명해도 이미 좋은 출발입니다.
 
 ## 1. DTO는 transport edge에 둔다
 
-가장 흔한 설계 실수 중 하나는 HTTP/JSON 모양의 struct를 애플리케이션 전체로 끌고 다니는 것입니다.
+좋지 않은 기본값:
 
-더 깔끔한 경계는 이렇습니다.
+```go
+type Payment struct {
+	PartnerID string `json:"partner_id"`
+	Amount    int    `json:"amount"`
+	Currency  string `json:"currency"`
+}
 
-- handler에 request DTO
-- service 내부에는 domain 혹은 service input
-- 응답 직전에 response DTO
+func (s Service) CreatePayment(ctx context.Context, payment Payment) error {
+	// JSON concern이 service 안까지 들어옴
+	return nil
+}
+```
+
+더 나은 구조:
 
 ```go
 type CreatePaymentRequest struct {
@@ -57,17 +70,48 @@ type Payment struct {
 	Currency  string
 	CreatedAt time.Time
 }
+
+type PaymentResponse struct {
+	ID        string `json:"id"`
+	PartnerID string `json:"partner_id"`
+	Amount    int    `json:"amount"`
+	Currency  string `json:"currency"`
+	CreatedAt string `json:"created_at"`
+}
 ```
 
-이 방식이 더 나은 이유:
+핵심은 이겁니다.
 
-- transport concern이 edge에만 남고
-- service code가 JSON tag에 의존하지 않으며
-- 테스트가 plain type 중심으로 단순해집니다
+- handler가 request/response DTO를 소유하고
+- service는 plain type을 소유합니다
 
-## 2. interface는 consumer 가까이에 둔다
+이렇게 해야 transport concern이 애플리케이션 전체로 번지지 않습니다.
 
-Go에서는 보통 interface를 구현체 쪽이 아니라 소비하는 쪽에 둡니다.
+## 2. DTO mapping은 작아도 명시적으로 둔다
+
+작은 mapping 함수는 부끄러운 코드가 아니라, 오히려 Go 서비스 코드에서 가장 깔끔한 부분 중 하나입니다.
+
+```go
+func toPaymentResponse(payment Payment) PaymentResponse {
+	return PaymentResponse{
+		ID:        payment.ID,
+		PartnerID: payment.PartnerID,
+		Amount:    payment.Amount,
+		Currency:  payment.Currency,
+		CreatedAt: payment.CreatedAt.Format(time.RFC3339),
+	}
+}
+```
+
+이게 다음보다 낫습니다.
+
+- DB model을 그대로 JSON으로 내보내기
+- persistence field를 response에 그대로 노출하기
+- reflection magic에 숨기기
+
+## 3. interface는 consumer 가까이에 둔다
+
+Go에서는 interface를 보통 구현체 쪽이 아니라 소비하는 쪽에 둡니다.
 
 ```go
 type PaymentStore interface {
@@ -79,71 +123,217 @@ type Service struct {
 }
 ```
 
-미리 큰 `repository` 패키지를 만들어 speculative interface를 쌓는 것보다 이 편이 더 Go답습니다.
+큰 `repository` 패키지를 만들고 speculative interface를 쌓는 것보다 이 편이 더 Go답습니다.
 
-인터뷰에서 기억할 답:
+인터뷰용 한 문장:
 
-“Go에서는 작은 interface를 보통 consumer package에 둡니다. dependency shape를 실제로 소유하는 쪽이 consumer이기 때문입니다.”
+“Go에서는 dependency contract를 실제로 소비하는 쪽이 shape를 결정하므로, 작은 interface를 consumer package 가까이에 둡니다.”
 
-## 3. `context.Context`는 call chain 전체에 흘린다
+## 4. `context.Context`는 request path 전체에 흘린다
 
 기본 규칙은 이렇습니다.
 
-- handler는 `r.Context()`를 받고
-- service는 첫 번째 인자로 `ctx`를 받으며
+- handler는 `r.Context()`를 쓰고
+- service는 첫 번째 인자로 `ctx`를 받고
 - store와 outbound call도 같은 context를 받습니다
 
 ```go
+func (h Handler) createPayment(w http.ResponseWriter, r *http.Request) {
+	resp, err := h.service.CreatePayment(r.Context(), req)
+	_ = resp
+	_ = err
+}
+
 func (s Service) CreatePayment(ctx context.Context, req CreatePaymentRequest) (PaymentResponse, error) {
-	// validation
-	// store.Save(ctx, ...)
-	// outbound calls with ctx
+	if err := s.store.Save(ctx, payment); err != nil {
+		return PaymentResponse{}, err
+	}
+	return toPaymentResponse(payment), nil
 }
 ```
 
-request-scoped code에서 `context.Background()`나 global lifetime을 몰래 쓰지 않는 것이 기본입니다.
-
-## 4. channel direction으로 ownership을 드러낸다
-
-작은 문법이지만 API를 훨씬 읽기 좋게 만듭니다.
+request-scoped code에서 이런 식은 피합니다.
 
 ```go
-type Service struct {
-	audit chan<- AuditEvent
+func (s Service) CreatePayment(_ context.Context, req CreatePaymentRequest) error {
+	return s.store.Save(context.Background(), payment) // bad
+}
+```
+
+이렇게 하면 caller의 timeout과 cancellation을 잃습니다.
+
+## 5. Channel direction 치트시트
+
+여기서 많이 헷갈리는 게 정상입니다. 짧게 외우면 됩니다.
+
+### 세 가지 형태
+
+| 타입 | 의미 | 이 쪽에서 할 수 있는 일 |
+| --- | --- | --- |
+| `chan T` | bidirectional | send, receive 둘 다 |
+| `chan<- T` | send-only | send만 |
+| `<-chan T` | receive-only | receive만 |
+
+### 가장 쉬운 기억법
+
+- `chan<- T`: 내가 `T`를 집어넣는다
+- `<-chan T`: 내가 `T`를 꺼내온다
+
+### 최소 예제
+
+```go
+func producer(out chan<- int) {
+	out <- 1
 }
 
-func drainAudit(events <-chan AuditEvent, sink AuditSink) {
+func consumer(in <-chan int) int {
+	return <-in
+}
+
+func pipe() <-chan int {
+	out := make(chan int, 1)
+	out <- 42
+	close(out)
+	return out
+}
+```
+
+### 왜 이게 유용한가
+
+좋지 않은 예:
+
+```go
+func drainAudit(events chan AuditEvent) {
 	for event := range events {
-		_ = sink.Write(context.Background(), event)
+		_ = event
 	}
 }
 ```
 
-이렇게 쓰면 의도가 바로 드러납니다.
+이 함수가 send도 가능한지, receive만 하는지, close owner인지 읽는 사람이 알 수 없습니다.
 
-- service는 send만 할 수 있고
-- worker는 receive만 할 수 있습니다
+더 나은 예:
 
-`chan AuditEvent`를 여기저기 넘기며 ownership을 추측하게 만드는 것보다 훨씬 낫습니다.
+```go
+func drainAudit(events <-chan AuditEvent) {
+	for event := range events {
+		_ = event
+	}
+}
+```
 
-## 5. handler는 얇게 유지한다
+이제 API 자체가 말해줍니다.
 
-HTTP handler는 보통 네 가지만 하면 됩니다.
+- 이 함수는 read만 하고
+- write하지 않으며
+- sending side owner도 아니다
+
+### 실전 규칙
+
+channel direction은 다음에 특히 유용합니다.
+
+- 함수 파라미터
+- ownership을 드러내는 struct field
+- producer 스타일의 return type
+
+모든 local variable에 강제로 붙일 필요는 없습니다.
+
+## 6. Handler는 얇게 유지한다
+
+HTTP handler는 보통 네 가지만 하면 충분합니다.
 
 1. request DTO decode/validate
 2. service 호출
 3. service error를 HTTP status로 매핑
 4. response DTO encode
 
-그 정도면 충분합니다.
+좋은 예:
 
-handler가 business branching, persistence logic, retry, background coordination까지 다 해버리면 경계가 이미 너무 넓어진 것입니다.
+```go
+func (h Handler) createPayment(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
 
-## 6. graceful shutdown은 app boundary 책임이다
+	var req CreatePaymentRequest
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
 
-graceful shutdown은 대개 service layer 책임이 아니라 application 책임입니다.
+	resp, err := h.service.CreatePayment(r.Context(), req)
+	if err != nil {
+		writeServiceError(w, err)
+		return
+	}
 
-깔끔한 형태는 대략 이렇습니다.
+	writeJSON(w, http.StatusCreated, resp)
+}
+```
+
+좋지 않은 예:
+
+```go
+func createPayment(w http.ResponseWriter, r *http.Request) {
+	// decode JSON
+	// validate business rules
+	// build SQL
+	// call external API
+	// enqueue audit event
+	// map status codes
+}
+```
+
+이건 경계가 너무 넓습니다.
+
+## 7. Validation은 일찍, error mapping은 edge에서
+
+service는 ordinary Go error를 반환하고,
+handler는 그것을 protocol behavior로 바꾸는 식이 깔끔합니다.
+
+```go
+var ErrPartnerIDRequired = errors.New("partner_id is required")
+
+func writeServiceError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, ErrPartnerIDRequired):
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+	default:
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
+	}
+}
+```
+
+이렇게 하면:
+
+- service 안의 business error가 읽기 쉽고
+- handler의 protocol mapping도 명확하며
+- framework-style hidden behavior가 줄어듭니다
+
+## 8. Framework magic보다 explicit construction
+
+Go 서비스는 dependency가 보일수록 더 깔끔해집니다.
+
+```go
+app := NewApp(":8080", Dependencies{
+	Store:     store,
+	IDs:       ids,
+	AuditSink: auditSink,
+	Now:       time.Now,
+})
+```
+
+이게 지루해 보여도 장점입니다.
+
+읽는 사람은 바로 알 수 있습니다.
+
+- 앱이 무엇에 의존하는지
+- 무엇이 테스트 대체 가능인지
+- wiring이 어디서 일어나는지
+
+## 9. Graceful shutdown은 app boundary 책임이다
+
+graceful shutdown은 보통 service layer가 아니라 application 책임입니다.
 
 ```go
 ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
@@ -159,73 +349,115 @@ go func() {
 }()
 ```
 
-[`examples/cleanservice`](https://github.com/jaeyoung0509/golang-handbook/tree/develop/examples/cleanservice) 예제는 여기서 한 단계 더 가서, HTTP 서버가 새 요청을 멈춘 뒤 audit worker까지 drain합니다.
-
-동시성 패턴 관점에서 더 깊게 보려면 [Graceful Shutdown](/ko/patterns/graceful-shutdown) 문서를 같이 읽으면 됩니다.
-
-## 7. validation은 일찍, error mapping은 edge에서
-
-좋은 Go 서비스 코드는 보통 boundary 가까이에서 validation을 하고, 위로는 ordinary error를 반환합니다.
+background worker도 소유하고 있다면, 새 작업 수용을 멈춘 뒤 worker도 drain해야 합니다.
 
 ```go
-var ErrPartnerIDRequired = errors.New("partner_id is required")
+func (a *App) Shutdown(ctx context.Context) error {
+	if err := a.server.Shutdown(ctx); err != nil {
+		return err
+	}
 
-switch {
-case errors.Is(err, ErrPartnerIDRequired):
-	writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
-default:
-	writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
+	close(a.auditCh)
+	a.auditWg.Wait()
+	return nil
 }
 ```
 
-이 패턴의 장점은:
+더 깊은 동시성 패턴은 [Graceful Shutdown](/ko/patterns/graceful-shutdown) 문서를 같이 보면 됩니다.
 
-- service 안에서는 business error가 읽기 쉽고
-- handler에서는 protocol mapping이 명확하며
-- 프레임워크성 hidden behavior가 줄어든다는 점입니다
-
-## 8. framework magic보다 explicit construction
-
-Go 서비스는 dependency가 눈에 보일수록 깔끔해집니다.
-
-```go
-app := NewApp(":8080", Dependencies{
-	Store:     store,
-	IDs:       ids,
-	AuditSink: auditSink,
-	Now:       time.Now,
-})
-```
-
-이게 Go 서비스가 프레임워크 중심 시스템보다 “가볍게” 느껴지는 이유 중 하나입니다. construction이 지루할 만큼 명시적이라는 건 보통 장점입니다.
-
-## 추천 패키지 구조
+## 10. 추천 패키지 구조
 
 적당한 크기의 API 서비스라면 이 정도면 충분합니다.
 
 ```text
 internal/
   payments/
-    service.go
-    handler.go
     dto.go
+    handler.go
+    service.go
     store.go
 cmd/api/
   main.go
 ```
 
-처음부터 거대한 hexagonal folder tree가 필요한 건 아닙니다.
+처음부터 거대한 folder taxonomy가 필요한 건 아닙니다.
 
-정말 필요한 것은:
+정말 중요한 것은:
 
 - 분명한 edge
 - 분명한 service boundary
-- explicit dependency wiring
+- explicit wiring
 - 중요한 동작을 증명하는 테스트
 
 입니다.
 
-## 인터뷰 체크리스트
+## 11. 자주 나오는 기본 실수
+
+### 실수: request work에서 `context.Background()` 사용
+
+```go
+func (s Service) CreatePayment(ctx context.Context, req CreatePaymentRequest) error {
+	return s.store.Save(context.Background(), payment) // bad
+}
+```
+
+더 나은 예:
+
+```go
+func (s Service) CreatePayment(ctx context.Context, req CreatePaymentRequest) error {
+	return s.store.Save(ctx, payment)
+}
+```
+
+### 실수: 큰 bidirectional channel을 아무 데나 전달
+
+```go
+func startAudit(ch chan AuditEvent) { ... } // ownership이 모호함
+```
+
+더 나은 예:
+
+```go
+func startAudit(in <-chan AuditEvent) { ... }
+func emitAudit(out chan<- AuditEvent, event AuditEvent) { out <- event }
+```
+
+### 실수: DTO가 비즈니스 코드까지 침투
+
+```go
+func (s Service) CreatePayment(ctx context.Context, req http.Request) error { ... }
+```
+
+더 나은 예:
+
+```go
+func (s Service) CreatePayment(ctx context.Context, req CreatePaymentRequest) (PaymentResponse, error) { ... }
+```
+
+### 실수: 시간과 ID를 global로 숨김
+
+```go
+func CreatePayment(...) Payment {
+	return Payment{ID: uuid.NewString(), CreatedAt: time.Now()}
+}
+```
+
+더 나은 예:
+
+```go
+type IDGenerator interface {
+	Next() string
+}
+
+type Service struct {
+	ids IDGenerator
+	now func() time.Time
+}
+```
+
+이렇게 해야 테스트가 쉬워집니다.
+
+## 12. 인터뷰 체크리스트
 
 “Go 백엔드 서비스를 어떻게 구조화하나요?”라는 질문에는 이렇게 답하면 강합니다.
 
@@ -235,10 +467,11 @@ cmd/api/
 - `context.Context`는 request-scoped dependency 전체로 전달합니다.
 - ownership이 중요하면 channel direction을 사용합니다.
 - graceful shutdown은 deadline을 둔 `http.Server.Shutdown`으로 처리합니다.
-- error는 service에서 wrap하고, protocol status 매핑은 edge에서 합니다.
+- error는 service에서 반환하고, protocol status 매핑은 edge에서 합니다.
+- constructor에서 dependency를 명시적으로 wiring하고 global state는 줄입니다.
 
 ## Practical takeaway
 
 FastAPI 같은 마법이 없어도 Go 서비스는 충분히 깔끔해질 수 있습니다.
 
-필요한 것은 더 날카로운 경계, 더 작은 interface, 더 명시적인 lifecycle ownership입니다.
+필요한 것은 더 날카로운 경계, 더 작은 interface, 더 명시적인 lifecycle ownership, 그리고 압박 상황에서도 바로 떠올릴 수 있을 만큼 짧고 많은 코드 스니펫입니다.


### PR DESCRIPTION
## Summary
- expand the clean Go service basics guide in English and Korean with substantially more inline code snippets
- add a channel direction cheat sheet for `chan T`, `chan<- T`, and `<-chan T` with clearer beginner-friendly examples
- add more bad-vs-better examples for DTO boundaries, thin handlers, context usage, constructors, and graceful shutdown

## Testing
- go test ./...
- npm run docs:build

Closes #57
