### PR TITLE
Fix deployed pattern snippet rendering

### DIFF
--- a/docs/ko/patterns/channel-of-channels.md
+++ b/docs/ko/patterns/channel-of-channels.md
@@ -120,11 +120,6 @@ bulk parallel work를 처리하려면 [워커 풀](/ko/patterns/worker-pool), mu
 아래 블록은 `examples/requestreply`의 실제 파일을 그대로 렌더링합니다.
 
 ::: code-group
-```go [requestreply.go]
-<<< ../../../examples/requestreply/requestreply.go
-```
-
-```go [requestreply_test.go]
-<<< ../../../examples/requestreply/requestreply_test.go
-```
+<<< ../../../examples/requestreply/requestreply.go [requestreply.go]
+<<< ../../../examples/requestreply/requestreply_test.go [requestreply_test.go]
 :::

--- a/docs/ko/patterns/context-cancellation.md
+++ b/docs/ko/patterns/context-cancellation.md
@@ -124,11 +124,6 @@ child goroutine에 buffered send 경로도 없고 `ctx.Done()` 경로도 없고 
 아래 블록은 `examples/contexttimeout`의 실제 파일을 그대로 렌더링합니다.
 
 ::: code-group
-```go [contexttimeout.go]
-<<< ../../../examples/contexttimeout/contexttimeout.go
-```
-
-```go [contexttimeout_test.go]
-<<< ../../../examples/contexttimeout/contexttimeout_test.go
-```
+<<< ../../../examples/contexttimeout/contexttimeout.go [contexttimeout.go]
+<<< ../../../examples/contexttimeout/contexttimeout_test.go [contexttimeout_test.go]
 :::

--- a/docs/ko/patterns/fan-out-fan-in.md
+++ b/docs/ko/patterns/fan-out-fan-in.md
@@ -130,11 +130,6 @@ shared channel의 close 조건은 보통 aggregator가 소유해야 합니다. �
 아래 블록은 `examples/fanoutfanin`의 실제 파일을 그대로 렌더링합니다.
 
 ::: code-group
-```go [fanoutfanin.go]
-<<< ../../../examples/fanoutfanin/fanoutfanin.go
-```
-
-```go [fanoutfanin_test.go]
-<<< ../../../examples/fanoutfanin/fanoutfanin_test.go
-```
+<<< ../../../examples/fanoutfanin/fanoutfanin.go [fanoutfanin.go]
+<<< ../../../examples/fanoutfanin/fanoutfanin_test.go [fanoutfanin_test.go]
 :::

--- a/docs/ko/patterns/graceful-shutdown.md
+++ b/docs/ko/patterns/graceful-shutdown.md
@@ -134,11 +134,6 @@ if !p.closed {
 아래 블록은 `examples/gracefulshutdown`의 실제 파일을 그대로 렌더링합니다.
 
 ::: code-group
-```go [gracefulshutdown.go]
-<<< ../../../examples/gracefulshutdown/gracefulshutdown.go
-```
-
-```go [gracefulshutdown_test.go]
-<<< ../../../examples/gracefulshutdown/gracefulshutdown_test.go
-```
+<<< ../../../examples/gracefulshutdown/gracefulshutdown.go [gracefulshutdown.go]
+<<< ../../../examples/gracefulshutdown/gracefulshutdown_test.go [gracefulshutdown_test.go]
 :::

--- a/docs/ko/patterns/optional-values-across-boundaries.md
+++ b/docs/ko/patterns/optional-values-across-boundaries.md
@@ -242,11 +242,6 @@ plain required value로 충분하면 그냥 `T`를 유지하고 transport noise�
 아래 블록은 `examples/optionalvalues`의 실제 파일을 그대로 렌더링합니다.
 
 ::: code-group
-```go [optionalvalues.go]
-<<< ../../../examples/optionalvalues/optionalvalues.go
-```
-
-```go [optionalvalues_test.go]
-<<< ../../../examples/optionalvalues/optionalvalues_test.go
-```
+<<< ../../../examples/optionalvalues/optionalvalues.go [optionalvalues.go]
+<<< ../../../examples/optionalvalues/optionalvalues_test.go [optionalvalues_test.go]
 :::

--- a/docs/ko/patterns/or-done-tee-bridge.md
+++ b/docs/ko/patterns/or-done-tee-bridge.md
@@ -106,11 +106,6 @@ func forward(in <-chan Item, out chan<- Item) {
 아래 블록은 `examples/ordoneteebridge`의 실제 파일을 그대로 렌더링합니다.
 
 ::: code-group
-```go [ordoneteebridge.go]
-<<< ../../../examples/ordoneteebridge/ordoneteebridge.go
-```
-
-```go [ordoneteebridge_test.go]
-<<< ../../../examples/ordoneteebridge/ordoneteebridge_test.go
-```
+<<< ../../../examples/ordoneteebridge/ordoneteebridge.go [ordoneteebridge.go]
+<<< ../../../examples/ordoneteebridge/ordoneteebridge_test.go [ordoneteebridge_test.go]
 :::

--- a/docs/ko/patterns/pipeline.md
+++ b/docs/ko/patterns/pipeline.md
@@ -145,11 +145,6 @@ func stage(in <-chan Event) <-chan Score {
 아래 블록은 `examples/pipeline`의 실제 파일을 그대로 렌더링합니다.
 
 ::: code-group
-```go [pipeline.go]
-<<< ../../../examples/pipeline/pipeline.go
-```
-
-```go [pipeline_test.go]
-<<< ../../../examples/pipeline/pipeline_test.go
-```
+<<< ../../../examples/pipeline/pipeline.go [pipeline.go]
+<<< ../../../examples/pipeline/pipeline_test.go [pipeline_test.go]
 :::

--- a/docs/ko/patterns/worker-pool.md
+++ b/docs/ko/patterns/worker-pool.md
@@ -152,11 +152,6 @@ worker가 shared context나 shutdown signal을 보지 않으면, caller가 이�
 아래 블록은 `examples/workerpool`의 실제 파일을 그대로 렌더링합니다.
 
 ::: code-group
-```go [workerpool.go]
-<<< ../../../examples/workerpool/workerpool.go
-```
-
-```go [workerpool_test.go]
-<<< ../../../examples/workerpool/workerpool_test.go
-```
+<<< ../../../examples/workerpool/workerpool.go [workerpool.go]
+<<< ../../../examples/workerpool/workerpool_test.go [workerpool_test.go]
 :::

--- a/docs/patterns/channel-of-channels.md
+++ b/docs/patterns/channel-of-channels.md
@@ -120,11 +120,6 @@ If you need bulk parallel work rather than routed replies, use [Worker Pool](/pa
 The blocks below render the exact files from `examples/requestreply`.
 
 ::: code-group
-```go [requestreply.go]
-<<< ../../examples/requestreply/requestreply.go
-```
-
-```go [requestreply_test.go]
-<<< ../../examples/requestreply/requestreply_test.go
-```
+<<< ../../examples/requestreply/requestreply.go [requestreply.go]
+<<< ../../examples/requestreply/requestreply_test.go [requestreply_test.go]
 :::

--- a/docs/patterns/context-cancellation.md
+++ b/docs/patterns/context-cancellation.md
@@ -121,11 +121,6 @@ It is the safety net that keeps the rest of your concurrency patterns from leaki
 The blocks below render the exact files from `examples/contexttimeout`.
 
 ::: code-group
-```go [contexttimeout.go]
-<<< ../../examples/contexttimeout/contexttimeout.go
-```
-
-```go [contexttimeout_test.go]
-<<< ../../examples/contexttimeout/contexttimeout_test.go
-```
+<<< ../../examples/contexttimeout/contexttimeout.go [contexttimeout.go]
+<<< ../../examples/contexttimeout/contexttimeout_test.go [contexttimeout_test.go]
 :::

--- a/docs/patterns/fan-out-fan-in.md
+++ b/docs/patterns/fan-out-fan-in.md
@@ -129,11 +129,6 @@ The aggregator should usually own the receive loop and the final close condition
 The blocks below render the exact files from `examples/fanoutfanin`.
 
 ::: code-group
-```go [fanoutfanin.go]
-<<< ../../examples/fanoutfanin/fanoutfanin.go
-```
-
-```go [fanoutfanin_test.go]
-<<< ../../examples/fanoutfanin/fanoutfanin_test.go
-```
+<<< ../../examples/fanoutfanin/fanoutfanin.go [fanoutfanin.go]
+<<< ../../examples/fanoutfanin/fanoutfanin_test.go [fanoutfanin_test.go]
 :::

--- a/docs/patterns/graceful-shutdown.md
+++ b/docs/patterns/graceful-shutdown.md
@@ -136,11 +136,6 @@ If you skip this pattern, the problems are predictable:
 The blocks below render the exact files from `examples/gracefulshutdown`.
 
 ::: code-group
-```go [gracefulshutdown.go]
-<<< ../../examples/gracefulshutdown/gracefulshutdown.go
-```
-
-```go [gracefulshutdown_test.go]
-<<< ../../examples/gracefulshutdown/gracefulshutdown_test.go
-```
+<<< ../../examples/gracefulshutdown/gracefulshutdown.go [gracefulshutdown.go]
+<<< ../../examples/gracefulshutdown/gracefulshutdown_test.go [gracefulshutdown_test.go]
 :::

--- a/docs/patterns/optional-values-across-boundaries.md
+++ b/docs/patterns/optional-values-across-boundaries.md
@@ -242,11 +242,6 @@ If a plain required value is enough, keep the field as plain `T` and avoid trans
 The blocks below render the exact files from `examples/optionalvalues`.
 
 ::: code-group
-```go [optionalvalues.go]
-<<< ../../examples/optionalvalues/optionalvalues.go
-```
-
-```go [optionalvalues_test.go]
-<<< ../../examples/optionalvalues/optionalvalues_test.go
-```
+<<< ../../examples/optionalvalues/optionalvalues.go [optionalvalues.go]
+<<< ../../examples/optionalvalues/optionalvalues_test.go [optionalvalues_test.go]
 :::

--- a/docs/patterns/or-done-tee-bridge.md
+++ b/docs/patterns/or-done-tee-bridge.md
@@ -104,11 +104,6 @@ These are "advanced small patterns." They do not dominate architecture decisions
 The blocks below render the exact files from `examples/ordoneteebridge`.
 
 ::: code-group
-```go [ordoneteebridge.go]
-<<< ../../examples/ordoneteebridge/ordoneteebridge.go
-```
-
-```go [ordoneteebridge_test.go]
-<<< ../../examples/ordoneteebridge/ordoneteebridge_test.go
-```
+<<< ../../examples/ordoneteebridge/ordoneteebridge.go [ordoneteebridge.go]
+<<< ../../examples/ordoneteebridge/ordoneteebridge_test.go [ordoneteebridge_test.go]
 :::

--- a/docs/patterns/pipeline.md
+++ b/docs/patterns/pipeline.md
@@ -145,11 +145,6 @@ If you mostly need to ask several backends the same question at once, the [Fan-O
 The blocks below render the exact files from `examples/pipeline`.
 
 ::: code-group
-```go [pipeline.go]
-<<< ../../examples/pipeline/pipeline.go
-```
-
-```go [pipeline_test.go]
-<<< ../../examples/pipeline/pipeline_test.go
-```
+<<< ../../examples/pipeline/pipeline.go [pipeline.go]
+<<< ../../examples/pipeline/pipeline_test.go [pipeline_test.go]
 :::

--- a/docs/patterns/worker-pool.md
+++ b/docs/patterns/worker-pool.md
@@ -155,11 +155,6 @@ If you need multiple stages with different responsibilities, move to a [Pipeline
 The blocks below render the exact files from `examples/workerpool`.
 
 ::: code-group
-```go [workerpool.go]
-<<< ../../examples/workerpool/workerpool.go
-```
-
-```go [workerpool_test.go]
-<<< ../../examples/workerpool/workerpool_test.go
-```
+<<< ../../examples/workerpool/workerpool.go [workerpool.go]
+<<< ../../examples/workerpool/workerpool_test.go [workerpool_test.go]
 :::


### PR DESCRIPTION
## Summary
- fix the VitePress code-group snippet syntax in the bilingual top-level Patterns docs
- keep the inline full-example experience introduced in the previous PR
- ensure deployed pages render actual source code instead of literal `<<< path` text

## What changed
- replaced fenced code blocks around snippet imports with the correct direct `<<< path [title]` form inside `::: code-group`
- updated all affected English/Korean pattern pages consistently

## Validation
- `go test ./...`
- `npm run docs:build`
- verified the built site no longer contains literal `<<< ...examples/...` directives

Closes #63
