### PR TITLE
Add application-layer parallelism guide

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -7,6 +7,7 @@ const enSidebar = [
       { text: "Getting Started", link: "/guide/getting-started" },
       { text: "How to Read the Examples", link: "/guide/how-to-read" },
       { text: "Clean Go Service Basics", link: "/guide/clean-go-service-basics" },
+      { text: "Application-Layer Parallelism", link: "/guide/application-layer-parallelism" },
     ],
   },
   {
@@ -137,6 +138,7 @@ const koSidebar = [
       { text: "시작하기", link: "/ko/guide/getting-started" },
       { text: "예제 읽는 법", link: "/ko/guide/how-to-read" },
       { text: "깔끔한 Go 서비스 기본기", link: "/ko/guide/clean-go-service-basics" },
+      { text: "애플리케이션 레이어 병렬 호출", link: "/ko/guide/application-layer-parallelism" },
     ],
   },
   {

--- a/docs/guide/application-layer-parallelism.md
+++ b/docs/guide/application-layer-parallelism.md
@@ -1,0 +1,384 @@
+---
+title: Application-Layer Parallelism
+description: How clean Go services should parallelize downstream work, why large Go codebases wrap errgroup or WaitGroup, and which tool fits each scenario.
+---
+
+# Application-Layer Parallelism
+
+In a real Go service, the application or use-case layer often has to call several downstreams in parallel:
+
+- partner config,
+- risk rules,
+- balances,
+- inventory,
+- pricing,
+- entitlement or policy checks.
+
+The problem is not whether goroutines are allowed.
+
+The real problem is choosing the right lifetime contract for that parallel work.
+
+:::tip Quick takeaway
+Use direct `errgroup` for one request with a small finite sibling set. Use a thin `errgroup` wrapper when the team wants explicit `Go(ctx)` semantics, shared limit policy, tracing, or helper methods. Use a thin `WaitGroup` or lifecycle wrapper for long-lived background loops and shutdown ownership.
+:::
+
+If you want concrete code, see [`examples/appparallel`](https://github.com/jaeyoung0509/golang-handbook/tree/develop/examples/appparallel).
+
+## Mental model
+
+```mermaid
+flowchart LR
+    A["handler"] --> B["application service"]
+    B --> C["direct errgroup for one request"]
+    B --> D["wrapped errgroup for bounded fan-out"]
+    E["app boundary"] --> F["background lifecycle group"]
+    F --> G["cache warmer"]
+    F --> H["audit projector"]
+    F --> I["subscription loop"]
+```
+
+The application layer is where you decide:
+
+- which calls should succeed or fail together,
+- which calls should cancel siblings on the first error,
+- which goroutines are request-scoped,
+- and which goroutines belong to the process itself.
+
+That is why concurrency policy belongs in the application layer, not hidden inside arbitrary helpers.
+
+## Why large codebases wrap `errgroup` and `WaitGroup`
+
+Large Go codebases do not wrap these primitives because they are bad.
+
+They wrap them because the raw primitives are intentionally small and do not encode local service policy.
+
+Raw `errgroup` gives you:
+
+- child goroutine start,
+- parent-derived cancellation,
+- one `Wait`,
+- optional bounded parallelism through `SetLimit`.
+
+Raw `sync.WaitGroup` gives you:
+
+- a counter,
+- and almost nothing else.
+
+What raw primitives do not encode:
+
+- explicit context ownership,
+- admission control after shutdown begins,
+- standard logging and tracing hooks,
+- panic policy,
+- spawn-and-wait helper shapes,
+- stop-signal conventions,
+- and the difference between request lifetime and service lifetime.
+
+That is why wrappers appear in real systems.
+
+## Open-source source pointers
+
+Three good examples:
+
+- [CockroachDB `ctxgroup`](https://github.com/cockroachdb/cockroach/blob/master/pkg/util/ctxgroup/ctxgroup.go): a wrapper over `errgroup` that makes context passing explicit with `GoCtx(func(ctx context.Context) error)` and adds helper shapes such as `GoAndWait`.
+- [CockroachDB `stop.Stopper`](https://github.com/cockroachdb/cockroach/blob/master/pkg/util/stop/stopper.go): a heavier lifecycle wrapper that rejects new work during quiescing, waits for tasks, and treats goroutine management as part of service shutdown.
+- [Kubernetes `wait.Group`](https://github.com/kubernetes/apimachinery/blob/master/pkg/util/wait/wait.go): a thin wrapper over `sync.WaitGroup` with `Start`, `StartWithContext`, and `StartWithChannel` so goroutine startup follows one consistent convention.
+
+The important point is not the exact API.
+
+The important point is that each project encodes its own invariants once instead of asking every call site to remember them forever.
+
+## Scenario 1: direct `errgroup` for one request
+
+This is the default for request-scoped fan-out.
+
+Use it when:
+
+- the task set is finite,
+- the tasks belong to one request or one use case,
+- one failure should cancel siblings,
+- all child work should finish before the handler returns.
+
+The example package uses direct `errgroup` for `LoadCheckoutSnapshot`, which fans out to partner config, risk, and balance reads.
+
+```go
+func LoadCheckoutSnapshot(ctx context.Context, req CheckoutRequest, deps Dependencies) (CheckoutSnapshot, error) {
+	group, groupCtx := errgroup.WithContext(ctx)
+
+	var partner PartnerConfig
+	var risk RiskDecision
+	var balance BalanceSnapshot
+
+	group.Go(func() error {
+		result, err := deps.PartnerConfigs.LoadPartnerConfig(groupCtx, req.PartnerID)
+		if err != nil {
+			return fmt.Errorf("load partner config: %w", err)
+		}
+		partner = result
+		return nil
+	})
+
+	group.Go(func() error {
+		result, err := deps.Risk.EvaluateRisk(groupCtx, req)
+		if err != nil {
+			return fmt.Errorf("evaluate risk: %w", err)
+		}
+		risk = result
+		return nil
+	})
+
+	group.Go(func() error {
+		result, err := deps.Balances.LoadBalance(groupCtx, req.UserID)
+		if err != nil {
+			return fmt.Errorf("load balance: %w", err)
+		}
+		balance = result
+		return nil
+	})
+
+	if err := group.Wait(); err != nil {
+		return CheckoutSnapshot{}, err
+	}
+
+	return CheckoutSnapshot{
+		UserID:    req.UserID,
+		PartnerID: req.PartnerID,
+		Partner:   partner,
+		Risk:      risk,
+		Balance:   balance,
+	}, nil
+}
+```
+
+Why this is the right default:
+
+- the lifetime is obvious,
+- cancellation is automatic,
+- the handler cannot accidentally return before the work is done.
+
+If your use case is just “call three downstreams and join the results,” do not invent a framework first.
+
+## Scenario 2: wrap `errgroup` when the team wants one standard request fan-out shape
+
+This is where large services start wrapping `errgroup`.
+
+Common reasons:
+
+- avoid `group, ctx := errgroup.WithContext(ctx)` shadowing mistakes,
+- standardize `SetLimit` policy,
+- pass the derived context explicitly into every task,
+- add tracing, metrics, logging, or panic normalization,
+- expose helper shapes such as `RunAll`, `GoCtx`, or `GoAndWait`.
+
+The example package uses a thin wrapper called `TaskGroup`.
+
+```go
+type TaskGroup struct {
+	ctx   context.Context
+	group *errgroup.Group
+}
+
+func NewTaskGroup(ctx context.Context, limit int) (*TaskGroup, error) {
+	group, childCtx := errgroup.WithContext(ctx)
+	group.SetLimit(limit)
+
+	return &TaskGroup{
+		ctx:   childCtx,
+		group: group,
+	}, nil
+}
+
+func (g *TaskGroup) Go(fn func(context.Context) error) {
+	g.group.Go(func() error {
+		return fn(g.ctx)
+	})
+}
+```
+
+That wrapper does not change the underlying model.
+
+It changes the call-site discipline.
+
+The batch example uses it for bounded partner fan-out:
+
+```go
+group, err := NewTaskGroup(ctx, limit)
+if err != nil {
+	return nil, err
+}
+
+for index, partnerID := range partnerIDs {
+	index := index
+	partnerID := partnerID
+
+	group.Go(func(ctx context.Context) error {
+		summary, err := fetch.FetchPartnerSummary(ctx, partnerID)
+		if err != nil {
+			return fmt.Errorf("fetch partner %s: %w", partnerID, err)
+		}
+		results[index] = summary
+		return nil
+	})
+}
+
+if err := group.Wait(); err != nil {
+	return nil, err
+}
+```
+
+Best fit:
+
+- request-scoped batch reads,
+- bounded fan-out over many IDs,
+- one team-wide concurrency shape for use cases,
+- shared instrumentation and limit policy.
+
+This is the same core idea you can see in CockroachDB `ctxgroup`: keep the `errgroup` semantics, but make the context and helper contract harder to misuse.
+
+## Scenario 3: wrap `WaitGroup` for long-lived background tasks
+
+`sync.WaitGroup` is not a request fan-out primitive.
+
+It has no:
+
+- error propagation,
+- derived context,
+- shutdown contract,
+- admission control,
+- or cancellation semantics.
+
+That is why raw `WaitGroup` is usually the wrong tool inside request-scoped application code.
+
+Where it does fit is long-lived background work that belongs to the process:
+
+- cache warmers,
+- audit projectors,
+- subscription loops,
+- periodic refreshers,
+- controller or watcher loops.
+
+In those cases the real need is lifecycle management, not fail-fast error aggregation.
+
+The example package uses `BackgroundGroup`, a thin wrapper around `WaitGroup` plus owned cancellation.
+
+```go
+type BackgroundGroup struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	mu     sync.Mutex
+	closed bool
+	wg     sync.WaitGroup
+}
+
+func (g *BackgroundGroup) Go(fn func(context.Context)) error {
+	g.mu.Lock()
+	if g.closed {
+		g.mu.Unlock()
+		return ErrClosed
+	}
+	g.wg.Add(1)
+	g.mu.Unlock()
+
+	go func() {
+		defer g.wg.Done()
+		fn(g.ctx)
+	}()
+
+	return nil
+}
+
+func (g *BackgroundGroup) Shutdown(ctx context.Context) error {
+	g.mu.Lock()
+	if !g.closed {
+		g.closed = true
+		g.cancel()
+	}
+	g.mu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		g.wg.Wait()
+	}()
+
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+```
+
+This is the same design pressure that leads Kubernetes to add `StartWithContext` around `WaitGroup`, and CockroachDB to build a much heavier `Stopper` around service quiescing.
+
+## Scenario matrix
+
+| Scenario | Best default | Why |
+| --- | --- | --- |
+| One request, three to six sibling downstream calls | direct `errgroup.WithContext` | Fail-fast cancellation and one wait point are exactly the contract you want. |
+| One request, many IDs, but still one bounded batch | thin `errgroup` wrapper with `SetLimit` | Same fail-fast model, but the wrapper makes context, limits, and instrumentation uniform. |
+| Background worker owned by the process | lifecycle wrapper around `WaitGroup` | The important contract is start, stop, reject-new-work, and wait-for-exit. |
+| Service startup components that must quiesce cleanly | lifecycle wrapper or stopper-style abstraction | Shutdown policy and admission control matter more than raw counting. |
+| Partial-success fan-out where one failure must not cancel the rest | result collector or worker-pool style orchestration | Raw fail-fast `errgroup` is the wrong semantics. |
+| Best-effort side effects triggered by a request | durable queue, outbox, or owned background subsystem | Detached request goroutines are easy to leak and hard to reason about. |
+
+## Failure patterns to avoid
+
+### 1. Raw `WaitGroup` in request fan-out
+
+```go
+var wg sync.WaitGroup
+var risk RiskDecision
+var balance BalanceSnapshot
+
+wg.Add(2)
+go func() {
+	defer wg.Done()
+	risk, _ = riskClient.EvaluateRisk(ctx, req)
+}()
+go func() {
+	defer wg.Done()
+	balance, _ = balanceClient.LoadBalance(ctx, req.UserID)
+}()
+wg.Wait()
+```
+
+This compiles, but now you have no first-error policy, no automatic sibling cancellation, and no clear rule for how failures are returned.
+
+### 2. Fire-and-forget inside the application layer
+
+```go
+go auditSink.Write(context.Background(), event)
+```
+
+Now the work is no longer request-scoped and not clearly process-scoped either.
+
+That is how “just one goroutine” turns into leaks and mystery shutdown bugs.
+
+### 3. Mixing request and process lifetimes in one abstraction
+
+Do not use the same helper type for:
+
+- request fan-out that must finish before the handler returns,
+- and background loops that outlive any one request.
+
+Those are different lifetime contracts.
+
+## What to say in an interview
+
+A strong answer is:
+
+1. “For one request with a finite set of sibling calls, I use `errgroup.WithContext` directly.”
+2. “If the team repeatedly needs the same bounded fan-out shape, I wrap `errgroup` so context passing, limits, and instrumentation are standardized.”
+3. “For long-lived goroutines owned by the service, I do not treat `WaitGroup` as a request primitive. I wrap it with shutdown ownership and rejection of new work.”
+
+That answer is usually better than naming five packages without explaining lifetime semantics.
+
+## Related pages
+
+- [Clean Go Service Basics](/guide/clean-go-service-basics)
+- [Structured Concurrency](/advanced/structured-concurrency)
+- [Graceful Shutdown](/patterns/graceful-shutdown)
+- [Leak, Shutdown, and Timeout Testing](/testing/leaks-and-shutdowns)

--- a/docs/guide/clean-go-service-basics.md
+++ b/docs/guide/clean-go-service-basics.md
@@ -23,6 +23,8 @@ For interviews, a strong default answer is: `handler -> service -> store`, DTOs 
 
 If you want a concrete version of this shape, see [`examples/cleanservice`](https://github.com/jaeyoung0509/golang-handbook/tree/develop/examples/cleanservice).
 
+If the next question is “what happens when one use case has to call several downstreams in parallel?”, continue with [Application-Layer Parallelism](/guide/application-layer-parallelism).
+
 ## The default shape to memorize
 
 ```mermaid

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -32,6 +32,7 @@ That split matters because the site explains the patterns, but the Go packages p
 │   ├── extras/
 │   └── ko/
 ├── examples/
+│   ├── appparallel/
 │   ├── actor/
 │   ├── cleanservice/
 │   ├── contexttimeout/
@@ -68,10 +69,11 @@ Use the commands above before pushing changes. The first validates the static si
 
 1. Read [Fundamentals Overview](/fundamentals/).
 2. If you are preparing for interviews or basic backend service design, read [Clean Go Service Basics](/guide/clean-go-service-basics).
-3. Move through [Patterns Overview](/patterns/) with the matching package under `examples/`.
-4. Read [Testing Overview](/testing/) before trusting any timeout or shutdown path.
-5. Read [Production Overview](/production/) once you care about operating rules and large-scale system tradeoffs.
-6. Only then move into [Advanced Overview](/advanced/) and [Extras Overview](/extras/).
+3. If one use case needs several downstream calls in parallel, continue with [Application-Layer Parallelism](/guide/application-layer-parallelism).
+4. Move through [Patterns Overview](/patterns/) with the matching package under `examples/`.
+5. Read [Testing Overview](/testing/) before trusting any timeout or shutdown path.
+6. Read [Production Overview](/production/) once you care about operating rules and large-scale system tradeoffs.
+7. Only then move into [Advanced Overview](/advanced/) and [Extras Overview](/extras/).
 
 ## What is inside each example
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -116,6 +116,7 @@ features:
 | --- | --- |
 | Why goroutines are cheap and how the scheduler actually runs them | [Go Runtime and Scheduler](/fundamentals/go-runtime-scheduler) |
 | How to structure a clean Go API service for interviews and day-to-day backend work | [Clean Go Service Basics](/guide/clean-go-service-basics) |
+| How to parallelize several downstream calls in one use case without turning service code into goroutine soup | [Application-Layer Parallelism](/guide/application-layer-parallelism) |
 | Why a local value still ends up on the heap | [Compiler and Toolchain](/internals/compiler-and-toolchain) |
 | Why one allocation pattern hurts GC more than another | [Allocator and Hybrid Write Barrier](/internals/allocator-and-write-barrier) |
 | How request-scoped cancellation actually propagates | [context Package Internals](/stdlib/context-internals) |

--- a/docs/ko/guide/application-layer-parallelism.md
+++ b/docs/ko/guide/application-layer-parallelism.md
@@ -1,0 +1,384 @@
+---
+title: 애플리케이션 레이어 병렬 호출
+description: 깔끔한 Go 서비스에서 다운스트림 호출을 어떻게 병렬화할지, 왜 큰 Go 코드베이스가 errgroup이나 WaitGroup을 래핑하는지, 각 상황에 어떤 도구가 맞는지 설명합니다.
+---
+
+# 애플리케이션 레이어 병렬 호출
+
+실제 Go 서비스의 application 또는 use-case 레이어는 여러 다운스트림을 병렬로 호출해야 하는 경우가 많습니다.
+
+- partner config,
+- risk rule,
+- balance,
+- inventory,
+- pricing,
+- entitlement 또는 policy check.
+
+문제는 goroutine을 써도 되느냐가 아닙니다.
+
+진짜 문제는 그 병렬 작업에 어떤 lifetime contract를 줄 것인가입니다.
+
+:::tip Quick takeaway
+작고 유한한 sibling task를 가진 단일 요청에는 직접 `errgroup`를 쓰는 것이 기본값입니다. 팀이 `Go(ctx)` 형태, 공통 limit 정책, tracing, helper 메서드를 원하면 얇은 `errgroup` 래퍼를 둡니다. 오래 사는 background loop에는 `WaitGroup` 자체보다 lifecycle wrapper를 두는 편이 맞습니다.
+:::
+
+구체적인 코드는 [`examples/appparallel`](https://github.com/jaeyoung0509/golang-handbook/tree/develop/examples/appparallel)에서 볼 수 있습니다.
+
+## 머릿속 모델
+
+```mermaid
+flowchart LR
+    A["handler"] --> B["application service"]
+    B --> C["한 요청용 direct errgroup"]
+    B --> D["bounded fan-out용 wrapped errgroup"]
+    E["app boundary"] --> F["background lifecycle group"]
+    F --> G["cache warmer"]
+    F --> H["audit projector"]
+    F --> I["subscription loop"]
+```
+
+애플리케이션 레이어는 다음을 결정하는 곳입니다.
+
+- 어떤 호출들이 함께 성공하거나 실패해야 하는지,
+- 첫 오류가 sibling을 취소해야 하는지,
+- 어떤 goroutine이 request-scoped인지,
+- 어떤 goroutine이 프로세스 자체에 속하는지.
+
+그래서 concurrency policy는 임의의 helper 안에 숨기기보다 application layer에 드러나는 편이 맞습니다.
+
+## 왜 큰 코드베이스는 `errgroup`과 `WaitGroup`을 래핑할까
+
+큰 Go 코드베이스가 이 프리미티브를 래핑하는 이유는 원본이 나빠서가 아닙니다.
+
+원본 프리미티브가 의도적으로 작고, 로컬 서비스 정책을 담고 있지 않기 때문입니다.
+
+raw `errgroup`가 주는 것:
+
+- child goroutine 시작,
+- parent-derived cancellation,
+- 하나의 `Wait`,
+- `SetLimit`을 통한 bounded parallelism.
+
+raw `sync.WaitGroup`가 주는 것:
+
+- 카운터,
+- 사실상 그뿐입니다.
+
+raw 프리미티브가 직접 표현하지 않는 것:
+
+- 명시적인 context ownership,
+- shutdown 시작 후 새 작업 거부,
+- 표준 logging/tracing hook,
+- panic policy,
+- spawn-and-wait helper 형태,
+- stop-signal convention,
+- request lifetime과 service lifetime의 구분.
+
+그래서 실제 시스템에서는 래퍼가 등장합니다.
+
+## 오픈소스 source pointer
+
+좋은 예시는 세 가지입니다.
+
+- [CockroachDB `ctxgroup`](https://github.com/cockroachdb/cockroach/blob/master/pkg/util/ctxgroup/ctxgroup.go): `errgroup` 위에 얇게 올린 래퍼로, `GoCtx(func(ctx context.Context) error)`처럼 context 전달을 명시적으로 만들고 `GoAndWait` 같은 helper를 제공합니다.
+- [CockroachDB `stop.Stopper`](https://github.com/cockroachdb/cockroach/blob/master/pkg/util/stop/stopper.go): quiescing 중 새 작업을 거부하고, task를 기다리고, goroutine 관리를 서비스 shutdown 계약의 일부로 취급하는 더 무거운 lifecycle wrapper입니다.
+- [Kubernetes `wait.Group`](https://github.com/kubernetes/apimachinery/blob/master/pkg/util/wait/wait.go): `sync.WaitGroup` 위에 `Start`, `StartWithContext`, `StartWithChannel`을 추가해서 goroutine 시작 규약을 통일한 얇은 래퍼입니다.
+
+중요한 것은 정확히 같은 API를 복제하는 일이 아닙니다.
+
+중요한 것은 프로젝트별 invariant를 한 번만 정의하고, 모든 호출 지점이 매번 기억에 의존하지 않게 만드는 것입니다.
+
+## 시나리오 1: 한 요청에는 직접 `errgroup`
+
+이것이 request-scoped fan-out의 기본값입니다.
+
+다음 조건이면 잘 맞습니다.
+
+- task 집합이 유한하고,
+- 하나의 요청 또는 하나의 use case에 속하고,
+- 하나의 실패가 sibling 취소로 이어져야 하고,
+- handler가 반환되기 전에 child work가 모두 끝나야 할 때.
+
+예제 패키지의 `LoadCheckoutSnapshot`은 partner config, risk, balance를 직접 `errgroup`로 fan-out합니다.
+
+```go
+func LoadCheckoutSnapshot(ctx context.Context, req CheckoutRequest, deps Dependencies) (CheckoutSnapshot, error) {
+	group, groupCtx := errgroup.WithContext(ctx)
+
+	var partner PartnerConfig
+	var risk RiskDecision
+	var balance BalanceSnapshot
+
+	group.Go(func() error {
+		result, err := deps.PartnerConfigs.LoadPartnerConfig(groupCtx, req.PartnerID)
+		if err != nil {
+			return fmt.Errorf("load partner config: %w", err)
+		}
+		partner = result
+		return nil
+	})
+
+	group.Go(func() error {
+		result, err := deps.Risk.EvaluateRisk(groupCtx, req)
+		if err != nil {
+			return fmt.Errorf("evaluate risk: %w", err)
+		}
+		risk = result
+		return nil
+	})
+
+	group.Go(func() error {
+		result, err := deps.Balances.LoadBalance(groupCtx, req.UserID)
+		if err != nil {
+			return fmt.Errorf("load balance: %w", err)
+		}
+		balance = result
+		return nil
+	})
+
+	if err := group.Wait(); err != nil {
+		return CheckoutSnapshot{}, err
+	}
+
+	return CheckoutSnapshot{
+		UserID:    req.UserID,
+		PartnerID: req.PartnerID,
+		Partner:   partner,
+		Risk:      risk,
+		Balance:   balance,
+	}, nil
+}
+```
+
+이게 좋은 기본값인 이유:
+
+- lifetime이 명확하고,
+- cancellation이 자동으로 전파되고,
+- handler가 작업이 끝나기 전에 먼저 반환될 수 없습니다.
+
+즉, use case가 “세 개의 다운스트림을 병렬 호출해서 결과를 합친다” 정도라면 먼저 framework를 만들 필요가 없습니다.
+
+## 시나리오 2: 팀 공통 request fan-out 형태가 필요하면 `errgroup`을 래핑
+
+이 시점부터 큰 서비스들이 `errgroup`을 래핑하기 시작합니다.
+
+대표적인 이유:
+
+- `group, ctx := errgroup.WithContext(ctx)`에서 생기는 shadowing 실수를 줄이고 싶다.
+- `SetLimit` 정책을 표준화하고 싶다.
+- 파생된 context를 모든 task에 명시적으로 넘기고 싶다.
+- tracing, metrics, logging, panic normalization을 한곳에 넣고 싶다.
+- `RunAll`, `GoCtx`, `GoAndWait` 같은 helper 형태를 만들고 싶다.
+
+예제 패키지에는 `TaskGroup`이라는 얇은 래퍼가 있습니다.
+
+```go
+type TaskGroup struct {
+	ctx   context.Context
+	group *errgroup.Group
+}
+
+func NewTaskGroup(ctx context.Context, limit int) (*TaskGroup, error) {
+	group, childCtx := errgroup.WithContext(ctx)
+	group.SetLimit(limit)
+
+	return &TaskGroup{
+		ctx:   childCtx,
+		group: group,
+	}, nil
+}
+
+func (g *TaskGroup) Go(fn func(context.Context) error) {
+	g.group.Go(func() error {
+		return fn(g.ctx)
+	})
+}
+```
+
+이 래퍼는 근본 모델을 바꾸지 않습니다.
+
+대신 호출 지점의 discipline을 바꿉니다.
+
+배치 예제는 이를 이용해 partner fan-out에 bounded parallelism을 겁니다.
+
+```go
+group, err := NewTaskGroup(ctx, limit)
+if err != nil {
+	return nil, err
+}
+
+for index, partnerID := range partnerIDs {
+	index := index
+	partnerID := partnerID
+
+	group.Go(func(ctx context.Context) error {
+		summary, err := fetch.FetchPartnerSummary(ctx, partnerID)
+		if err != nil {
+			return fmt.Errorf("fetch partner %s: %w", partnerID, err)
+		}
+		results[index] = summary
+		return nil
+	})
+}
+
+if err := group.Wait(); err != nil {
+	return nil, err
+}
+```
+
+잘 맞는 경우:
+
+- request-scoped batch read,
+- 많은 ID를 대상으로 한 bounded fan-out,
+- use case마다 같은 동시성 형태를 반복하는 팀,
+- 공통 instrumentation과 limit 정책이 필요한 경우.
+
+CockroachDB `ctxgroup`도 같은 압력에서 나옵니다. `errgroup` 의미는 유지하되, context와 helper 계약을 더 명시적으로 만드는 것입니다.
+
+## 시나리오 3: 오래 사는 background task에는 `WaitGroup`이 아니라 lifecycle wrapper
+
+`sync.WaitGroup`은 request fan-out 프리미티브가 아닙니다.
+
+다음이 없습니다.
+
+- error propagation,
+- derived context,
+- shutdown contract,
+- admission control,
+- cancellation semantics.
+
+그래서 raw `WaitGroup`은 request-scoped application code 안에서 대개 맞지 않습니다.
+
+반대로 프로세스에 속한 오래 사는 background 작업에는 맞는 자리가 있습니다.
+
+- cache warmer,
+- audit projector,
+- subscription loop,
+- periodic refresher,
+- controller 또는 watcher loop.
+
+이 경우 진짜 필요한 것은 fail-fast error aggregation이 아니라 lifecycle management입니다.
+
+예제 패키지는 `WaitGroup`과 owned cancellation을 합친 `BackgroundGroup`을 사용합니다.
+
+```go
+type BackgroundGroup struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	mu     sync.Mutex
+	closed bool
+	wg     sync.WaitGroup
+}
+
+func (g *BackgroundGroup) Go(fn func(context.Context)) error {
+	g.mu.Lock()
+	if g.closed {
+		g.mu.Unlock()
+		return ErrClosed
+	}
+	g.wg.Add(1)
+	g.mu.Unlock()
+
+	go func() {
+		defer g.wg.Done()
+		fn(g.ctx)
+	}()
+
+	return nil
+}
+
+func (g *BackgroundGroup) Shutdown(ctx context.Context) error {
+	g.mu.Lock()
+	if !g.closed {
+		g.closed = true
+		g.cancel()
+	}
+	g.mu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		g.wg.Wait()
+	}()
+
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+```
+
+Kubernetes가 `WaitGroup` 위에 `StartWithContext`를 얹는 이유도, CockroachDB가 훨씬 더 무거운 `Stopper`를 두는 이유도 결국 이 lifecycle pressure 때문입니다.
+
+## 시나리오별 선택표
+
+| 시나리오 | 기본 추천 | 이유 |
+| --- | --- | --- |
+| 하나의 요청 안에서 세 개에서 여섯 개 정도의 sibling downstream 호출 | 직접 `errgroup.WithContext` | fail-fast cancellation과 단일 wait point가 정확히 필요한 계약이기 때문입니다. |
+| 하나의 요청이지만 많은 ID를 bounded batch로 fan-out | `SetLimit`이 들어간 얇은 `errgroup` 래퍼 | 같은 fail-fast 모델을 유지하면서 context, limit, instrumentation을 통일할 수 있습니다. |
+| 프로세스가 소유한 background worker | `WaitGroup` 기반 lifecycle wrapper | 중요한 것은 start, stop, reject-new-work, wait-for-exit 계약입니다. |
+| 서비스 startup component가 clean quiescing을 해야 할 때 | lifecycle wrapper 또는 stopper 스타일 abstraction | 단순 카운트보다 shutdown policy와 admission control이 더 중요합니다. |
+| 하나의 실패가 나도 나머지를 끝까지 모아야 하는 partial-success fan-out | result collector 또는 worker-pool 스타일 orchestration | fail-fast `errgroup`의 의미론이 맞지 않습니다. |
+| 요청에서 파생된 best-effort side effect | durable queue, outbox, 또는 owned background subsystem | detached request goroutine은 leak과 shutdown bug를 만들기 쉽습니다. |
+
+## 피해야 할 실패 패턴
+
+### 1. request fan-out에 raw `WaitGroup`
+
+```go
+var wg sync.WaitGroup
+var risk RiskDecision
+var balance BalanceSnapshot
+
+wg.Add(2)
+go func() {
+	defer wg.Done()
+	risk, _ = riskClient.EvaluateRisk(ctx, req)
+}()
+go func() {
+	defer wg.Done()
+	balance, _ = balanceClient.LoadBalance(ctx, req.UserID)
+}()
+wg.Wait()
+```
+
+컴파일은 되지만, 이제 first-error policy도 없고 sibling cancellation도 없고 실패를 어떻게 반환할지도 불명확합니다.
+
+### 2. application layer 안에서 fire-and-forget
+
+```go
+go auditSink.Write(context.Background(), event)
+```
+
+이제 이 작업은 request-scoped도 아니고, 그렇다고 process-scoped ownership이 명확한 것도 아닙니다.
+
+이런 코드가 결국 leak과 정체 모를 shutdown 버그를 만듭니다.
+
+### 3. request lifetime과 process lifetime을 같은 추상화에 섞기
+
+같은 helper 타입을 다음 둘에 같이 쓰지 않는 편이 좋습니다.
+
+- handler가 반환되기 전에 반드시 끝나야 하는 request fan-out,
+- 어떤 단일 요청보다 오래 사는 background loop.
+
+둘은 다른 lifetime contract입니다.
+
+## 인터뷰에서 이렇게 말하면 좋다
+
+강한 답변은 보통 이 정도입니다.
+
+1. “한 요청에서 유한한 sibling call을 병렬화할 때는 `errgroup.WithContext`를 직접 씁니다.”
+2. “팀이 같은 bounded fan-out 형태를 반복하면 `errgroup`을 래핑해서 context 전달, limit, instrumentation을 표준화합니다.”
+3. “서비스가 소유한 오래 사는 goroutine에는 `WaitGroup`을 request primitive처럼 쓰지 않고, shutdown ownership과 새 작업 거부가 들어간 lifecycle wrapper를 둡니다.”
+
+여러 패키지 이름을 나열하는 것보다, lifetime semantics를 설명하는 편이 훨씬 낫습니다.
+
+## 같이 읽으면 좋은 페이지
+
+- [깔끔한 Go 서비스 기본기](/ko/guide/clean-go-service-basics)
+- [구조화된 동시성](/ko/advanced/structured-concurrency)
+- [Graceful Shutdown](/ko/patterns/graceful-shutdown)
+- [Leak, Shutdown, Timeout 테스트](/ko/testing/leaks-and-shutdowns)

--- a/docs/ko/guide/clean-go-service-basics.md
+++ b/docs/ko/guide/clean-go-service-basics.md
@@ -23,6 +23,8 @@ FastAPI, Spring, NestJS 쪽에 익숙하다면 Go에서도 “큰 프레임워�
 
 이 구조의 실제 예시는 [`examples/cleanservice`](https://github.com/jaeyoung0509/golang-handbook/tree/develop/examples/cleanservice)에서 볼 수 있습니다.
 
+그 다음 질문이 “한 use case 안에서 여러 다운스트림을 병렬로 불러야 하면 어떻게 하지?”라면 [애플리케이션 레이어 병렬 호출](/ko/guide/application-layer-parallelism)로 이어서 읽으면 됩니다.
+
 ## 먼저 외울 기본 구조
 
 ```mermaid

--- a/docs/ko/guide/getting-started.md
+++ b/docs/ko/guide/getting-started.md
@@ -32,6 +32,7 @@ description: VitePress 기반 Go 동시성 문서 저장소의 구조와 실행 
 │   ├── extras/
 │   └── ko/
 ├── examples/
+│   ├── appparallel/
 │   ├── actor/
 │   ├── cleanservice/
 │   ├── contexttimeout/
@@ -69,10 +70,11 @@ go test ./...
 
 1. [기초 원리 개요](/ko/fundamentals/)부터 읽습니다.
 2. 인터뷰나 기본 백엔드 서비스 설계가 급하면 [깔끔한 Go 서비스 기본기](/ko/guide/clean-go-service-basics)를 먼저 읽습니다.
-3. [패턴 개요](/ko/patterns/)와 `examples/` 대응 패키지를 같이 읽습니다.
-4. timeout과 shutdown 경로를 믿기 전에 [테스트 개요](/ko/testing/)를 읽습니다.
-5. 운영 규칙과 대규모 시스템 tradeoff가 중요해지면 [프로덕션 개요](/ko/production/)를 읽습니다.
-6. 그 다음에 [고급 주제 개요](/ko/advanced/), [비교 / 확장 개요](/ko/extras/)로 넘어갑니다.
+3. 한 use case 안에서 여러 다운스트림을 병렬 호출해야 한다면 [애플리케이션 레이어 병렬 호출](/ko/guide/application-layer-parallelism)까지 이어서 읽습니다.
+4. [패턴 개요](/ko/patterns/)와 `examples/` 대응 패키지를 같이 읽습니다.
+5. timeout과 shutdown 경로를 믿기 전에 [테스트 개요](/ko/testing/)를 읽습니다.
+6. 운영 규칙과 대규모 시스템 tradeoff가 중요해지면 [프로덕션 개요](/ko/production/)를 읽습니다.
+7. 그 다음에 [고급 주제 개요](/ko/advanced/), [비교 / 확장 개요](/ko/extras/)로 넘어갑니다.
 
 ## 예제 패키지 구성 원칙
 

--- a/docs/ko/index.md
+++ b/docs/ko/index.md
@@ -116,6 +116,7 @@ features:
 | --- | --- |
 | 고루틴이 왜 싸고, 스케줄러가 실제로 뭘 하는지 | [Go 런타임과 스케줄러](/ko/fundamentals/go-runtime-scheduler) |
 | 인터뷰와 실무에서 깔끔한 Go API 서비스를 어떻게 구조화하는지 | [깔끔한 Go 서비스 기본기](/ko/guide/clean-go-service-basics) |
+| 하나의 use case 안에서 여러 다운스트림 호출을 goroutine soup 없이 병렬화하는 법 | [애플리케이션 레이어 병렬 호출](/ko/guide/application-layer-parallelism) |
 | 지역 값이 왜 여전히 힙으로 가는지 | [컴파일러와 툴체인](/ko/internals/compiler-and-toolchain) |
 | 어떤 allocation 패턴이 왜 GC를 더 힘들게 하는지 | [할당기와 하이브리드 write barrier](/ko/internals/allocator-and-write-barrier) |
 | request-scoped cancellation이 실제로 어떻게 전파되는지 | [context 패키지 내부](/ko/stdlib/context-internals) |

--- a/examples/appparallel/appparallel.go
+++ b/examples/appparallel/appparallel.go
@@ -1,0 +1,280 @@
+package appparallel
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"golang.org/x/sync/errgroup"
+)
+
+var (
+	ErrLimitMustBePositive = errors.New("limit must be at least 1")
+	ErrClosed              = errors.New("background group is closed")
+)
+
+type CheckoutRequest struct {
+	UserID    string
+	PartnerID string
+	Amount    int
+	Currency  string
+}
+
+type PartnerConfig struct {
+	PartnerID       string
+	SettlementDelay int
+	FeeBPS          int
+}
+
+type RiskDecision struct {
+	Approved bool
+	Rule     string
+}
+
+type BalanceSnapshot struct {
+	UserID     string
+	Available  int
+	HoldAmount int
+}
+
+type CheckoutSnapshot struct {
+	UserID    string
+	PartnerID string
+	Partner   PartnerConfig
+	Risk      RiskDecision
+	Balance   BalanceSnapshot
+}
+
+type PartnerSummary struct {
+	PartnerID string
+	Tier      string
+}
+
+type PartnerConfigReader interface {
+	LoadPartnerConfig(context.Context, string) (PartnerConfig, error)
+}
+
+type RiskChecker interface {
+	EvaluateRisk(context.Context, CheckoutRequest) (RiskDecision, error)
+}
+
+type BalanceReader interface {
+	LoadBalance(context.Context, string) (BalanceSnapshot, error)
+}
+
+type PartnerSummaryFetcher interface {
+	FetchPartnerSummary(context.Context, string) (PartnerSummary, error)
+}
+
+type PartnerConfigReaderFunc func(context.Context, string) (PartnerConfig, error)
+
+func (fn PartnerConfigReaderFunc) LoadPartnerConfig(ctx context.Context, partnerID string) (PartnerConfig, error) {
+	return fn(ctx, partnerID)
+}
+
+type RiskCheckerFunc func(context.Context, CheckoutRequest) (RiskDecision, error)
+
+func (fn RiskCheckerFunc) EvaluateRisk(ctx context.Context, req CheckoutRequest) (RiskDecision, error) {
+	return fn(ctx, req)
+}
+
+type BalanceReaderFunc func(context.Context, string) (BalanceSnapshot, error)
+
+func (fn BalanceReaderFunc) LoadBalance(ctx context.Context, userID string) (BalanceSnapshot, error) {
+	return fn(ctx, userID)
+}
+
+type PartnerSummaryFetcherFunc func(context.Context, string) (PartnerSummary, error)
+
+func (fn PartnerSummaryFetcherFunc) FetchPartnerSummary(ctx context.Context, partnerID string) (PartnerSummary, error) {
+	return fn(ctx, partnerID)
+}
+
+type Dependencies struct {
+	PartnerConfigs PartnerConfigReader
+	Risk           RiskChecker
+	Balances       BalanceReader
+}
+
+// LoadCheckoutSnapshot is the plain errgroup case:
+// a single request, a finite set of sibling calls, and fail-fast cancellation.
+func LoadCheckoutSnapshot(ctx context.Context, req CheckoutRequest, deps Dependencies) (CheckoutSnapshot, error) {
+	if deps.PartnerConfigs == nil || deps.Risk == nil || deps.Balances == nil {
+		return CheckoutSnapshot{}, errors.New("dependencies must not be nil")
+	}
+
+	group, groupCtx := errgroup.WithContext(ctx)
+
+	var partner PartnerConfig
+	var risk RiskDecision
+	var balance BalanceSnapshot
+
+	group.Go(func() error {
+		result, err := deps.PartnerConfigs.LoadPartnerConfig(groupCtx, req.PartnerID)
+		if err != nil {
+			return fmt.Errorf("load partner config: %w", err)
+		}
+		partner = result
+		return nil
+	})
+
+	group.Go(func() error {
+		result, err := deps.Risk.EvaluateRisk(groupCtx, req)
+		if err != nil {
+			return fmt.Errorf("evaluate risk: %w", err)
+		}
+		risk = result
+		return nil
+	})
+
+	group.Go(func() error {
+		result, err := deps.Balances.LoadBalance(groupCtx, req.UserID)
+		if err != nil {
+			return fmt.Errorf("load balance: %w", err)
+		}
+		balance = result
+		return nil
+	})
+
+	if err := group.Wait(); err != nil {
+		return CheckoutSnapshot{}, err
+	}
+
+	return CheckoutSnapshot{
+		UserID:    req.UserID,
+		PartnerID: req.PartnerID,
+		Partner:   partner,
+		Risk:      risk,
+		Balance:   balance,
+	}, nil
+}
+
+// TaskGroup is the wrapped errgroup case: explicit Go(ctx) semantics and one
+// place for limit policy.
+type TaskGroup struct {
+	ctx   context.Context
+	group *errgroup.Group
+}
+
+func NewTaskGroup(ctx context.Context, limit int) (*TaskGroup, error) {
+	if limit < 1 {
+		return nil, ErrLimitMustBePositive
+	}
+
+	group, childCtx := errgroup.WithContext(ctx)
+	group.SetLimit(limit)
+
+	return &TaskGroup{
+		ctx:   childCtx,
+		group: group,
+	}, nil
+}
+
+func (g *TaskGroup) Go(fn func(context.Context) error) {
+	g.group.Go(func() error {
+		return fn(g.ctx)
+	})
+}
+
+func (g *TaskGroup) Wait() error {
+	return g.group.Wait()
+}
+
+func LoadPartnerSummaries(ctx context.Context, partnerIDs []string, limit int, fetch PartnerSummaryFetcher) ([]PartnerSummary, error) {
+	if fetch == nil {
+		return nil, errors.New("fetch must not be nil")
+	}
+
+	group, err := NewTaskGroup(ctx, limit)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]PartnerSummary, len(partnerIDs))
+	for index, partnerID := range partnerIDs {
+		index := index
+		partnerID := partnerID
+
+		group.Go(func(ctx context.Context) error {
+			summary, err := fetch.FetchPartnerSummary(ctx, partnerID)
+			if err != nil {
+				return fmt.Errorf("fetch partner %s: %w", partnerID, err)
+			}
+			results[index] = summary
+			return nil
+		})
+	}
+
+	if err := group.Wait(); err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}
+
+// BackgroundGroup is the wrapped WaitGroup case: long-lived tasks with owned
+// cancellation and shutdown semantics.
+type BackgroundGroup struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	mu     sync.Mutex
+	closed bool
+	wg     sync.WaitGroup
+}
+
+func NewBackgroundGroup(parent context.Context) *BackgroundGroup {
+	if parent == nil {
+		parent = context.Background()
+	}
+
+	ctx, cancel := context.WithCancel(parent)
+	return &BackgroundGroup{
+		ctx:    ctx,
+		cancel: cancel,
+	}
+}
+
+func (g *BackgroundGroup) Go(fn func(context.Context)) error {
+	g.mu.Lock()
+	if g.closed {
+		g.mu.Unlock()
+		return ErrClosed
+	}
+	g.wg.Add(1)
+	g.mu.Unlock()
+
+	go func() {
+		defer g.wg.Done()
+		fn(g.ctx)
+	}()
+
+	return nil
+}
+
+func (g *BackgroundGroup) Shutdown(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	g.mu.Lock()
+	if !g.closed {
+		g.closed = true
+		g.cancel()
+	}
+	g.mu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		g.wg.Wait()
+	}()
+
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/examples/appparallel/appparallel_test.go
+++ b/examples/appparallel/appparallel_test.go
@@ -1,0 +1,191 @@
+package appparallel
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestLoadCheckoutSnapshotSuccess(t *testing.T) {
+	deps := Dependencies{
+		PartnerConfigs: PartnerConfigReaderFunc(func(_ context.Context, partnerID string) (PartnerConfig, error) {
+			return PartnerConfig{
+				PartnerID:       partnerID,
+				SettlementDelay: 2,
+				FeeBPS:          35,
+			}, nil
+		}),
+		Risk: RiskCheckerFunc(func(_ context.Context, req CheckoutRequest) (RiskDecision, error) {
+			return RiskDecision{
+				Approved: req.Amount < 100000,
+				Rule:     "checkout.default",
+			}, nil
+		}),
+		Balances: BalanceReaderFunc(func(_ context.Context, userID string) (BalanceSnapshot, error) {
+			return BalanceSnapshot{
+				UserID:     userID,
+				Available:  250000,
+				HoldAmount: 10000,
+			}, nil
+		}),
+	}
+
+	snapshot, err := LoadCheckoutSnapshot(context.Background(), CheckoutRequest{
+		UserID:    "user-7",
+		PartnerID: "partner-1",
+		Amount:    45000,
+		Currency:  "GBP",
+	}, deps)
+	if err != nil {
+		t.Fatalf("LoadCheckoutSnapshot returned error: %v", err)
+	}
+
+	if snapshot.Partner.PartnerID != "partner-1" {
+		t.Fatalf("unexpected partner config: %+v", snapshot.Partner)
+	}
+	if !snapshot.Risk.Approved {
+		t.Fatalf("expected approved risk decision, got %+v", snapshot.Risk)
+	}
+	if snapshot.Balance.UserID != "user-7" {
+		t.Fatalf("unexpected balance snapshot: %+v", snapshot.Balance)
+	}
+}
+
+func TestLoadCheckoutSnapshotCancelsSiblingsOnError(t *testing.T) {
+	cancelObserved := make(chan struct{}, 1)
+
+	deps := Dependencies{
+		PartnerConfigs: PartnerConfigReaderFunc(func(ctx context.Context, _ string) (PartnerConfig, error) {
+			<-ctx.Done()
+			select {
+			case cancelObserved <- struct{}{}:
+			default:
+			}
+			return PartnerConfig{}, ctx.Err()
+		}),
+		Risk: RiskCheckerFunc(func(_ context.Context, _ CheckoutRequest) (RiskDecision, error) {
+			return RiskDecision{}, errors.New("fraud backend timed out")
+		}),
+		Balances: BalanceReaderFunc(func(_ context.Context, userID string) (BalanceSnapshot, error) {
+			return BalanceSnapshot{UserID: userID, Available: 120000}, nil
+		}),
+	}
+
+	_, err := LoadCheckoutSnapshot(context.Background(), CheckoutRequest{
+		UserID:    "user-9",
+		PartnerID: "partner-9",
+		Amount:    70000,
+	}, deps)
+	if err == nil {
+		t.Fatal("expected an error but got nil")
+	}
+
+	select {
+	case <-cancelObserved:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("expected sibling call to observe cancellation")
+	}
+}
+
+func TestLoadPartnerSummariesRespectsLimitAndPreservesOrder(t *testing.T) {
+	partnerIDs := []string{
+		"partner-a",
+		"partner-b",
+		"partner-c",
+		"partner-d",
+		"partner-e",
+		"partner-f",
+	}
+
+	var inFlight atomic.Int32
+	var maxInFlight atomic.Int32
+
+	summaries, err := LoadPartnerSummaries(context.Background(), partnerIDs, 2, PartnerSummaryFetcherFunc(func(_ context.Context, partnerID string) (PartnerSummary, error) {
+		current := inFlight.Add(1)
+		defer inFlight.Add(-1)
+
+		for {
+			seen := maxInFlight.Load()
+			if current <= seen || maxInFlight.CompareAndSwap(seen, current) {
+				break
+			}
+		}
+
+		time.Sleep(10 * time.Millisecond)
+
+		return PartnerSummary{
+			PartnerID: partnerID,
+			Tier:      "standard",
+		}, nil
+	}))
+	if err != nil {
+		t.Fatalf("LoadPartnerSummaries returned error: %v", err)
+	}
+
+	if maxInFlight.Load() > 2 {
+		t.Fatalf("limit exceeded: got %d", maxInFlight.Load())
+	}
+
+	for index, summary := range summaries {
+		if summary.PartnerID != partnerIDs[index] {
+			t.Fatalf("summary %d mismatch: got %s want %s", index, summary.PartnerID, partnerIDs[index])
+		}
+	}
+}
+
+func TestBackgroundGroupShutdownCancelsTasksAndRejectsNewWork(t *testing.T) {
+	group := NewBackgroundGroup(context.Background())
+
+	stopped := make(chan struct{})
+	if err := group.Go(func(ctx context.Context) {
+		<-ctx.Done()
+		close(stopped)
+	}); err != nil {
+		t.Fatalf("Go returned error: %v", err)
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	if err := group.Shutdown(shutdownCtx); err != nil {
+		t.Fatalf("Shutdown returned error: %v", err)
+	}
+
+	select {
+	case <-stopped:
+	default:
+		t.Fatal("expected background task to stop")
+	}
+
+	if err := group.Go(func(context.Context) {}); !errors.Is(err, ErrClosed) {
+		t.Fatalf("expected ErrClosed, got %v", err)
+	}
+}
+
+func TestBackgroundGroupShutdownHonorsCallerDeadline(t *testing.T) {
+	group := NewBackgroundGroup(context.Background())
+	done := make(chan struct{})
+
+	if err := group.Go(func(context.Context) {
+		defer close(done)
+		time.Sleep(100 * time.Millisecond)
+	}); err != nil {
+		t.Fatalf("Go returned error: %v", err)
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	err := group.Shutdown(shutdownCtx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context deadline exceeded, got %v", err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("expected background task to finish eventually")
+	}
+}


### PR DESCRIPTION
## Summary
- add a bilingual guide chapter for application-layer parallelism in clean Go services
- add a runnable `examples/appparallel` package that demonstrates direct `errgroup`, wrapped `errgroup`, and wrapped `WaitGroup` lifecycle management
- link the new chapter from the Guide sidebar, Getting Started, homepage quick-start table, and clean-service basics page

## What changed
- new guide page: `docs/guide/application-layer-parallelism.md`
- Korean mirror: `docs/ko/guide/application-layer-parallelism.md`
- new example package with tests: `examples/appparallel`
- navigation updates in VitePress config and onboarding pages
- small follow-up links from `clean-go-service-basics`

## Why this matters
The application layer is where clean Go services usually need to fan out to several downstreams. Large Go codebases rarely leave this as raw `errgroup` or `WaitGroup` everywhere. This change explains when direct `errgroup` is enough, when wrapping helps, why large OSS does it, and what the best tool is for each lifetime contract.

## Validation
- `go test ./...`
- `npm run docs:build`

Closes #59
